### PR TITLE
PP-2971 Add PaymentRequest and Token entities, with relative DAOs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-jdbi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-migrations</artifactId>
             <exclusions>
                 <exclusion>
@@ -122,10 +126,17 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.exparity</groupId>
+            <artifactId>hamcrest-date</artifactId>
+            <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitConfig.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitConfig.java
@@ -18,6 +18,13 @@ public class DirectDebitConfig extends Configuration {
     @NotNull
     private DataSourceFactory dataSourceFactory;
 
+    @Valid
+    @NotNull
+    private LinksConfig links = new LinksConfig();
+
+    @NotNull
+    private ProxyConfiguration proxyConfiguration;
+
     @JsonProperty("database")
     public DataSourceFactory getDataSourceFactory() {
         return dataSourceFactory;
@@ -27,4 +34,15 @@ public class DirectDebitConfig extends Configuration {
     public GoCardlessFactory getGoCardless() {
         return goCardless;
     }
+
+
+    public LinksConfig getLinks() {
+        return links;
+    }
+
+    @JsonProperty("proxy")
+    public ProxyConfiguration getProxyConfiguration() {
+        return proxyConfiguration;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/directdebit/app/config/LinksConfig.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/LinksConfig.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.directdebit.app.config;
+
+import io.dropwizard.Configuration;
+
+public class LinksConfig extends Configuration {
+
+    private String frontendUrl;
+
+    public String getFrontendUrl() {
+        return frontendUrl;
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/app/config/ProxyConfiguration.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/ProxyConfiguration.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.directdebit.app.config;
+
+import io.dropwizard.Configuration;
+
+import javax.validation.constraints.NotNull;
+
+public class ProxyConfiguration extends Configuration {
+
+    @NotNull
+    private String host;
+
+    @NotNull
+    private Integer port;
+
+    public String getHost() {
+        return host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/dao/DateArgumentFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/dao/DateArgumentFactory.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.directdebit.common.dao;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.sql.Timestamp;
+import java.time.ZonedDateTime;
+
+public class DateArgumentFactory implements ArgumentFactory<ZonedDateTime> {
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx)
+    {
+        return value instanceof ZonedDateTime;
+    }
+
+    @Override
+    public Argument build(Class<?> aClass, ZonedDateTime zonedDateTime, StatementContext statementContext) {
+        return (position, preparedStatement, statementContext1) ->
+                preparedStatement.setTimestamp(position, Timestamp.from(zonedDateTime.toInstant()));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/util/RandomIdGenerator.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/util/RandomIdGenerator.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.directdebit.common.util;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+public class RandomIdGenerator {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    /**
+     * This method will generate a URL safe random string.
+     * This works by choosing 130 bits from a cryptographically secure random bit generator,
+     * and encoding them in base-32.
+     * <p> 128 bits is considered to be cryptographically strong,
+     * but each digit in a base 32 number can encode 5 bits, so 128 is rounded up to the next multiple of 5.
+     * This encoding is compact and efficient, with 5 random bits per character. Compare this to a random UUID,
+     * which only has 3.4 bits per character in standard layout, and only 122 random bits in total </p>
+     *
+     * @return a random number in base32 (in string format)
+     */
+    public static String newId() {
+        return new BigInteger(130, RANDOM).toString(32);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.directdebit.payments.dao;
+
+import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterArgumentFactory;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+import uk.gov.pay.directdebit.common.dao.DateArgumentFactory;
+import uk.gov.pay.directdebit.payments.dao.mapper.PaymentRequestMapper;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+
+import java.util.Optional;
+
+@RegisterMapper(PaymentRequestMapper.class)
+public interface PaymentRequestDao {
+    @SqlQuery("SELECT * FROM payment_requests p WHERE p.id = :id")
+    @SingleValueResult(PaymentRequest.class)
+    Optional<PaymentRequest> findById(@Bind("id") Long id);
+
+    @SqlQuery("SELECT * FROM payment_requests p WHERE p.external_id = :externalId")
+    @SingleValueResult(PaymentRequest.class)
+    Optional<PaymentRequest> findByExternalId(@Bind("externalId") String externalId);
+
+    @SqlQuery("SELECT * FROM payment_requests p INNER JOIN tokens t ON t.charge_id = p.id WHERE t.secure_redirect_token = :tokenId")
+    @SingleValueResult(PaymentRequest.class)
+    Optional<PaymentRequest> findByTokenId(@Bind("tokenId") String tokenId);
+
+    @SqlUpdate("INSERT INTO payment_requests(external_id, gateway_account_id, amount, reference, description, return_url, created_date) VALUES (:externalId, :gatewayAccountId, :amount, :reference, :description, :returnUrl, :createdDate)")
+    @GetGeneratedKeys
+    @RegisterArgumentFactory(DateArgumentFactory.class)
+    Long insert(@BindBean PaymentRequest paymentRequest);
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TokenDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TokenDao.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.directdebit.payments.dao;
+
+
+import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+import uk.gov.pay.directdebit.payments.model.Token;
+import uk.gov.pay.directdebit.payments.dao.mapper.TokenMapper;
+
+import java.util.Optional;
+
+@RegisterMapper(TokenMapper.class)
+public interface TokenDao {
+    @SqlQuery("SELECT * FROM tokens t WHERE t.secure_redirect_token = :token")
+    @SingleValueResult(Token.class)
+    Optional<Token> findByTokenId(@Bind("token") String token);
+
+    @SqlQuery("SELECT * FROM tokens t WHERE t.charge_id = :chargeId")
+    @SingleValueResult(Token.class)
+    Optional<Token> findByChargeId(@Bind("chargeId") Long chargeId);
+
+    @SqlUpdate("INSERT INTO tokens(charge_id, secure_redirect_token) VALUES (:chargeId, :token)")
+    @GetGeneratedKeys
+    Long insert(@BindBean Token token);
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentRequestMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentRequestMapper.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.directdebit.payments.dao.mapper;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class PaymentRequestMapper implements ResultSetMapper<PaymentRequest> {
+    private static final String ID_COLUMN = "id";
+    private static final String EXTERNAL_ID_COLUMN = "external_id";
+    private static final String GATEWAY_ACCOUNT_ID_COLUMN = "gateway_account_id";
+    private static final String AMOUNT_COLUMN = "amount";
+    private static final String REFERENCE_COLUMN = "reference";
+    private static final String DESCRIPTION_COLUMN = "description";
+    private static final String RETURN_URL_COLUMN = "return_url";
+    private static final String CREATED_DATE_COLUMN = "created_date";
+
+    @Override
+    public PaymentRequest map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        return new PaymentRequest(
+                resultSet.getLong(ID_COLUMN),
+                resultSet.getLong(AMOUNT_COLUMN),
+                resultSet.getString(RETURN_URL_COLUMN),
+                resultSet.getLong(GATEWAY_ACCOUNT_ID_COLUMN),
+                resultSet.getString(DESCRIPTION_COLUMN),
+                resultSet.getString(REFERENCE_COLUMN),
+                resultSet.getString(EXTERNAL_ID_COLUMN),
+                ZonedDateTime.ofInstant(resultSet.getTimestamp(CREATED_DATE_COLUMN).toInstant(), ZoneId.of("UTC")));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TokenMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TokenMapper.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.directdebit.payments.dao.mapper;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.pay.directdebit.payments.model.Token;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class TokenMapper implements ResultSetMapper<Token> {
+    private static final String ID_COLUMN = "id";
+    private static final String CHARGE_ID_COLUMN = "charge_id";
+    private static final String TOKEN_COLUMN = "secure_redirect_token";
+
+    @Override
+    public Token map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        return new Token(resultSet.getLong(ID_COLUMN), resultSet.getString(TOKEN_COLUMN), resultSet.getLong(CHARGE_ID_COLUMN));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
@@ -1,0 +1,97 @@
+package uk.gov.pay.directdebit.payments.model;
+
+import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class PaymentRequest {
+
+    private Long id;
+    private String externalId;
+    private Long amount;
+    private String returnUrl;
+    private Long gatewayAccountId;
+    private String description;
+    private String reference;
+    private ZonedDateTime createdDate;
+
+    public PaymentRequest(Long id, Long amount, String returnUrl, Long gatewayAccountId, String description, String reference, String externalId, ZonedDateTime createdDate) {
+        this.id = id;
+        this.amount = amount;
+        this.returnUrl = returnUrl;
+        this.gatewayAccountId = gatewayAccountId;
+        this.description = description;
+        this.reference = reference;
+        this.createdDate = createdDate;
+        this.externalId = externalId;
+    }
+
+    public PaymentRequest(Long amount, String returnUrl, Long gatewayAccountId, String description, String reference) {
+        this(null, amount, returnUrl, gatewayAccountId, description, reference, RandomIdGenerator.newId(), ZonedDateTime.now(ZoneId.of("UTC")));
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public void setReturnUrl(String returnUrl) {
+        this.returnUrl = returnUrl;
+    }
+
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public void setGatewayAccountId(Long gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Token.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Token.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.directdebit.payments.model;
+
+import java.util.UUID;
+
+public class Token {
+
+    private Long id;
+    private String token;
+    private Long chargeId;
+
+    public Token(Long id, String token, Long chargeId) {
+        this.id = id;
+        this.token = token;
+        this.chargeId = chargeId;
+    }
+
+    public Token(String token, Long chargeId) {
+        this(null, token, chargeId);
+    }
+    public static Token generateNewTokenFor(Long chargeId) {
+        return new Token(UUID.randomUUID().toString(), chargeId);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public Long getChargeId() {
+        return chargeId;
+    }
+
+    public void setChargeId(Long chargeId) {
+        this.chargeId = chargeId;
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,7 +13,14 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
+
+proxy:
+  host: ${HTTP_PROXY_HOST}
+  port: ${HTTP_PROXY_PORT}
+
+links:
+  frontendUrl: ${FRONTEND_URL:-}
 
 goCardless:
   # For initial integration we will use sandbox access token.

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <includeAll path="migrations"/>
+
+</databaseChangeLog>

--- a/src/main/resources/migrations/00001_create_table_payment_requests.sql
+++ b/src/main/resources/migrations/00001_create_table_payment_requests.sql
@@ -1,0 +1,16 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-payment_requests
+CREATE TABLE payment_requests (
+    id BIGSERIAL PRIMARY KEY,
+    external_id VARCHAR(26),
+    gateway_account_id BIGSERIAL NOT NULL,
+    amount BIGINT NOT NULL,
+    reference VARCHAR(255) NOT NULL,
+    description VARCHAR(255) NOT NULL,
+    return_url TEXT NOT NULL,
+    created_date TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'utc') NOT NULL,
+    version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table payment_requests;
+

--- a/src/main/resources/migrations/00002_create_table_tokens.sql
+++ b/src/main/resources/migrations/00002_create_table_tokens.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-tokens
+CREATE TABLE tokens (
+    id BIGSERIAL PRIMARY KEY,
+    charge_id BIGSERIAL NOT NULL,
+    secure_redirect_token VARCHAR(255) NOT NULL,
+    version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table tokens;

--- a/src/test/java/uk/gov/pay/directdebit/infra/DaoITestBase.java
+++ b/src/test/java/uk/gov/pay/directdebit/infra/DaoITestBase.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.directdebit.infra;
+
+import io.dropwizard.jdbi.OptionalContainerFactory;
+import liquibase.Liquibase;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.pay.directdebit.util.DatabaseTestHelper;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Properties;
+
+public class DaoITestBase {
+    @Rule
+    public PostgresDockerRule postgres;
+
+    protected DBI jdbi;
+    protected DatabaseTestHelper databaseTestHelper;
+
+    public DaoITestBase() {
+        postgres = new PostgresDockerRule();
+        jdbi = new DBI(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword());
+        jdbi.registerContainerFactory(new OptionalContainerFactory());
+    }
+
+    @Before
+    public void setupTests() throws Exception {
+        final Properties properties = new Properties();
+        properties.put("javax.persistence.jdbc.driver", postgres.getDriverClass());
+        properties.put("javax.persistence.jdbc.url", postgres.getConnectionUrl());
+        properties.put("javax.persistence.jdbc.user", postgres.getUsername());
+        properties.put("javax.persistence.jdbc.password", postgres.getPassword());
+
+        databaseTestHelper = new DatabaseTestHelper(jdbi);
+
+        Connection connection = null;
+        try {
+            connection = DriverManager.getConnection(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword());
+
+            Liquibase migrator = new Liquibase("migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
+            migrator.update("");
+        } finally {
+            if(connection != null)
+                connection.close();
+        }
+
+    }
+
+    @After
+    public void tearDown() {
+        Connection connection = null;
+        try {
+            connection = DriverManager.getConnection(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword());
+            Liquibase migrator = new Liquibase("migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
+            migrator.dropAll();
+            connection.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/infra/PostgresDockerRule.java
+++ b/src/test/java/uk/gov/pay/directdebit/infra/PostgresDockerRule.java
@@ -74,4 +74,8 @@ public class PostgresDockerRule implements TestRule {
         container.stop();
         container = null;
     }
+
+    public String getDriverClass() {
+        return "org.postgresql.Driver";
+    }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDaoTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDaoTest.java
@@ -1,0 +1,122 @@
+package uk.gov.pay.directdebit.payments.dao;
+
+import liquibase.exception.LiquibaseException;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.directdebit.infra.DaoITestBase;
+import uk.gov.pay.directdebit.infra.DropwizardAppWithPostgresRule;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.fixtures.TokenFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+import uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.paymentRequestFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.TokenFixture.tokenFixture;
+import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.*;
+
+
+public class PaymentRequestDaoTest extends DaoITestBase {
+
+    @Rule
+    public DropwizardAppWithPostgresRule postgres;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    private PaymentRequestDao paymentRequestDao;
+
+    private PaymentRequestFixture testPaymentRequest;
+    private TokenFixture testToken;
+
+    @Before
+    public void setup() throws IOException, LiquibaseException {
+        paymentRequestDao = jdbi.onDemand(PaymentRequestDao.class);
+        this.testPaymentRequest = paymentRequestFixture(databaseTestHelper)
+                .withGatewayAccountId(RandomUtils.nextLong(1, 99999))
+                .insert();
+       this.testToken = tokenFixture(databaseTestHelper)
+                .withChargeId(testPaymentRequest.getId())
+                .insert();
+    }
+
+
+    @Test
+    public void shouldInsertAPaymentRequest() {
+        Long id = paymentRequestDao.insert(testPaymentRequest.toEntity());
+        Map<String, Object> foundPaymentRequest = databaseTestHelper.getPaymentRequestById(id);
+        assertThat(foundPaymentRequest.get("id"), is(id));
+        assertThat(foundPaymentRequest.get("external_id"), is(testPaymentRequest.getExternalId()));
+        assertThat(foundPaymentRequest.get("amount"), is(testPaymentRequest.getAmount()));
+        assertThat(foundPaymentRequest.get("reference"), is(testPaymentRequest.getReference()));
+        assertThat(foundPaymentRequest.get("description"), is(testPaymentRequest.getDescription()));
+        assertThat(foundPaymentRequest.get("return_url"), is(testPaymentRequest.getReturnUrl()));
+        assertThat((Timestamp) foundPaymentRequest.get("created_date"), isDate(testPaymentRequest.getCreatedDate()));
+    }
+
+    @Test
+    public void shouldFindPaymentRequestById() {
+        PaymentRequest paymentRequest = paymentRequestDao.findById(testPaymentRequest.getId()).get();
+        assertThat(paymentRequest.getId(), is(notNullValue()));
+        assertThat(paymentRequest.getAmount(), is(testPaymentRequest.getAmount()));
+        assertThat(paymentRequest.getCreatedDate(), is(testPaymentRequest.getCreatedDate()));
+        assertThat(paymentRequest.getDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(paymentRequest.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
+        assertThat(paymentRequest.getReference(), is(testPaymentRequest.getReference()));
+        assertThat(paymentRequest.getReturnUrl(), is(testPaymentRequest.getReturnUrl()));
+        assertThat(paymentRequest.getExternalId(), is(testPaymentRequest.getExternalId()));
+    }
+
+    @Test
+    public void shouldNotFindPaymentRequestById_ifIdIsInvalid() {
+        Long noExistingChargeId = 9876512L;
+        assertThat(paymentRequestDao.findById(noExistingChargeId).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldFindPaymentRequestByExternalId() {
+        PaymentRequest paymentRequest = paymentRequestDao.findByExternalId(testPaymentRequest.getExternalId()).get();
+        assertThat(paymentRequest.getId(), is(notNullValue()));
+        assertThat(paymentRequest.getAmount(), is(testPaymentRequest.getAmount()));
+        assertThat(paymentRequest.getCreatedDate(), is(testPaymentRequest.getCreatedDate()));
+        assertThat(paymentRequest.getDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(paymentRequest.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
+        assertThat(paymentRequest.getReference(), is(testPaymentRequest.getReference()));
+        assertThat(paymentRequest.getReturnUrl(), is(testPaymentRequest.getReturnUrl()));
+        assertThat(paymentRequest.getExternalId(), is(testPaymentRequest.getExternalId()));
+    }
+
+    @Test
+    public void shouldNotFindPaymentRequestByExternalId_ifExternalIdIsInvalid() {
+        String externalId = "non_existing_externalId";
+        assertThat(paymentRequestDao.findByTokenId(externalId), is(Optional.empty()));
+    }
+
+    @Test
+    public void shouldFindPaymentRequestByTokenId() {
+        PaymentRequest paymentRequest = paymentRequestDao.findByTokenId(testToken.getToken()).get();
+        assertThat(paymentRequest.getId(), is(notNullValue()));
+        assertThat(paymentRequest.getAmount(), is(testPaymentRequest.getAmount()));
+        assertThat(paymentRequest.getCreatedDate(), is(testPaymentRequest.getCreatedDate()));
+        assertThat(paymentRequest.getDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(paymentRequest.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
+        assertThat(paymentRequest.getReference(), is(testPaymentRequest.getReference()));
+        assertThat(paymentRequest.getReturnUrl(), is(testPaymentRequest.getReturnUrl()));
+        assertThat(paymentRequest.getExternalId(), is(testPaymentRequest.getExternalId()));
+    }
+
+    @Test
+    public void shouldNotFindPaymentRequestByTokenId_ifTokenIdIsInvalid() {
+        String tokenId = "non_existing_tokenId";
+        assertThat(paymentRequestDao.findByTokenId(tokenId), is(Optional.empty()));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/TokenDaoTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/TokenDaoTest.java
@@ -1,0 +1,89 @@
+package uk.gov.pay.directdebit.payments.dao;
+
+import liquibase.exception.LiquibaseException;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.directdebit.infra.DaoITestBase;
+import uk.gov.pay.directdebit.infra.DropwizardAppWithPostgresRule;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.fixtures.TokenFixture;
+import uk.gov.pay.directdebit.payments.model.Token;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.*;
+import static uk.gov.pay.directdebit.payments.fixtures.TokenFixture.tokenFixture;
+
+
+public class TokenDaoTest extends DaoITestBase {
+
+    @Rule
+    public DropwizardAppWithPostgresRule postgres;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    private TokenDao tokenDao;
+
+    private PaymentRequestFixture testPaymentRequest;
+    private TokenFixture testToken;
+
+    @Before
+    public void setup() throws IOException, LiquibaseException {
+        tokenDao = jdbi.onDemand(TokenDao.class);
+        this.testPaymentRequest = paymentRequestFixture(databaseTestHelper)
+                .withGatewayAccountId(RandomUtils.nextLong(1, 99999))
+                .insert();
+       this.testToken = tokenFixture(databaseTestHelper)
+                .withChargeId(testPaymentRequest.getId())
+                .insert();
+    }
+
+
+    @Test
+    public void shouldInsertAToken() {
+        String tokenId = "ldfbsdfsaf";
+        Long chargeId = 103244L;
+        Token token = new Token(tokenId, chargeId);
+        Long id = tokenDao.insert(token);
+        Map<String, Object> foundToken = databaseTestHelper.getTokenByChargeId(chargeId);
+        assertThat(foundToken.get("id"), is(id));
+        assertThat(foundToken.get("charge_id"), is(chargeId));
+        assertThat(foundToken.get("secure_redirect_token"), is(tokenId));
+    }
+
+    @Test
+    public void findByChargeId_shouldFindToken() {
+        Token token = tokenDao.findByChargeId(testPaymentRequest.getId()).get();
+        assertThat(token.getId(), is(notNullValue()));
+        assertThat(token.getToken(), is(testToken.getToken()));
+        assertThat(token.getChargeId(), is(testPaymentRequest.getId()));
+    }
+
+    @Test
+    public void findByChargeId_shouldNotFindToken() {
+        Long noExistingChargeId = 9876512L;
+        assertThat(tokenDao.findByChargeId(noExistingChargeId).isPresent(), is(false));
+    }
+
+    @Test
+    public void findByTokenId_shouldFindToken() {
+        Token token = tokenDao.findByTokenId(testToken.getToken()).get();
+        assertThat(token.getId(), is(notNullValue()));
+        assertThat(token.getChargeId(), is(testPaymentRequest.getId()));
+        assertThat(token.getToken(), is(testToken.getToken()));
+    }
+
+    @Test
+    public void findByTokenId_shouldNotFindToken() {
+        String tokenId = "non_existing_tokenId";
+        assertThat(tokenDao.findByTokenId(tokenId), is(Optional.empty()));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/DbFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/DbFixture.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.directdebit.payments.fixtures;
+
+public interface DbFixture<F, E> {
+    F insert();
+    E toEntity();
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentRequestFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentRequestFixture.java
@@ -1,0 +1,109 @@
+package uk.gov.pay.directdebit.payments.fixtures;
+
+import org.apache.commons.lang3.RandomUtils;
+import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+import uk.gov.pay.directdebit.util.DatabaseTestHelper;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class PaymentRequestFixture implements DbFixture<PaymentRequestFixture, PaymentRequest> {
+    private DatabaseTestHelper databaseTestHelper;
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private Long gatewayAccountId = 23L;
+    private String description = "Test description";
+    private String externalId = RandomIdGenerator.newId();
+    private long amount = 101L;
+    private String returnUrl = "http://service.com/success-page";
+    private String reference = "Test reference";
+
+    private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+
+    public PaymentRequestFixture(DatabaseTestHelper databaseTestHelper) {
+        this.databaseTestHelper = databaseTestHelper;
+    }
+
+    public static PaymentRequestFixture paymentRequestFixture(DatabaseTestHelper databaseHelper) {
+        return new PaymentRequestFixture(databaseHelper);
+    }
+
+    public PaymentRequestFixture withId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public PaymentRequestFixture withExternalId(String externalId) {
+        this.externalId = externalId;
+        return this;
+    }
+
+    public PaymentRequestFixture withReference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    public PaymentRequestFixture withGatewayAccountId(Long gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
+        return this;
+    }
+    public PaymentRequestFixture withAmount(long amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public PaymentRequestFixture withCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+
+
+    public PaymentRequestFixture withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public long getAmount() {
+        return amount;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    @Override
+    public PaymentRequestFixture insert() {
+        databaseTestHelper.add(this);
+        return this;
+    }
+
+    @Override
+    public PaymentRequest toEntity() {
+        return new PaymentRequest(id, amount, returnUrl, gatewayAccountId, description, reference, externalId, createdDate);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TokenFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TokenFixture.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.directdebit.payments.fixtures;
+
+import org.apache.commons.lang3.RandomUtils;
+import uk.gov.pay.directdebit.payments.model.Token;
+import uk.gov.pay.directdebit.util.DatabaseTestHelper;
+
+public class TokenFixture implements DbFixture<TokenFixture, Token> {
+    private DatabaseTestHelper databaseTestHelper;
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private String token = "3c9fee80-977a-4da5-a003-4872a8cf95b6";
+    private Long chargeId =  RandomUtils.nextLong(1, 99999);;
+
+    private TokenFixture(DatabaseTestHelper databaseTestHelper) {
+        this.databaseTestHelper = databaseTestHelper;
+    }
+
+    public static TokenFixture tokenFixture(DatabaseTestHelper databaseHelper) {
+        return new TokenFixture(databaseHelper);
+    }
+
+    public TokenFixture withChargeId(Long chargeId) {
+        this.chargeId = chargeId;
+        return this;
+    }
+
+    public TokenFixture withToken(String token) {
+        this.token = token;
+        return this;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public Long getChargeId() {
+        return chargeId;
+    }
+
+    @Override
+    public TokenFixture insert() {
+        databaseTestHelper.add(this);
+        return this;
+    }
+
+    @Override
+    public Token toEntity() {
+        return new Token(id, token, chargeId);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.directdebit.util;
+
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.util.StringColumnMapper;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.fixtures.TokenFixture;
+
+import java.sql.Timestamp;
+import java.util.Map;
+
+public class DatabaseTestHelper {
+
+    private DBI jdbi;
+
+    public DatabaseTestHelper(DBI jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    public Map<String, Object> getTokenByChargeId(Long chargeId) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT * from tokens t WHERE t.charge_id = :charge_id")
+                        .bind("charge_id", chargeId)
+                        .first()
+        );
+    }
+
+    public String getTokenByChargeExternalId(String externalId) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT secure_redirect_token from tokens t JOIN payment_requests p ON p.id = t.charge_id WHERE p.external_id = :external_id ORDER BY t.id DESC")
+                        .bind("external_id", externalId)
+                        .map(StringColumnMapper.INSTANCE)
+                        .first()
+        );
+    }
+
+    public void add(TokenFixture token) {
+        jdbi.withHandle(handle ->
+                handle
+                        .createStatement("INSERT INTO tokens(charge_id, secure_redirect_token) VALUES (:charge_id, :secure_redirect_token)")
+                        .bind("charge_id", token.getChargeId())
+                        .bind("secure_redirect_token", token.getToken())
+                        .execute()
+        );
+    }
+
+    public Map<String, Object> getPaymentRequestById(Long id) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT * from payment_requests p WHERE p.id = :id")
+                        .bind("id", id)
+                        .first()
+        );
+    }
+    public void add(PaymentRequestFixture paymentRequest) {
+        jdbi.withHandle(h ->
+                h.update(
+                        "INSERT INTO" +
+                                "    payment_requests(\n" +
+                                "        id,\n" +
+                                "        external_id,\n" +
+                                "        amount,\n" +
+                                "        gateway_account_id,\n" +
+                                "        return_url,\n" +
+                                "        description,\n" +
+                                "        created_date,\n" +
+                                "        reference\n" +
+                                "    )\n" +
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?)\n",
+                        paymentRequest.getId(),
+                        paymentRequest.getExternalId(),
+                        paymentRequest.getAmount(),
+                        paymentRequest.getGatewayAccountId(),
+                        paymentRequest.getReturnUrl(),
+                        paymentRequest.getDescription(),
+                        Timestamp.from(paymentRequest.getCreatedDate().toInstant()),
+                        paymentRequest.getReference()
+                )
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/util/NumberMatcher.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/NumberMatcher.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.directdebit.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+import static java.lang.String.format;
+
+public class NumberMatcher extends BaseMatcher<Number> {
+    private final Number expectation;
+    private String actualClass;
+
+    private NumberMatcher(Number expectation) {
+        this.expectation = expectation;
+    }
+
+    public static NumberMatcher isNumber(Number expectation) {
+        return new NumberMatcher(expectation);
+    }
+
+    @Override
+    public boolean matches(Object item) {
+        if (item instanceof Number) {
+            return expectation.longValue() == ((Number) item).longValue();
+        }
+        actualClass = item.getClass().getSimpleName();
+        return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        if (StringUtils.isNotBlank(actualClass)) {
+            description.appendText(format("A Number type, received type: [%s].", actualClass));
+        } else {
+            description.appendValue(expectation);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/util/ZonedDateTimeTimestampMatcher.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/ZonedDateTimeTimestampMatcher.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.directdebit.util;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.sql.Timestamp;
+import java.time.ZonedDateTime;
+
+public class ZonedDateTimeTimestampMatcher extends TypeSafeMatcher<Timestamp> {
+
+    private Timestamp from;
+
+    private ZonedDateTimeTimestampMatcher(Timestamp from) {
+        this.from = from;
+    }
+
+    public static ZonedDateTimeTimestampMatcher isDate(ZonedDateTime zonedDateTime) {
+        return new ZonedDateTimeTimestampMatcher(Timestamp.from(zonedDateTime.toInstant()));
+    }
+
+    @Override
+    protected boolean matchesSafely(Timestamp to) {
+        return Matchers.is(from).matches(to);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("A timestamp: " + from);
+    }
+}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -14,6 +14,12 @@ logging:
         timeZone: UTC
         target: stdout
         logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+links:
+  frontendUrl: http://Frontend/
+
+proxy:
+  host: localhost
+  port: 1234
 
 goCardless:
   accessToken: accesstoken


### PR DESCRIPTION
This PR introduces two new entities, `PaymentRequest` and `Token`, with relative DAOs and test infrastructure.

- `PaymentRequest` and `Token` are modelled according to https://payments-platform.atlassian.net/browse/PP-2841. There is a difference: `payment_provider` is not in the`payment_requests` table, as will be inferred from the gateway account once that is modelled
- The DAOs are built according to JDBI 3 Declarative APIs
- Migrations are currently run before each test (See the `DAOItestBase`'s rules), this will changed once the DB spike is completed and the work is brought in master