### PR TITLE
PP-2883 Rollback RuntimeException for empty webhook secret

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/config/GoCardlessFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/config/GoCardlessFactory.java
@@ -25,9 +25,7 @@ public class GoCardlessFactory {
 
     public WebhookVerifier buildSignatureVerifier() {
         if (StringUtils.isBlank(webhookSecret)) {
-            return null;
-            // do not throw exception for now (until we have GoCardless webhook secret for testing)
-            //throw new RuntimeException("GoCardless webhook secret is blank");
+            throw new RuntimeException("GoCardless webhook secret is blank");
         }
 
         return new WebhookVerifier(webhookSecret);

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -19,7 +19,7 @@ goCardless:
   # For initial integration we will use sandbox access token.
   # When in live mode: access token should be removed from the config and we should use partner integration instead.
   accessToken: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ACCESS_TOKEN:-}
-  webhookSecret: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_WEBHOOK_SECRET:-}
+  webhookSecret: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_WEBHOOK_SECRET:-change-me}
   environment: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ENVIRONMENT:-sandbox}
 
 # TODO: Awaiting AWS environments to be ready


### PR DESCRIPTION
## WHAT

- Rollback RuntimeException for empty webhook secret and add dummy secret
- Temporary added dummy secret in the configuration to avoid blocking `msl -a up`
- Probably we need to add an environment flag and mock the GoCardless SDK if it's not in AWS environment