### PR TITLE
PP-2971 Add a separate docker compose script to run migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /app
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh
+ADD docker-startup-with-db-migration.sh /app/docker-startup-with-db-migration.sh
 ADD chamber.sha256sum /app/chamber.sha256sum
 
 RUN apk add openssl && \

--- a/docker-startup-with-db-migration.sh
+++ b/docker-startup-with-db-migration.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ -n "${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:-}" ]; then
+  # Looks like we're in ECS and we've got access to credentials.
+  # Use Chamber so we can use them to get secrets from Parameter Store
+  AWS_REGION=${ECS_AWS_REGION} bin/chamber exec ${ECS_SERVICE} -- java -jar *-allinone.jar server *.yaml
+else
+  # Do a normal startup and run db migrations
+  java -jar *-allinone.jar db migrate *.yaml && \
+  java -jar *-allinone.jar server *.yaml
+fi

--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -5,6 +5,8 @@ import com.google.inject.Injector;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.migrations.MigrationsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.directdebit.app.bootstrap.DependentResourcesWaitCommand;
@@ -36,6 +38,12 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
                         new EnvironmentVariableSubstitutor(NON_STRICT_VARIABLE_SUBSTITUTOR)
                 )
         );
+        bootstrap.addBundle(new MigrationsBundle<DirectDebitConfig>() {
+            @Override
+            public DataSourceFactory getDataSourceFactory(DirectDebitConfig configuration) {
+                return configuration.getDataSourceFactory();
+            }
+        });
         bootstrap.addCommand(new DependentResourcesWaitCommand());
     }
 


### PR DESCRIPTION
 - This will PR makes so that db migrations are _not_ run at deployment time, just locally