### PR TITLE
PP-2883 Added Chamber binary to support AWS EC2 parameter store

### DIFF
--- a/chamber
+++ b/chamber
@@ -1,0 +1,1 @@
+chamber-v1.9.0-linux-amd64

--- a/chamber-v1.9.0-linux-amd64.sha256.txt
+++ b/chamber-v1.9.0-linux-amd64.sha256.txt
@@ -1,0 +1,1 @@
+88290cff6960fce9a2f30a7447d8c2a7dfa6e3d1d7a0446de75cb475505ef537  chamber-v1.9.0-linux-amd64


### PR DESCRIPTION
## WHAT:

- Added `chamber-v1.9.0-linux-amd64` binary from https://github.com/segmentio/chamber/releases
- Created symbolic link `chamber` to `chamber-v1.9.0-linux-amd64` binary
- Generated SHA256 signature for `chamber-v1.9.0-linux-amd64` file:
  ```
  shasum -a 256 chamber-v1.9.0-linux-amd64 > chamber-v1.9.0-linux-amd64.sha256.txt
  ```

## NOTICE:

1. When upgrading the Chamber binary:

- In the new pull request you should have the new binary, symbolic link to it and the new signature for it.
- Before approving the pull request make sure to verify the new binary by generating the signature on your own machine.
  For example:
  In the PR you have `chamber-v1.10.0-linux-amd64` and `chamber-v1.10.0-linux-amd64.sha256.txt`.
  To verify `chamber-v1.10.0-linux-amd64` binary, download it from https://github.com/segmentio/chamber/releases and generate the SHA256 hash:
  ```
  shasum -a 256 chamber-v1.10.0-linux-amd64 > chamber-v1.10.0-linux-amd64.sha256.txt
  ```
  Compare `chamber-v1.10.0-linux-amd64.sha256.txt` with the same file in the PR: it must be the same.

2. When running the Chamber binary:

- You can check if you are running valid Chamber binary by executing:
  ```
  shasum -c chamber-v1.9.0-linux-amd64.sha256.txt
  ```
  the output should be `OK`, for example:
  ```
  chamber-v1.9.0-linux-amd64: OK
  ```