### PR TITLE
PP-2883 Do not throw "GoCardless webhook secret is blank" exception

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/config/GoCardlessFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/config/GoCardlessFactory.java
@@ -25,7 +25,9 @@ public class GoCardlessFactory {
 
     public WebhookVerifier buildSignatureVerifier() {
         if (StringUtils.isBlank(webhookSecret)) {
-            throw new RuntimeException("GoCardless webhook secret is blank");
+            return null;
+            // do not throw exception for now (until we have GoCardless webhook secret for testing)
+            //throw new RuntimeException("GoCardless webhook secret is blank");
         }
 
         return new WebhookVerifier(webhookSecret);


### PR DESCRIPTION
## WHAT

Do not throw "GoCardless webhook secret is blank" exception (we don't have test webhook secret yet).
Ignore the exception for now and we will discuss should we have dummy value or some kind of condition for dev env.