### PR TITLE
PP-2971 Create Transactions

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.directdebit.payments.dao;
+
+import org.skife.jdbi.v2.sqlobject.BindBean;
+import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import uk.gov.pay.directdebit.payments.dao.mapper.TransactionMapper;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+
+@RegisterMapper(TransactionMapper.class)
+public interface TransactionDao {
+    @SqlUpdate("INSERT INTO transactions(payment_request_id, amount, type, state) VALUES (:paymentRequestId, :amount, :type, :state)")
+    @GetGeneratedKeys
+    Long insert(@BindBean Transaction transaction);
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.directdebit.payments.dao.mapper;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.pay.directdebit.payments.model.*;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class TransactionMapper implements ResultSetMapper<Transaction> {
+    private static final String ID_COLUMN = "id";
+    private static final String PAYMENT_REQUEST_ID_COLUMN = "payment_request_id";
+    private static final String AMOUNT_COLUMN = "amount";
+    private static final String TYPE_COLUMN = "type";
+    private static final String STATE_COLUMN = "state";
+
+    @Override
+    public Transaction map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        return new Transaction(
+                resultSet.getLong(ID_COLUMN),
+                resultSet.getLong(PAYMENT_REQUEST_ID_COLUMN),
+                resultSet.getLong(AMOUNT_COLUMN),
+                Transaction.Type.valueOf(resultSet.getString(TYPE_COLUMN)),
+                PaymentState.valueOf(resultSet.getString(STATE_COLUMN)));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -2,12 +2,13 @@ package uk.gov.pay.directdebit.payments.model;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.payments.exception.UnsupportedPaymentRequestEventException;
 
 import java.time.ZonedDateTime;
 
 public class PaymentRequestEvent {
-    private static final Logger logger = LoggerFactory.getLogger(PaymentRequestEvent.class);
+    private static final Logger logger = PayLoggerFactory.getLogger(PaymentRequestEvent.class);
 
     private Long id;
     private Long paymentRequestId;
@@ -68,7 +69,7 @@ public class PaymentRequestEvent {
     }
 
     public enum Type {
-        CHARGE, MANDATE, PAYER;
+        CHARGE, MANDATE, PAYER
     }
 
     public enum SupportedEvent {

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
@@ -54,7 +54,7 @@ public class PaymentStatesGraph {
         this.goCardlessGraphStates = buildGoCardlessStatesGraph();
     }
 
-    public PaymentState getNextValidStateForEvent(PaymentState from, SupportedEvent event) {
+    public PaymentState getNextStateForEvent(PaymentState from, SupportedEvent event) {
         return goCardlessGraphStates.successors(from).stream()
                 .filter(to -> isValidTransition(from, to, event))
                 .findFirst()

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.directdebit.payments.model;
+
+public class Transaction {
+
+    private Long id;
+    private Long paymentRequestId;
+    private Long amount;
+    private Type type;
+    private PaymentState state;
+
+    public Transaction(Long id, Long paymentRequestId, Long amount, Type type, PaymentState state) {
+        this.id = id;
+        this.paymentRequestId = paymentRequestId;
+        this.amount = amount;
+        this.type = type;
+        this.state = state;
+    }
+
+    public Transaction(Long paymentRequestId, Long amount, Type type, PaymentState state) {
+        this(null, paymentRequestId, amount, type, state);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getPaymentRequestId() {
+        return paymentRequestId;
+    }
+
+    public void setPaymentRequestId(Long paymentRequestId) {
+        this.paymentRequestId = paymentRequestId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public PaymentState getState() {
+        return state;
+    }
+
+    public void setState(PaymentState state) {
+        this.state = state;
+    }
+    public enum Type {
+        CHARGE, REFUND
+    }
+}

--- a/src/main/resources/migrations/00004_create_table_transactions.sql
+++ b/src/main/resources/migrations/00004_create_table_transactions.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-transactions
+CREATE TABLE transactions (
+    id BIGSERIAL PRIMARY KEY,
+    payment_request_id BIGSERIAL NOT NULL,
+    amount BIGINT NOT NULL,
+    type TEXT NOT NULL,
+    state TEXT NOT NULL,
+    version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table transactions;

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDaoTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDaoTest.java
@@ -11,7 +11,6 @@ import uk.gov.pay.directdebit.infra.DropwizardAppWithPostgresRule;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TokenFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentRequest;
-import uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher;
 
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -23,7 +22,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.paymentRequestFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.TokenFixture.tokenFixture;
-import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.*;
+import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.isDate;
 
 
 public class PaymentRequestDaoTest extends DaoITestBase {

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.directdebit.infra.DaoITestBase;
 import uk.gov.pay.directdebit.infra.DropwizardAppWithPostgresRule;
-import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
 
@@ -20,7 +19,7 @@ import java.util.Map;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.paymentRequestFixture;
-import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.*;
+import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.isDate;
 
 public class PaymentRequestEventDaoTest extends DaoITestBase {
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoTest.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.directdebit.payments.dao;
+
+import liquibase.exception.LiquibaseException;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.directdebit.infra.DaoITestBase;
+import uk.gov.pay.directdebit.infra.DropwizardAppWithPostgresRule;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.paymentRequestFixture;
+import static uk.gov.pay.directdebit.util.NumberMatcher.isNumber;
+
+
+public class TransactionDaoTest extends DaoITestBase {
+
+    @Rule
+    public DropwizardAppWithPostgresRule postgres;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    private TransactionDao transactionDao;
+
+    private PaymentRequestFixture testPaymentRequest;
+
+    @Before
+    public void setup() throws IOException, LiquibaseException {
+        transactionDao = jdbi.onDemand(TransactionDao.class);
+        this.testPaymentRequest = paymentRequestFixture(jdbi)
+                .withGatewayAccountId(RandomUtils.nextLong(1, 99999))
+                .insert();
+    }
+
+    @Test
+    public void shouldInsertATransaction() {
+        Long paymentRequestId = testPaymentRequest.getId();
+        Long amount = 13L;
+        Transaction.Type type = Transaction.Type.CHARGE;
+        PaymentState state = PaymentState.NEW;
+        Transaction transaction = new Transaction(paymentRequestId, amount, type, state);
+        Long id = transactionDao.insert(transaction);
+        Map<String, Object> foundTransaction = databaseTestHelper.getTransactionById(id);
+        assertThat(foundTransaction.get("id"), is(id));
+        assertThat(foundTransaction.get("payment_request_id"), is(paymentRequestId));
+        assertThat((Long) foundTransaction.get("amount"), isNumber(amount));
+        assertThat(Transaction.Type.valueOf((String) foundTransaction.get("type")), is(type));
+        assertThat(PaymentState.valueOf((String) foundTransaction.get("state")), is(state));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
@@ -1,0 +1,94 @@
+package uk.gov.pay.directdebit.payments.fixtures;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.Token;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+import uk.gov.pay.directdebit.util.DatabaseTestHelper;
+
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class TransactionFixture implements DbFixture<TransactionFixture, Transaction> {
+    private DBI jdbi;
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private Long paymentRequestId = RandomUtils.nextLong(1, 99999);
+    private Long amount = RandomUtils.nextLong(1, 99999);
+    private Transaction.Type type = Transaction.Type.CHARGE;
+    private PaymentState state = PaymentState.NEW;
+
+    private TransactionFixture(DBI jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    public static TransactionFixture transactionFixture(DBI jdbi) {
+        return new TransactionFixture(jdbi);
+    }
+
+    public TransactionFixture withPaymentRequestId(Long paymentRequestId) {
+        this.paymentRequestId = paymentRequestId;
+        return this;
+    }
+
+    public TransactionFixture withAmount(Long amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public TransactionFixture withType(Transaction.Type type) {
+        this.type = type;
+        return this;
+    }
+
+    public TransactionFixture withState(PaymentState state) {
+        this.state = state;
+        return this;
+    }
+
+    public Long getPaymentRequestId() {
+        return paymentRequestId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public Transaction.Type getType() {
+        return type;
+    }
+
+    public PaymentState getState() {
+        return state;
+    }
+
+    @Override
+    public TransactionFixture insert() {
+        jdbi.withHandle(h ->
+                h.update(
+                        "INSERT INTO" +
+                                "    transactions(\n" +
+                                "        id,\n" +
+                                "        payment_request_id,\n" +
+                                "        amount,\n" +
+                                "        type,\n" +
+                                "        state\n" +
+                                "    )\n" +
+                                "   VALUES(?, ?, ?, ?, ?)\n",
+                        id,
+                        paymentRequestId,
+                        amount,
+                        type,
+                        state
+                )
+        );
+        return this;
+    }
+
+    @Override
+    public Transaction toEntity() {
+        return new Transaction(id, paymentRequestId, amount, type, state);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraphTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraphTest.java
@@ -5,7 +5,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
-import uk.gov.pay.directdebit.payments.exception.UnsupportedPaymentRequestEventException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -32,7 +31,7 @@ public class PaymentStatesGraphTest {
 
     @Test
     public void getNextStateForEvent_shouldGiveTheNextStateIfEventIsValid() {
-        assertThat(paymentStatesGraph.getNextValidStateForEvent(NEW, SYSTEM_CANCEL), is(PaymentState.SYSTEM_CANCELLED));
+        assertThat(paymentStatesGraph.getNextStateForEvent(NEW, SYSTEM_CANCEL), is(PaymentState.SYSTEM_CANCELLED));
     }
 
     @Test
@@ -40,7 +39,7 @@ public class PaymentStatesGraphTest {
         thrown.expect(InvalidStateTransitionException.class);
         thrown.expectMessage("Transition WEBHOOK_ACTION_PAID_OUT from state NEW is not valid");
         thrown.reportMissingExceptionWithMessage("InvalidStateTransitionException expected");
-        paymentStatesGraph.getNextValidStateForEvent(NEW, WEBHOOK_ACTION_PAID_OUT);
+        paymentStatesGraph.getNextStateForEvent(NEW, WEBHOOK_ACTION_PAID_OUT);
     }
 
     @Test
@@ -52,3 +51,4 @@ public class PaymentStatesGraphTest {
         assertThat(paymentStatesGraph.isValidTransition(PaymentState.NEW, PaymentState.ENTER_DIRECT_DEBIT_DETAILS, SupportedEvent.SYSTEM_CANCEL), is(false));
     }
 }
+

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -2,10 +2,7 @@ package uk.gov.pay.directdebit.util;
 
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.util.StringColumnMapper;
-import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
-import uk.gov.pay.directdebit.payments.fixtures.TokenFixture;
 
-import java.sql.Timestamp;
 import java.util.Map;
 
 public class DatabaseTestHelper {
@@ -52,4 +49,12 @@ public class DatabaseTestHelper {
         );
     }
 
+    public Map<String, Object> getTransactionById(Long id) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT * from transactions t WHERE t.id = :id")
+                        .bind("id", id)
+                        .first()
+        );
+    }
 }


### PR DESCRIPTION
- There are a few differences from the proposed database design.
1. `status` is `state`, to be consistent with the rest (ie. `PaymentState`).
This was something that bit us in connector, as we started to have both status and state , and it became quickly very confusing.
1. operation` has been renamed to`type`. This is to be consistent with the rest, as we already have a payment event type, and it makes sense to have a transaction type, too.
1. `gateway_transaction_id` has been removed, as it is gocardless specific and should be part of another table