### PR TITLE
PP-2073 Database add foreign keys

### DIFF
--- a/src/main/resources/migrations/00001_create_table_payment_requests.sql
+++ b/src/main/resources/migrations/00001_create_table_payment_requests.sql
@@ -14,7 +14,6 @@ CREATE TABLE payment_requests (
 );
 --rollback drop table payment_requests;
 
---changeset uk.gov.pay:add_index-payment_requests_external_id
-CREATE UNIQUE INDEX payment_requests_external_id ON payment_requests(external_id)
---rollback drop index payment_requests_external_id;
-
+--changeset uk.gov.pay:add_payment_requests_external_id_idx
+CREATE UNIQUE INDEX payment_requests_external_id_idx ON payment_requests(external_id)
+--rollback drop index payment_requests_external_id_idx;

--- a/src/main/resources/migrations/00002_create_table_tokens.sql
+++ b/src/main/resources/migrations/00002_create_table_tokens.sql
@@ -8,3 +8,11 @@ CREATE TABLE tokens (
     version INTEGER DEFAULT 0 NOT NULL
 );
 --rollback drop table tokens;
+
+--changeset uk.gov.pay:add_tokens_payment_requests_fk
+ALTER TABLE tokens ADD CONSTRAINT tokens_payment_requests_fk FOREIGN KEY (payment_request_id) REFERENCES payment_requests (id);
+--rollback drop constraint tokens_payment_requests_fk;
+
+--changeset uk.gov.pay:add_index-tokens_secure_redirect_token
+CREATE INDEX tokens_secure_redirect_token_idx ON tokens(secure_redirect_token)
+--rollback drop index tokens_secure_redirect_token_idx;

--- a/src/main/resources/migrations/00003_create_table_payment_request_events.sql
+++ b/src/main/resources/migrations/00003_create_table_payment_request_events.sql
@@ -10,3 +10,7 @@ CREATE TABLE payment_request_events (
     version INTEGER DEFAULT 0 NOT NULL
 );
 --rollback drop table payment_request_events;
+
+--changeset uk.gov.pay:add_payment_requests_events_payment_requests_fk
+ALTER TABLE payment_request_events ADD CONSTRAINT payment_requests_events_payment_requests_fk FOREIGN KEY (payment_request_id) REFERENCES payment_requests (id);
+--rollback drop constraint payment_requests_events_payment_requests_fk;

--- a/src/main/resources/migrations/00004_create_table_transactions.sql
+++ b/src/main/resources/migrations/00004_create_table_transactions.sql
@@ -11,6 +11,6 @@ CREATE TABLE transactions (
 );
 --rollback drop table transactions;
 
---changeset uk.gov.pay:add_index-transactions_payment_request_id
-CREATE INDEX transactions_payment_request_id ON transactions(payment_request_id)
---rollback drop index transactions_payment_request_id;
+--changeset uk.gov.pay:add_transactions_payment_requests_fk
+ALTER TABLE transactions ADD CONSTRAINT transactions_payment_requests_fk FOREIGN KEY (payment_request_id) REFERENCES payment_requests (id);
+--rollback drop constraint transactions_payment_requests_fk;


### PR DESCRIPTION
## WHAT

- Add missing Foreign keys using naming convention suffix '_fk'.

- Renamed index to use suffix '_idx'

- Add Index to 'tokens.secure_redirect_token' since is the value used to query tokens + deletes.