### PR TITLE
Fix EclipseLink and java.lang.SecurityException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,29 @@
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>
             <version>${eclipselink.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>javax.persistence</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa</artifactId>
             <version>${eclipselink.version}</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>javax.persistence</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## WHAT

The eclipselink 2.7.0 artifact depends on javax.persistence 2.2.0 and both contain classes that are in the package javax.persistence. However the javax.persistence jar is signed while the eclipselink one is not. So the Java runtime will complain, when loading a class from the package javax.persistence in the eclipselink jar, that it's lack of signing doesn't match with classes already loaded from the same package in the javax.persistence jar.

When running the app, we are receiving:
```
java.lang.SecurityException: class "javax.persistence.PersistenceUtil"'s signer information does not match signer information of other classes in the same package
```

More information:

- https://bugs.eclipse.org/bugs/show_bug.cgi?id=525457
- https://stackoverflow.com/questions/45870753/eclipselink-2-7-0-and-jpa-api-2-2-0-signature-mismatch