### PR TITLE
PP-2971 Add payment request events

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDao.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.directdebit.payments.dao;
+
+import org.skife.jdbi.v2.sqlobject.BindBean;
+import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterArgumentFactory;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import uk.gov.pay.directdebit.common.dao.DateArgumentFactory;
+import uk.gov.pay.directdebit.payments.dao.mapper.PaymentRequestEventMapper;
+import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
+
+@RegisterMapper(PaymentRequestEventMapper.class)
+public interface PaymentRequestEventDao {
+
+    @SqlUpdate("INSERT INTO payment_request_events(payment_request_id, event_type, event, event_date) VALUES (:paymentRequestId, :eventType, :event, :eventDate)")
+    @GetGeneratedKeys
+    @RegisterArgumentFactory(DateArgumentFactory.class)
+    Long insert(@BindBean PaymentRequestEvent paymentRequestevent);
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentRequestEventMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentRequestEventMapper.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.directdebit.payments.dao.mapper;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class PaymentRequestEventMapper implements ResultSetMapper<PaymentRequestEvent> {
+    private static final String ID_COLUMN = "id";
+    private static final String PAYMENT_REQUEST_ID_COLUMN = "payment_request_id";
+    private static final String EVENT_TYPE_COLUMN = "event_type";
+    private static final String EVENT_COLUMN = "event";
+    private static final String EVENT_DATE_COLUMN = "event_date";
+
+    @Override
+    public PaymentRequestEvent map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        return new PaymentRequestEvent(
+                resultSet.getLong(ID_COLUMN),
+                resultSet.getLong(PAYMENT_REQUEST_ID_COLUMN),
+                PaymentRequestEvent.Type.valueOf(resultSet.getString(EVENT_TYPE_COLUMN)),
+                PaymentRequestEvent.SupportedEvent.valueOf(resultSet.getString(EVENT_COLUMN)),
+                ZonedDateTime.ofInstant(resultSet.getTimestamp(EVENT_DATE_COLUMN).toInstant(), ZoneId.of("UTC")));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/UnsupportedPaymentRequestEventException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/UnsupportedPaymentRequestEventException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.directdebit.payments.exception;
+
+public class UnsupportedPaymentRequestEventException extends Exception {
+
+    public UnsupportedPaymentRequestEventException(String unsupportedEvent) {
+        super(String.format("Event \"%s\" is not supported", unsupportedEvent));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -1,0 +1,104 @@
+package uk.gov.pay.directdebit.payments.model;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.payments.exception.UnsupportedPaymentRequestEventException;
+
+import java.time.ZonedDateTime;
+
+public class PaymentRequestEvent {
+    private static final Logger logger = LoggerFactory.getLogger(PaymentRequestEvent.class);
+
+    private Long id;
+    private Long paymentRequestId;
+    private Type eventType;
+    private SupportedEvent event;
+    private ZonedDateTime eventDate;
+
+    public PaymentRequestEvent(Long id, Long paymentRequestId, Type eventType, SupportedEvent event, ZonedDateTime eventDate) {
+        this.id = id;
+        this.paymentRequestId = paymentRequestId;
+        this.eventType = eventType;
+        this.event = event;
+        this.eventDate = eventDate;
+    }
+
+    public PaymentRequestEvent(Long paymentRequestId, Type eventType, SupportedEvent event, ZonedDateTime eventDate) {
+        this(null, paymentRequestId, eventType, event, eventDate);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getPaymentRequestId() {
+        return paymentRequestId;
+    }
+
+    public void setPaymentRequestId(Long paymentRequestId) {
+        this.paymentRequestId = paymentRequestId;
+    }
+
+    public Type getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(Type eventType) {
+        this.eventType = eventType;
+    }
+
+    public SupportedEvent getEvent() {
+        return event;
+    }
+
+    public void setEvent(SupportedEvent event) {
+        this.event = event;
+    }
+
+    public ZonedDateTime getEventDate() {
+        return eventDate;
+    }
+
+    public void setEventDate(ZonedDateTime eventDate) {
+        this.eventDate = eventDate;
+    }
+
+    public enum Type {
+        CHARGE, MANDATE, PAYER;
+    }
+
+    public enum SupportedEvent {
+        CHARGE_CREATED,
+        SHOW_ENTER_DIRECT_DEBIT_DETAILS,
+        SYSTEM_CANCEL,
+        PAYMENT_EXPIRED,
+        SHOW_CONFIRM,
+        CREATE_CUSTOMER_FAILED,
+        CREATE_CUSTOMER_BANK_ACCOUNT_ERROR,
+        USER_CANCEL,
+        MANDATE_PAYMENT_CREATED,
+        CREATE_MANDATE_FAILED,
+        CREATE_MANDATE_ERROR,
+        WEBHOOK_ACTION_PAYMENT_CREATED,
+        WEBHOOK_ACTION_CUSTOMER_DENIED,
+        WEBHOOK_ACTION_PAYMENT_ERROR,
+        WEBHOOK_ACTION_CONFIRMED,
+        WEBHOOK_ACTION_DATA_MISSING,
+        WEBHOOK_ACTION_CUSTOMER_CANCELLED,
+        WEBHOOK_ACTION_PAID_OUT;
+
+
+        public static SupportedEvent fromString(String event) throws UnsupportedPaymentRequestEventException {
+            try {
+                return SupportedEvent.valueOf(event);
+            } catch (Exception e) {
+                logger.warn("Tried to parse unknown event {}", event);
+                throw new UnsupportedPaymentRequestEventException(event);
+            }
+        }
+    }
+}

--- a/src/main/resources/migrations/00003_create_table_payment_request_events.sql
+++ b/src/main/resources/migrations/00003_create_table_payment_request_events.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-payment_request_events
+CREATE TABLE payment_request_events (
+    id BIGSERIAL PRIMARY KEY,
+    payment_request_id BIGSERIAL NOT NULL,
+    event_type TEXT NOT NULL,
+    event TEXT NOT NULL,
+    event_date TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'utc') NOT NULL,
+    version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table payment_request_events;

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDaoTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDaoTest.java
@@ -41,10 +41,10 @@ public class PaymentRequestDaoTest extends DaoITestBase {
     @Before
     public void setup() throws IOException, LiquibaseException {
         paymentRequestDao = jdbi.onDemand(PaymentRequestDao.class);
-        this.testPaymentRequest = paymentRequestFixture(databaseTestHelper)
+        this.testPaymentRequest = paymentRequestFixture(jdbi)
                 .withGatewayAccountId(RandomUtils.nextLong(1, 99999))
                 .insert();
-       this.testToken = tokenFixture(databaseTestHelper)
+       this.testToken = tokenFixture(jdbi)
                 .withChargeId(testPaymentRequest.getId())
                 .insert();
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoTest.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.directdebit.payments.dao;
+
+import liquibase.exception.LiquibaseException;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.directdebit.infra.DaoITestBase;
+import uk.gov.pay.directdebit.infra.DropwizardAppWithPostgresRule;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.paymentRequestFixture;
+import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.*;
+
+public class PaymentRequestEventDaoTest extends DaoITestBase {
+
+    @Rule
+    public DropwizardAppWithPostgresRule postgres;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    private PaymentRequestEventDao paymentRequestEventDao;
+
+    private PaymentRequestFixture testPaymentRequest;
+
+    @Before
+    public void setup() throws IOException, LiquibaseException {
+        paymentRequestEventDao = jdbi.onDemand(PaymentRequestEventDao.class);
+        this.testPaymentRequest = paymentRequestFixture(jdbi)
+                .withGatewayAccountId(RandomUtils.nextLong(1, 99999))
+                .insert();
+    }
+
+    @Test
+    public void shouldInsertAnEvent() {
+        Long paymentRequestId = testPaymentRequest.getId();
+        PaymentRequestEvent.Type eventType = PaymentRequestEvent.Type.PAYER;
+        PaymentRequestEvent.SupportedEvent event = PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
+        ZonedDateTime eventDate = ZonedDateTime.now();
+        PaymentRequestEvent paymentRequestEvent = new PaymentRequestEvent(paymentRequestId, eventType, event, eventDate);
+        Long id = paymentRequestEventDao.insert(paymentRequestEvent);
+        Map<String, Object> foundPaymentRequestEvent = databaseTestHelper.getPaymentRequestEventById(id);
+        assertThat(foundPaymentRequestEvent.get("id"), is(id));
+        assertThat(foundPaymentRequestEvent.get("payment_request_id"), is(paymentRequestId));
+        assertThat(foundPaymentRequestEvent.get("event_type"), is(eventType.toString()));
+        assertThat(foundPaymentRequestEvent.get("event"), is(event.toString()));
+        assertThat((Timestamp) foundPaymentRequestEvent.get("event_date"), isDate(eventDate));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/TokenDaoTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/TokenDaoTest.java
@@ -38,10 +38,10 @@ public class TokenDaoTest extends DaoITestBase {
     @Before
     public void setup() throws IOException, LiquibaseException {
         tokenDao = jdbi.onDemand(TokenDao.class);
-        this.testPaymentRequest = paymentRequestFixture(databaseTestHelper)
+        this.testPaymentRequest = paymentRequestFixture(jdbi)
                 .withGatewayAccountId(RandomUtils.nextLong(1, 99999))
                 .insert();
-       this.testToken = tokenFixture(databaseTestHelper)
+       this.testToken = tokenFixture(jdbi)
                 .withChargeId(testPaymentRequest.getId())
                 .insert();
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentRequestEventFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentRequestEventFixture.java
@@ -1,0 +1,99 @@
+package uk.gov.pay.directdebit.payments.fixtures;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
+
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class PaymentRequestEventFixture implements DbFixture<PaymentRequestEventFixture, PaymentRequestEvent> {
+    private DBI jdbi;
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private Long paymentRequestId = RandomUtils.nextLong(1, 99999);
+    private PaymentRequestEvent.Type eventType;
+    private PaymentRequestEvent.SupportedEvent event;
+    private ZonedDateTime eventDate = ZonedDateTime.now(ZoneId.of("UTC"));
+
+    public PaymentRequestEventFixture(DBI jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    public static PaymentRequestEventFixture paymentRequestEventFixture(DBI jdbi) {
+        return new PaymentRequestEventFixture(jdbi);
+    }
+
+    public PaymentRequestEventFixture withId(long id) {
+        this.id = id;
+        return this;
+    }
+    public PaymentRequestEventFixture withPaymentRequestId(long paymentRequestId) {
+        this.paymentRequestId = paymentRequestId;
+        return this;
+    }
+    public PaymentRequestEventFixture withType(PaymentRequestEvent.Type type) {
+        this.eventType = type;
+        return this;
+    }
+
+    public PaymentRequestEventFixture withEvent(PaymentRequestEvent.SupportedEvent event) {
+        this.event = event;
+        return this;
+    }
+
+    public PaymentRequestEventFixture withEventDate(ZonedDateTime eventDate) {
+        this.eventDate = eventDate;
+        return this;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getPaymentRequestId() {
+        return paymentRequestId;
+    }
+
+    public PaymentRequestEvent.Type getEventType() {
+        return eventType;
+    }
+
+    public PaymentRequestEvent.SupportedEvent getEvent() {
+        return event;
+    }
+
+    public ZonedDateTime getEventDate() {
+        return eventDate;
+    }
+
+    @Override
+    public PaymentRequestEventFixture insert() {
+        jdbi.withHandle(h ->
+                h.update(
+                        "INSERT INTO" +
+                                "    payment_request(\n" +
+                                "        id,\n" +
+                                "        payment_request_id,\n" +
+                                "        event_type,\n" +
+                                "        event,\n" +
+                                "        event_date\n" +
+                                "    )\n" +
+                                "   VALUES(?, ?, ?, ?, ?)\n",
+                        id,
+                        paymentRequestId,
+                        eventType.toString(),
+                        event.toString(),
+                        Timestamp.from(eventDate.toInstant())
+                )
+        );
+        return this;
+    }
+
+    @Override
+    public PaymentRequestEvent toEntity() {
+        return new PaymentRequestEvent(id, paymentRequestId, eventType, event, eventDate);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TokenFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TokenFixture.java
@@ -1,21 +1,21 @@
 package uk.gov.pay.directdebit.payments.fixtures;
 
 import org.apache.commons.lang3.RandomUtils;
+import org.skife.jdbi.v2.DBI;
 import uk.gov.pay.directdebit.payments.model.Token;
-import uk.gov.pay.directdebit.util.DatabaseTestHelper;
 
 public class TokenFixture implements DbFixture<TokenFixture, Token> {
-    private DatabaseTestHelper databaseTestHelper;
+    private DBI jdbi;
     private Long id = RandomUtils.nextLong(1, 99999);
     private String token = "3c9fee80-977a-4da5-a003-4872a8cf95b6";
-    private Long chargeId =  RandomUtils.nextLong(1, 99999);;
+    private Long chargeId =  RandomUtils.nextLong(1, 99999);
 
-    private TokenFixture(DatabaseTestHelper databaseTestHelper) {
-        this.databaseTestHelper = databaseTestHelper;
+    private TokenFixture( DBI jdbi) {
+        this.jdbi = jdbi;
     }
 
-    public static TokenFixture tokenFixture(DatabaseTestHelper databaseHelper) {
-        return new TokenFixture(databaseHelper);
+    public static TokenFixture tokenFixture(DBI jdbi) {
+        return new TokenFixture(jdbi);
     }
 
     public TokenFixture withChargeId(Long chargeId) {
@@ -38,7 +38,13 @@ public class TokenFixture implements DbFixture<TokenFixture, Token> {
 
     @Override
     public TokenFixture insert() {
-        databaseTestHelper.add(this);
+        jdbi.withHandle(handle ->
+                handle
+                        .createStatement("INSERT INTO tokens(charge_id, secure_redirect_token) VALUES (:charge_id, :secure_redirect_token)")
+                        .bind("charge_id", chargeId)
+                        .bind("secure_redirect_token", token)
+                        .execute()
+        );
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.directdebit.payments.model;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.directdebit.payments.exception.UnsupportedPaymentRequestEventException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.WEBHOOK_ACTION_CONFIRMED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.fromString;
+
+public class PaymentRequestEventTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldGetPaymentEventFromString() throws UnsupportedPaymentRequestEventException {
+        assertThat(fromString("WEBHOOK_ACTION_CONFIRMED"), is(WEBHOOK_ACTION_CONFIRMED));
+    }
+
+    @Test
+    public void shouldThrowExceptionIfUnknownEvent() throws UnsupportedPaymentRequestEventException {
+        thrown.expect(Exception.class);
+        thrown.expectMessage("Event \"blabla\" is not supported");
+        thrown.reportMissingExceptionWithMessage("UnknownPaymentRequestEventException expected");
+        //any other expectations
+        fromString("blabla");
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -35,16 +35,6 @@ public class DatabaseTestHelper {
         );
     }
 
-    public void add(TokenFixture token) {
-        jdbi.withHandle(handle ->
-                handle
-                        .createStatement("INSERT INTO tokens(charge_id, secure_redirect_token) VALUES (:charge_id, :secure_redirect_token)")
-                        .bind("charge_id", token.getChargeId())
-                        .bind("secure_redirect_token", token.getToken())
-                        .execute()
-        );
-    }
-
     public Map<String, Object> getPaymentRequestById(Long id) {
         return jdbi.withHandle(handle ->
                 handle
@@ -53,30 +43,13 @@ public class DatabaseTestHelper {
                         .first()
         );
     }
-    public void add(PaymentRequestFixture paymentRequest) {
-        jdbi.withHandle(h ->
-                h.update(
-                        "INSERT INTO" +
-                                "    payment_requests(\n" +
-                                "        id,\n" +
-                                "        external_id,\n" +
-                                "        amount,\n" +
-                                "        gateway_account_id,\n" +
-                                "        return_url,\n" +
-                                "        description,\n" +
-                                "        created_date,\n" +
-                                "        reference\n" +
-                                "    )\n" +
-                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?)\n",
-                        paymentRequest.getId(),
-                        paymentRequest.getExternalId(),
-                        paymentRequest.getAmount(),
-                        paymentRequest.getGatewayAccountId(),
-                        paymentRequest.getReturnUrl(),
-                        paymentRequest.getDescription(),
-                        Timestamp.from(paymentRequest.getCreatedDate().toInstant()),
-                        paymentRequest.getReference()
-                )
+    public Map<String, Object> getPaymentRequestEventById(Long id) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT * from payment_request_events p WHERE p.id = :id")
+                        .bind("id", id)
+                        .first()
         );
     }
+
 }


### PR DESCRIPTION
- We support a series of events, which represent a transition between two states. These will be detailed as a graph in a subsequent PR.
- If we try to parse an unsupported event we return a checked exception. And we log a warning - this is because we have no control over which event will arrive from gocardless and we want to make sure we pick the ones we decide to support.