### PR TITLE
PP-2883 GoCardless client initial integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <jackson.version>2.9.2</jackson.version>
         <guice.version>4.1.0</guice.version>
         <guava.version>23.3-jre</guava.version>
+        <gocardless.version>2.6.0</gocardless.version>
         <hamcrest.version>1.3</hamcrest.version>
         <rest-assured.version>3.0.5</rest-assured.version>
     </properties>
@@ -132,6 +133,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.gocardless</groupId>
+            <artifactId>gocardless-pro</artifactId>
+            <version>${gocardless.version}</version>
         </dependency>
 
         <!-- testing -->

--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitConfig.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitConfig.java
@@ -1,9 +1,17 @@
 package uk.gov.pay.directdebit.app.config;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 //TODO: Awaiting AWS DB environment ready
-public class DirectDebitConfig extends Configuration{
+public class DirectDebitConfig extends Configuration {
+
+    @Valid
+    @NotNull
+    private GoCardlessFactory goCardless;
 
 //    @Valid
 //    @NotNull
@@ -13,6 +21,12 @@ public class DirectDebitConfig extends Configuration{
 //    @NotNull
 //    private JPAConfiguration jpaConfiguration;
 //
+
+    @JsonProperty("goCardless")
+    public GoCardlessFactory getGoCardless() {
+        return goCardless;
+    }
+
 //    public DataSourceFactory getDataSourceFactory() {
 //        return dataSourceFactory;
 //    }

--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.app.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gocardless.GoCardlessClient;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import io.dropwizard.setup.Environment;
@@ -45,6 +46,11 @@ public class DirectDebitModule extends AbstractModule {
 //
 //        return jpaModule;
 //    }
+
+    @Provides
+    public GoCardlessClient provideGoCardlessClient() {
+        return configuration.getGoCardless().buildClient();
+    }
 
     @Provides
     public ObjectMapper provideObjectMapper() {

--- a/src/main/java/uk/gov/pay/directdebit/app/config/GoCardlessFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/GoCardlessFactory.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.directdebit.app.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gocardless.GoCardlessClient;
+
+import javax.validation.constraints.NotNull;
+
+public class GoCardlessFactory {
+
+    @JsonProperty
+    private String accessToken;
+
+    @JsonProperty
+    private String webhookSecret;
+
+    @JsonProperty
+    @NotNull
+    private GoCardlessClient.Environment environment;
+
+    public GoCardlessClient buildClient() {
+        return GoCardlessClient.create(accessToken, environment);
+    }
+
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -15,6 +15,13 @@ logging:
         target: stdout
         logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
 
+goCardless:
+  # For initial integration we will use sandbox access token.
+  # When in live mode: access token should be removed from the config and we should use partner integration instead.
+  accessToken: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ACCESS_TOKEN:-}
+  webhookSecret: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_WEBHOOK_SECRET:-}
+  environment: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ENVIRONMENT:-sandbox}
+
 # TODO: Awaiting AWS environments to be ready
 
 #database:


### PR DESCRIPTION
## WHAT

This PR adds initial GoCardless SDK integration.
It will use `GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ACCESS_TOKEN` environment variable to initialise sandbox API keys only.
Later, when the partner integration is implemented we should not use `GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ACCESS_TOKEN` and persist the api access tokens in the database.

The changes are based on https://github.com/gocardless/gocardless-pro-java-example