### PR TITLE
PP-2973 Add endpoint to receive DD details data from frontend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,11 @@
             <artifactId>gocardless-pro</artifactId>
             <version>${gocardless.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.mindrot</groupId>
+            <artifactId>jbcrypt</artifactId>
+            <version>0.4</version>
+        </dependency>
         <!-- testing -->
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitConfig.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitConfig.java
@@ -20,10 +20,14 @@ public class DirectDebitConfig extends Configuration {
 
     @Valid
     @NotNull
-    private LinksConfig links = new LinksConfig();
+    private LinksConfig links;
 
     @NotNull
-    private ProxyConfiguration proxyConfiguration;
+    private ProxyConfig proxyConfig;
+
+    @Valid
+    @NotNull
+    private EncryptionConfig encryptionConfig;
 
     @JsonProperty("database")
     public DataSourceFactory getDataSourceFactory() {
@@ -41,8 +45,12 @@ public class DirectDebitConfig extends Configuration {
     }
 
     @JsonProperty("proxy")
-    public ProxyConfiguration getProxyConfiguration() {
-        return proxyConfiguration;
+    public ProxyConfig getProxyConfig() {
+        return proxyConfig;
     }
 
+    @JsonProperty("encryption")
+    public EncryptionConfig getEncryptionConfig() {
+        return encryptionConfig;
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/app/config/EncryptionConfig.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/EncryptionConfig.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.directdebit.app.config;
+
+import io.dropwizard.Configuration;
+
+public class EncryptionConfig extends Configuration {
+
+    private String encryptDBSalt;
+
+    public String getEncryptDBSalt() {
+        return encryptDBSalt;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/app/config/ProxyConfig.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/ProxyConfig.java
@@ -4,7 +4,7 @@ import io.dropwizard.Configuration;
 
 import javax.validation.constraints.NotNull;
 
-public class ProxyConfiguration extends Configuration {
+public class ProxyConfig extends Configuration {
 
     @NotNull
     private String host;

--- a/src/main/java/uk/gov/pay/directdebit/common/util/URIBuilder.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/util/URIBuilder.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.directdebit.common.util;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.Map;
+
+public class URIBuilder {
+
+
+    public static URI selfUriFor(UriInfo uriInfo, String path, String... ids) {
+        return uriInfo.getBaseUriBuilder()
+                .path(path)
+                .build(ids);
+    }
+
+    public static URI nextUrl(String baseUrl, String... paths) {
+        UriBuilder uriBuilder = UriBuilder.fromUri(baseUrl);
+        for (String path: paths) {
+            uriBuilder = uriBuilder.path(path);
+        }
+        return uriBuilder.build();
+    }
+
+    public static Map<String, Object> createLink(String rel, String method, URI href) {
+        return ImmutableMap.of(
+                "rel", rel,
+                "method", method,
+                "href", href
+        );
+    }
+
+    public static Map<String, Object> createLink(String rel, String method, URI href, String type, Map<String, Object> params) {
+        return ImmutableMap.of(
+                "rel", rel,
+                "method", method,
+                "href", href,
+                "type", type,
+                "params", params
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerResponse.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.directdebit.payers.api;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.directdebit.payers.model.Payer;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public class CreatePayerResponse {
+
+    @JsonProperty("payer_external_id")
+    private String payerExternalId;
+
+
+    public CreatePayerResponse(String payerExternalId) {
+        this.payerExternalId = payerExternalId;
+    }
+
+    public static CreatePayerResponse from(Payer payer) {
+        return new CreatePayerResponse(payer.getExternalId());
+    }
+
+    public String getPayerExternalId() {
+        return payerExternalId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CreatePayerResponse that = (CreatePayerResponse) o;
+
+        return payerExternalId != null ? payerExternalId.equals(that.payerExternalId) : that.payerExternalId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return payerExternalId != null ? payerExternalId.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "CreatePayerResponse{" +
+                "payerExternalId='" + payerExternalId + '\'' +
+                '}';
+    }
+}
+
+

--- a/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidator.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.directdebit.payers.api;
+
+import com.google.common.collect.ImmutableMap;
+import uk.gov.pay.directdebit.common.validation.ApiValidation;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class CreatePayerValidator extends ApiValidation {
+    private final static String ACCOUNT_NUMBER_KEY = "account_number";
+    private final static String SORTCODE_KEY = "sort_code";
+    private final static String NAME_KEY = "account_holder_name";
+    private final static String EMAIL_KEY = "email";
+    private final static String ADDRESS_LINE1_KEY = "address_line1";
+    private final static String ADDRESS_CITY_KEY = "city";
+    private final static String ADDRESS_COUNTRY_KEY = "country_code";
+    private final static String ADDRESS_POSTCODE_KEY = "postcode";
+
+    private static boolean isNumeric(String string) {
+        return string.matches("[0-9]+");
+    }
+    private final static Map<String, Function<String, Boolean>> validators = ImmutableMap.of(
+            ACCOUNT_NUMBER_KEY, CreatePayerValidator::isNumeric,
+            SORTCODE_KEY, CreatePayerValidator::isNumeric
+    );
+    private final static String[] requiredFields = {ACCOUNT_NUMBER_KEY, SORTCODE_KEY, NAME_KEY, EMAIL_KEY, ADDRESS_LINE1_KEY, ADDRESS_CITY_KEY, ADDRESS_COUNTRY_KEY, ADDRESS_POSTCODE_KEY};
+    private final static Map<String, Integer> maximumFieldsSize = ImmutableMap.of(
+            EMAIL_KEY, 254,
+            SORTCODE_KEY, 6,
+            ACCOUNT_NUMBER_KEY, 10
+    );
+    public CreatePayerValidator() {
+        super(requiredFields, maximumFieldsSize, validators);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payers/dao/PayerDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/dao/PayerDao.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.directdebit.payers.dao;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.BindBean;
+import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterArgumentFactory;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+import uk.gov.pay.directdebit.common.dao.DateArgumentFactory;
+import uk.gov.pay.directdebit.payers.dao.mapper.PayerMapper;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.dao.mapper.PaymentRequestMapper;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+
+import java.util.Optional;
+
+@RegisterMapper(PayerMapper.class)
+public interface PayerDao {
+    @SqlQuery("SELECT * FROM payers p WHERE p.id = :id")
+    @SingleValueResult(Payer.class)
+    Optional<Payer> findById(@Bind("id") Long id);
+
+    @SqlQuery("SELECT * FROM payers p WHERE p.external_id = :externalId")
+    @SingleValueResult(Payer.class)
+    Optional<Payer> findByExternalId(@Bind("externalId") String externalId);
+
+    @SqlQuery("SELECT * FROM payers p WHERE p.payment_request_id = :paymentRequestId")
+    @SingleValueResult(Payer.class)
+    Optional<Payer> findByPaymentRequestId(@Bind("paymentRequestId") Long paymentRequestId);
+
+    @SqlUpdate("INSERT INTO payers(payment_request_id, external_id, name, email, bank_account_number_last_two_digits, bank_account_requires_authorisation, bank_account_number, bank_account_sort_code, address_line1, address_line2, address_postcode, address_city, address_country, created_date ) VALUES (:paymentRequestId, :externalId, :name, :email, :accountNumberLastTwoDigits, :accountRequiresAuthorisation, :accountNumber, :sortCode, :addressLine1, :addressLine2, :addressPostcode, :addressCity, :addressCountry, :createdDate)")
+    @GetGeneratedKeys
+    @RegisterArgumentFactory(DateArgumentFactory.class)
+    Long insert(@BindBean Payer payer);
+}

--- a/src/main/java/uk/gov/pay/directdebit/payers/dao/mapper/PayerMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/dao/mapper/PayerMapper.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.directdebit.payers.dao.mapper;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class PayerMapper implements ResultSetMapper<Payer> {
+    private static final String ID_COLUMN = "id";
+    private static final String PAYMENT_REQUEST_ID_COLUMN = "payment_request_id";
+    private static final String EXTERNAL_ID_COLUMN = "external_id";
+    private static final String NAME_COLUMN = "name";
+    private static final String EMAIL_COLUMN = "email";
+    private static final String BANK_ACCOUNT_LAST_DIGITS_COLUMN = "bank_account_number_last_two_digits";
+    private static final String BANK_ACCOUNT_REQUIRES_AUTH_COLUMN = "bank_account_requires_authorisation";
+    private static final String BANK_ACCOUNT_NUMBER = "bank_account_number";
+    private static final String BANK_ACCOUNT_SORT_CODE = "bank_account_sort_code";
+    private static final String ADDRESS_LINE1 = "address_line1";
+    private static final String ADDRESS_LINE2 = "address_line2";
+    private static final String ADDRESS_POSTCODE = "address_postcode";
+    private static final String ADDRESS_CITY = "address_city";
+    private static final String ADDRESS_COUNTRY = "address_country";
+    private static final String CREATED_DATE_COLUMN = "created_date";
+
+    @Override
+    public Payer map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        return new Payer(
+                resultSet.getLong(ID_COLUMN),
+                resultSet.getLong(PAYMENT_REQUEST_ID_COLUMN),
+                resultSet.getString(EXTERNAL_ID_COLUMN),
+                resultSet.getString(NAME_COLUMN),
+                resultSet.getString(EMAIL_COLUMN),
+                resultSet.getString(BANK_ACCOUNT_SORT_CODE),
+                resultSet.getString(BANK_ACCOUNT_NUMBER),
+                resultSet.getString(BANK_ACCOUNT_LAST_DIGITS_COLUMN),
+                resultSet.getBoolean(BANK_ACCOUNT_REQUIRES_AUTH_COLUMN),
+                resultSet.getString(ADDRESS_LINE1),
+                resultSet.getString(ADDRESS_LINE2),
+                resultSet.getString(ADDRESS_POSTCODE),
+                resultSet.getString(ADDRESS_CITY),
+                resultSet.getString(ADDRESS_COUNTRY),
+                ZonedDateTime.ofInstant(resultSet.getTimestamp(CREATED_DATE_COLUMN).toInstant(), ZoneId.of("UTC")));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/Payer.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/Payer.java
@@ -1,0 +1,114 @@
+package uk.gov.pay.directdebit.payers.model;
+
+import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class Payer {
+    private Long id;
+    private Long paymentRequestId;
+    private String externalId;
+    private String name;
+    private String email;
+    private String sortCode;
+    private String accountNumberLastTwoDigits;
+    private boolean accountRequiresAuthorisation;
+    private String accountNumber;
+    private String addressLine1;
+    private String addressLine2;
+    private String addressPostcode;
+    private String addressCity;
+    private String addressCountry;
+    private ZonedDateTime createdDate;
+
+    public Payer(Long id, Long paymentRequestId, String externalId, String name, String email, String sortCode, String accountNumber, String accountNumberLastTwoDigits, boolean accountRequiresAuthorisation, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCountry, ZonedDateTime createdDate) {
+        this.id = id;
+        this.paymentRequestId = paymentRequestId;
+        this.externalId = externalId;
+        this.name = name;
+        this.email = email;
+        this.accountNumberLastTwoDigits = accountNumberLastTwoDigits;
+        this.accountRequiresAuthorisation = accountRequiresAuthorisation;
+        this.sortCode = sortCode;
+        this.accountNumber = accountNumber;
+        this.addressLine1 = addressLine1;
+        this.addressLine2 = addressLine2;
+        this.addressPostcode = addressPostcode;
+        this.addressCity = addressCity;
+        this.addressCountry = addressCountry;
+        this.createdDate = createdDate;
+    }
+
+    public Payer(Long paymentRequestId, String name, String email, String sortCode, String accountNumber, String accountNumberLastTwoDigits, boolean accountRequiresAuthorisation, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCountry) {
+        this(null, paymentRequestId, RandomIdGenerator.newId(), name, email, sortCode, accountNumber, accountNumberLastTwoDigits, accountRequiresAuthorisation, addressLine1, addressLine2, addressPostcode, addressCity, addressCountry, ZonedDateTime.now(ZoneId.of("UTC")));
+    }
+
+    public Payer(Long paymentRequestId, String name, String email, String sortCode, String accountNumber, String accountNumberLastTwoDigits, boolean accountRequiresAuthorisation,  String addressLine1, String addressPostcode, String addressCity, String addressCountry) {
+        this(null, paymentRequestId, RandomIdGenerator.newId(), name, email, sortCode, accountNumber, accountNumberLastTwoDigits, accountRequiresAuthorisation, addressLine1,  null, addressPostcode, addressCity, addressCountry, ZonedDateTime.now(ZoneId.of("UTC")));
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getPaymentRequestId() {
+        return paymentRequestId;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getSortCode() {
+        return sortCode;
+    }
+
+    public String getAccountNumberLastTwoDigits() {
+        return accountNumberLastTwoDigits;
+    }
+
+    public boolean getAccountRequiresAuthorisation() {
+        return accountRequiresAuthorisation;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public String getAddressPostcode() {
+        return addressPostcode;
+    }
+
+    public String getAddressCity() {
+        return addressCity;
+    }
+
+    public String getAddressCountry() {
+        return addressCountry;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.directdebit.payers.resources;
+
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.common.util.URIBuilder;
+import uk.gov.pay.directdebit.payers.api.CreatePayerResponse;
+import uk.gov.pay.directdebit.payers.api.CreatePayerValidator;
+import uk.gov.pay.directdebit.payers.services.PayerService;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.Map;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/")
+public class PayerResource {
+    public static final String PAYER_API_PATH = "/v1/api/payment_requests/{paymentRequestExternalId}/payers/{payerExternalId}";
+    public static final String PAYERS_API_PATH = "/v1/api/payment_requests/{paymentRequestExternalId}/payers";
+
+    private static final Logger logger = PayLoggerFactory.getLogger(PayerResource.class);
+    private final PayerService payerService;
+    private final CreatePayerValidator createPayerValidator = new CreatePayerValidator();
+
+    public PayerResource(PayerService payerService) {
+        this.payerService = payerService;
+    }
+
+    @POST
+    @Path(PAYERS_API_PATH)
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public Response createPayer(@PathParam("paymentRequestExternalId") String paymentRequestExternalId, Map<String, String> createPayerRequest, @Context UriInfo uriInfo) {
+        createPayerValidator.validate(createPayerRequest);
+        logger.info("Create new payer request received for payment request {} ", paymentRequestExternalId);
+        CreatePayerResponse createPayerResponse = CreatePayerResponse.from(payerService.create(paymentRequestExternalId, createPayerRequest));
+        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, paymentRequestExternalId, createPayerResponse.getPayerExternalId());
+        return Response.created(newPayerLocation).entity(createPayerResponse).build();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/payers/services/PayerParser.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/services/PayerParser.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.directdebit.payers.services;
+
+import org.mindrot.jbcrypt.BCrypt;
+import uk.gov.pay.directdebit.app.config.EncryptionConfig;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+
+import java.util.Map;
+
+public class PayerParser {
+    private final String encryptDBSalt;
+
+    public PayerParser(EncryptionConfig encryptionConfig) {
+        this.encryptDBSalt = encryptionConfig.getEncryptDBSalt();
+    }
+
+    private String encrypt(String toEncrypt) {
+        return BCrypt.hashpw(toEncrypt, encryptDBSalt);
+    }
+
+    public Payer parse(Map<String, String> createPayerMap, Transaction transaction) {
+        String accountNumber = createPayerMap.get("account_number");
+        String sortCode = createPayerMap.get("sort_code");
+        return new Payer(
+                transaction.getPaymentRequestId(),
+                createPayerMap.get("account_holder_name"),
+                createPayerMap.get("email"),
+                encrypt(sortCode),
+                encrypt(accountNumber),
+                accountNumber.substring(accountNumber.length()-2),
+                Boolean.parseBoolean(createPayerMap.get("requires_authorisation")),
+                createPayerMap.get("address_line1"),
+                createPayerMap.get("address_line2"),
+                createPayerMap.get("postcode"),
+                createPayerMap.get("city"),
+                createPayerMap.get("country_code")
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.directdebit.payers.services;
+
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.config.EncryptionConfig;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.payers.dao.PayerDao;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+import uk.gov.pay.directdebit.payments.services.PaymentRequestService;
+import uk.gov.pay.directdebit.payments.services.TransactionService;
+
+import java.util.Map;
+
+public class PayerService {
+    private static final Logger logger = PayLoggerFactory.getLogger(PaymentRequestService.class);
+
+    private final PayerDao payerDao;
+    private final TransactionService transactionService;
+
+    private final PayerParser payerParser;
+
+    public PayerService(EncryptionConfig encryptionConfig, PayerDao payerDao, TransactionService transactionService) {
+        this.payerDao = payerDao;
+        this.transactionService = transactionService;
+        this.payerParser = new PayerParser(encryptionConfig);
+    }
+
+    public Payer create(String paymentRequestExternalId, Map<String, String> createPayerMap) {
+        Transaction transaction = transactionService.receiveDirectDebitDetailsFor(paymentRequestExternalId);
+        Payer payer = payerParser.parse(createPayerMap, transaction);
+        Long id = payerDao.insert(payer);
+        payer.setId(id);
+        logger.info("Created Payer with external id {}", payer.getExternalId());
+        transactionService.payerCreatedFor(transaction);
+        return payer;
+    }
+
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
@@ -15,6 +15,10 @@ import java.util.Optional;
 
 @RegisterMapper(TransactionMapper.class)
 public interface TransactionDao {
+    @SqlQuery("SELECT * FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id WHERE p.external_id = :paymentRequestExternalId")
+    @SingleValueResult(Transaction.class)
+    Optional<Transaction> findByPaymentRequestExternalId(@Bind("paymentRequestExternalId") String paymentRequestExternalId);
+
     @SqlQuery("SELECT * FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id WHERE t.payment_request_id = :paymentRequestId")
     @SingleValueResult(Transaction.class)
     Optional<Transaction> findByPaymentRequestId(@Bind("paymentRequestId") Long paymentRequestId);

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -10,18 +10,18 @@ import java.sql.SQLException;
 
 public class TransactionMapper implements ResultSetMapper<Transaction> {
     private static final String ID_COLUMN = "id";
-    private static final String PAYMENT_REQUEST_ID_COLUMN = "payment_request_id";
     private static final String AMOUNT_COLUMN = "amount";
     private static final String TYPE_COLUMN = "type";
     private static final String STATE_COLUMN = "state";
-    private static final String PAYMENT_REQUEST_EXTERNAL_ID = "external_id";
+    private static final String PAYMENT_REQUEST_ID_COLUMN = "payment_request_id";
+    private static final String PAYMENT_REQUEST_EXTERNAL_ID_COLUMN = "external_id";
 
     @Override
     public Transaction map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException {
         return new Transaction(
                 resultSet.getLong(ID_COLUMN),
                 resultSet.getLong(PAYMENT_REQUEST_ID_COLUMN),
-                resultSet.getString(PAYMENT_REQUEST_EXTERNAL_ID),
+                resultSet.getString(PAYMENT_REQUEST_EXTERNAL_ID_COLUMN),
                 resultSet.getLong(AMOUNT_COLUMN),
                 Transaction.Type.valueOf(resultSet.getString(TYPE_COLUMN)),
                 PaymentState.valueOf(resultSet.getString(STATE_COLUMN)));

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
@@ -94,4 +94,34 @@ public class PaymentRequest {
     public void setId(Long id) {
         this.id = id;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PaymentRequest that = (PaymentRequest) o;
+
+        if (!id.equals(that.id)) return false;
+        if (!externalId.equals(that.externalId)) return false;
+        if (!amount.equals(that.amount)) return false;
+        if (!returnUrl.equals(that.returnUrl)) return false;
+        if (!gatewayAccountId.equals(that.gatewayAccountId)) return false;
+        if (!description.equals(that.description)) return false;
+        if (!reference.equals(that.reference)) return false;
+        return createdDate.equals(that.createdDate);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id.hashCode();
+        result = 31 * result + externalId.hashCode();
+        result = 31 * result + amount.hashCode();
+        result = 31 * result + returnUrl.hashCode();
+        result = 31 * result + gatewayAccountId.hashCode();
+        result = 31 * result + description.hashCode();
+        result = 31 * result + reference.hashCode();
+        result = 31 * result + createdDate.hashCode();
+        return result;
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -23,8 +23,8 @@ public class PaymentRequestEvent {
         this.eventDate = eventDate;
     }
 
-    public PaymentRequestEvent(Long paymentRequestId, Type eventType, SupportedEvent event, ZonedDateTime eventDate) {
-        this(null, paymentRequestId, eventType, event, eventDate);
+    private PaymentRequestEvent(Long paymentRequestId, Type eventType, SupportedEvent event) {
+        this(null, paymentRequestId, eventType, event, ZonedDateTime.now());
     }
 
     public Long getId() {
@@ -68,12 +68,15 @@ public class PaymentRequestEvent {
     }
 
     public enum Type {
-        CHARGE
+        PAYER, CHARGE
     }
 
     public enum SupportedEvent {
         CHARGE_CREATED,
-        TOKEN_EXCHANGED;
+        TOKEN_EXCHANGED,
+        DIRECT_DEBIT_DETAILS_RECEIVED,
+        PAYER_CREATED;
+
         public static SupportedEvent fromString(String event) throws UnsupportedPaymentRequestEventException {
             try {
                 return SupportedEvent.valueOf(event);
@@ -83,4 +86,21 @@ public class PaymentRequestEvent {
             }
         }
     }
+
+    public static PaymentRequestEvent chargeCreated(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, PaymentRequestEvent.Type.CHARGE, PaymentRequestEvent.SupportedEvent.CHARGE_CREATED);
+    }
+
+    public static PaymentRequestEvent tokenExchanged(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, PaymentRequestEvent.Type.CHARGE, SupportedEvent.TOKEN_EXCHANGED);
+    }
+    public static PaymentRequestEvent directDebitDetailsReceived(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, PaymentRequestEvent.Type.CHARGE, SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED);
+    }
+
+    public static PaymentRequestEvent payerCreated(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, PaymentRequestEvent.Type.PAYER, SupportedEvent.PAYER_CREATED);
+    }
+
+
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentState.java
@@ -6,7 +6,9 @@ import static uk.gov.pay.directdebit.payments.api.ExternalPaymentState.EXTERNAL_
 
 public enum PaymentState {
     NEW(EXTERNAL_STARTED),
-    AWAITING_DIRECT_DEBIT_DETAILS(EXTERNAL_STARTED);
+    AWAITING_DIRECT_DEBIT_DETAILS(EXTERNAL_STARTED),
+    PROCESSING_DIRECT_DEBIT_DETAILS(EXTERNAL_STARTED),
+    AWAITING_CONFIRMATION(EXTERNAL_STARTED);
 
     private ExternalPaymentState externalState;
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
@@ -6,9 +6,13 @@ import com.google.common.graph.ValueGraphBuilder;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
 
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_CONFIRMATION;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_DIRECT_DEBIT_DETAILS;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.NEW;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.PROCESSING_DIRECT_DEBIT_DETAILS;
 
 public class PaymentStatesGraph {
 
@@ -34,6 +38,8 @@ public class PaymentStatesGraph {
         addNodes(graph, PaymentState.values());
 
         graph.putEdgeValue(NEW, AWAITING_DIRECT_DEBIT_DETAILS, TOKEN_EXCHANGED);
+        graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, PROCESSING_DIRECT_DEBIT_DETAILS, DIRECT_DEBIT_DETAILS_RECEIVED);
+        graph.putEdgeValue(PROCESSING_DIRECT_DEBIT_DETAILS, AWAITING_CONFIRMATION, PAYER_CREATED);
 
         return ImmutableValueGraph.copyOf(graph);
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Token.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Token.java
@@ -21,6 +21,10 @@ public class Token {
         return new Token(UUID.randomUUID().toString(), paymentRequestId);
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -73,4 +73,32 @@ public class Transaction {
     public enum Type {
         CHARGE, REFUND
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Transaction that = (Transaction) o;
+
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+        if (paymentRequestExternalId != null ? !paymentRequestExternalId.equals(that.paymentRequestExternalId) : that.paymentRequestExternalId != null)
+            return false;
+        if (paymentRequestId != null ? !paymentRequestId.equals(that.paymentRequestId) : that.paymentRequestId != null)
+            return false;
+        if (amount != null ? !amount.equals(that.amount) : that.amount != null) return false;
+        if (type != that.type) return false;
+        return state == that.state;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (paymentRequestExternalId != null ? paymentRequestExternalId.hashCode() : 0);
+        result = 31 * result + (paymentRequestId != null ? paymentRequestId.hashCode() : 0);
+        result = 31 * result + (amount != null ? amount.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (state != null ? state.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
@@ -48,7 +48,7 @@ public class PaymentRequestResource {
     public Response createNewPaymentRequest(@PathParam(ACCOUNT_ID) Long accountId, Map<String, String> paymentRequest, @Context UriInfo uriInfo) {
         paymentRequestValidator.validate(paymentRequest);
         logger.info("Creating new payment request - {}", paymentRequest.toString());
-        PaymentRequestResponse response = paymentRequestService.create(paymentRequest, accountId, uriInfo);
+        PaymentRequestResponse response = paymentRequestService.createCharge(paymentRequest, accountId, uriInfo);
         return created(response.getLink("self")).entity(response).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.directdebit.payments.services;
+
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.payments.dao.PaymentRequestEventDao;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+
+public class PaymentRequestEventService {
+    private static final Logger logger = PayLoggerFactory.getLogger(PaymentRequestEventService.class);
+
+    private final PaymentRequestEventDao paymentRequestEventDao;
+
+    public PaymentRequestEventService(PaymentRequestEventDao paymentRequestEventDao) {
+        this.paymentRequestEventDao = paymentRequestEventDao;
+    }
+
+    private void insertEventFor(Transaction charge, PaymentRequestEvent event) {
+        logger.info("Creating event for {} {}: {} - {}",
+                charge.getType(), charge.getPaymentRequestExternalId(),
+                event.getEventType(), event.getEvent());
+        paymentRequestEventDao.insert(event);
+    }
+
+    void insertEventFor(PaymentRequest paymentRequest, PaymentRequestEvent event) {
+        logger.info("Creating event for payment request {}: {} - {}",
+                paymentRequest.getExternalId(), event.getEventType(), event.getEvent());
+        paymentRequestEventDao.insert(event);
+    }
+
+    public void registerDirectDebitReceivedEventFor(Transaction charge) {
+        PaymentRequestEvent event = PaymentRequestEvent.directDebitDetailsReceived(charge.getPaymentRequestId());
+        insertEventFor(charge, event);
+    }
+
+    public void registerPayerCreatedEventFor(Transaction charge) {
+        PaymentRequestEvent event = PaymentRequestEvent.payerCreated(charge.getPaymentRequestId());
+        insertEventFor(charge, event);
+    }
+
+    public void registerTokenExchangedEventFor(Transaction charge) {
+        PaymentRequestEvent event = PaymentRequestEvent.tokenExchanged(charge.getPaymentRequestId());
+        insertEventFor(charge, event);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
@@ -5,83 +5,63 @@ import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
 import uk.gov.pay.directdebit.app.config.LinksConfig;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.common.util.URIBuilder;
 import uk.gov.pay.directdebit.payments.api.PaymentRequestResponse;
 import uk.gov.pay.directdebit.payments.dao.PaymentRequestDao;
-import uk.gov.pay.directdebit.payments.dao.PaymentRequestEventDao;
-import uk.gov.pay.directdebit.payments.dao.TransactionDao;
-import uk.gov.pay.directdebit.payments.exception.ChargeNotFoundException;
 import uk.gov.pay.directdebit.payments.exception.PaymentRequestNotFoundException;
 import uk.gov.pay.directdebit.payments.model.PaymentRequest;
-import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
-import uk.gov.pay.directdebit.payments.model.PaymentStatesGraph;
 import uk.gov.pay.directdebit.payments.model.Token;
 import uk.gov.pay.directdebit.payments.model.Transaction;
-import uk.gov.pay.directdebit.tokens.dao.TokenDao;
+import uk.gov.pay.directdebit.tokens.services.TokenService;
 
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static uk.gov.pay.directdebit.common.util.URIBuilder.*;
+import static uk.gov.pay.directdebit.common.util.URIBuilder.nextUrl;
+import static uk.gov.pay.directdebit.payments.resources.PaymentRequestResource.CHARGES_API_PATH;
 import static uk.gov.pay.directdebit.payments.resources.PaymentRequestResource.CHARGE_API_PATH;
 
 public class PaymentRequestService {
     private static final Logger logger = PayLoggerFactory.getLogger(PaymentRequestService.class);
 
     private final LinksConfig linksConfig;
-    private final TokenDao tokenDao;
     private final PaymentRequestDao paymentRequestDao;
-    private final PaymentRequestEventDao paymentRequestEventDao;
-    private final TransactionDao transactionDao;
+    private final TokenService tokenService;
+    private final TransactionService transactionService;
 
-    public PaymentRequestService(DirectDebitConfig config, PaymentRequestDao paymentRequestDao, TokenDao tokenDao, PaymentRequestEventDao paymentRequestEventDao, TransactionDao transactionDao) {
+    public PaymentRequestService(DirectDebitConfig config, PaymentRequestDao paymentRequestDao, TokenService tokenService, TransactionService transactionService) {
         this.paymentRequestDao = paymentRequestDao;
-        this.paymentRequestEventDao = paymentRequestEventDao;
-        this.tokenDao = tokenDao;
-        this.transactionDao = transactionDao;
+        this.tokenService = tokenService;
+        this.transactionService = transactionService;
         this.linksConfig = config.getLinks();
     }
-    private Map<String, Object> createLink(String rel, String method, URI href) {
-        return ImmutableMap.of(
-                "rel", rel,
-                "method", method,
-                "href", href
-        );
-    }
 
-    private Map<String, Object> createLink(String rel, String method, URI href, String type, Map<String, Object> params) {
-        return ImmutableMap.of(
-                "rel", rel,
-                "method", method,
-                "href", href,
-                "type", type,
-                "params", params
-        );
-    }
-
-    public PaymentRequestResponse populateResponseWith(PaymentRequest paymentRequest, Transaction charge, UriInfo uriInfo) {
+    private PaymentRequestResponse populateResponseWith(PaymentRequest paymentRequest, Transaction charge, UriInfo uriInfo) {
         String paymentRequestExternalId = paymentRequest.getExternalId();
         List<Map<String, Object>> dataLinks = new ArrayList<>();
-        dataLinks.add(createLink("self", GET, selfUriFor(uriInfo, paymentRequest.getGatewayAccountId(), paymentRequestExternalId)));
-        if (!charge.getState().toExternal().isFinished()) {
-            Token token = Token.generateNewTokenFor(paymentRequest.getId());
-            tokenDao.insert(token);
 
-            dataLinks.add(createLink("next_url", GET, nextUrl(token.getToken())));
-            dataLinks.add(createLink("next_url_post", POST, nextUrl(), APPLICATION_FORM_URLENCODED, new HashMap<String, Object>() {{
-                        put("chargeTokenId", token.getToken());
-                    }})
-            );
+        dataLinks.add(createLink("self", GET, selfUriFor(uriInfo, CHARGE_API_PATH, String.valueOf(paymentRequest.getGatewayAccountId()), paymentRequestExternalId)));
+
+        if (!charge.getState().toExternal().isFinished()) {
+            Token token = tokenService.generateNewTokenFor(paymentRequest);
+            dataLinks.add(createLink("next_url",
+                    GET,
+                    nextUrl(linksConfig.getFrontendUrl(), "secure", token.getToken())));
+            dataLinks.add(createLink("next_url_post",
+                    POST,
+                    nextUrl(linksConfig.getFrontendUrl(), "secure"),
+                    APPLICATION_FORM_URLENCODED,
+                    ImmutableMap.of("chargeTokenId", token.getToken())));
         }
-        return new PaymentRequestResponse(
-                paymentRequestExternalId,
+        return new PaymentRequestResponse(paymentRequestExternalId,
                 paymentRequest.getAmount(),
                 paymentRequest.getReturnUrl(),
                 paymentRequest.getDescription(),
@@ -90,70 +70,30 @@ public class PaymentRequestService {
                 dataLinks);
     }
 
-    public PaymentRequestResponse create(Map<String, String> paymentRequestMap, Long accountId, UriInfo uriInfo) {
+    public PaymentRequestResponse createCharge(Map<String, String> paymentRequestMap, Long accountId, UriInfo uriInfo) {
         //todo when we check the account id, return  notFoundResponse("Unknown gateway account: " + accountId)) if not found
-        PaymentRequest paymentRequest = new PaymentRequest(
-                new Long(paymentRequestMap.get("amount")),
+        PaymentRequest paymentRequest = new PaymentRequest(new Long(paymentRequestMap.get("amount")),
                 paymentRequestMap.get("return_url"),
                 accountId,
                 paymentRequestMap.get("description"),
                 paymentRequestMap.get("reference"));
+        logger.info("Creating payment request with external id {}", paymentRequest.getExternalId());
         Long id = paymentRequestDao.insert(paymentRequest);
         paymentRequest.setId(id);
-        insertCreatedEventFor(paymentRequest);
-        Transaction createdTransaction = insertCreatedTransactionFor(paymentRequest);
+        Transaction createdTransaction = transactionService.createChargeFor(paymentRequest);
         return populateResponseWith(paymentRequest, createdTransaction, uriInfo);
     }
-    private URI selfUriFor(UriInfo uriInfo, Long accountId, String chargeId) {
-        return uriInfo.getBaseUriBuilder()
-                .path(CHARGE_API_PATH)
-                .build(accountId, chargeId);
-    }
 
-    private URI nextUrl(String tokenId) {
-        return UriBuilder.fromUri(linksConfig.getFrontendUrl())
-                .path("secure")
-                .path(tokenId)
-                .build();
-    }
 
-    private URI nextUrl() {
-        return UriBuilder.fromUri(linksConfig.getFrontendUrl())
-                .path("secure")
-                .build();
-    }
-
+    //todo refactor this to get the transaction immediately and put the gateway account id there
     public PaymentRequestResponse getPaymentWithExternalId(String paymentExternalId, UriInfo uriInfo) {
         return paymentRequestDao
                 .findByExternalId(paymentExternalId)
                 .map(paymentRequest ->  {
-                    Transaction transaction = transactionDao.findByPaymentRequestId(paymentRequest.getId())
-                            .orElseThrow(() -> new ChargeNotFoundException(paymentExternalId));
-                    logger.info("Found charge for payment request with id: {}", paymentRequest.getExternalId());
+                    Transaction transaction = transactionService.findChargeForExternalId(paymentExternalId);
                     return populateResponseWith(paymentRequest, transaction, uriInfo);
                 })
                 .orElseThrow(() -> new PaymentRequestNotFoundException(paymentExternalId));
     }
 
-
-    private void insertCreatedEventFor(PaymentRequest paymentRequest) {
-        PaymentRequestEvent paymentRequestEvent = new PaymentRequestEvent(
-                paymentRequest.getId(),
-                PaymentRequestEvent.Type.CHARGE,
-                PaymentRequestEvent.SupportedEvent.CHARGE_CREATED,
-                ZonedDateTime.now());
-        logger.info("Created event for payment request {}", paymentRequest.getExternalId());
-        paymentRequestEventDao.insert(paymentRequestEvent);
-    }
-    private Transaction insertCreatedTransactionFor(PaymentRequest paymentRequest) {
-        Transaction transaction = new Transaction(
-                paymentRequest.getId(),
-                paymentRequest.getExternalId(),
-                paymentRequest.getAmount(),
-                Transaction.Type.CHARGE,
-                PaymentStatesGraph.initialState());
-        logger.info("Created transaction for payment request {}", paymentRequest.getExternalId());
-        transactionDao.insert(transaction);
-        return transaction;
-    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -1,0 +1,81 @@
+package uk.gov.pay.directdebit.payments.services;
+
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.payments.dao.TransactionDao;
+import uk.gov.pay.directdebit.payments.exception.ChargeNotFoundException;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.PaymentStatesGraph;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+
+import java.util.Optional;
+
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.chargeCreated;
+import static uk.gov.pay.directdebit.payments.model.PaymentStatesGraph.getStates;
+
+public class TransactionService {
+    private static final Logger logger = PayLoggerFactory.getLogger(TransactionService.class);
+
+    private final TransactionDao transactionDao;
+    private final PaymentRequestEventService paymentRequestEventService;
+    public TransactionService(TransactionDao transactionDao, PaymentRequestEventService paymentRequestEventService) {
+        this.paymentRequestEventService = paymentRequestEventService;
+        this.transactionDao = transactionDao;
+    }
+
+    public Transaction findChargeForExternalId(String paymentRequestExternalId) {
+        Transaction transaction = transactionDao.findByPaymentRequestExternalId(paymentRequestExternalId)
+                .orElseThrow(() -> new ChargeNotFoundException(paymentRequestExternalId));
+        logger.info("Found charge for payment request with id: {}", paymentRequestExternalId);
+        return transaction;
+    }
+
+    Transaction createChargeFor(PaymentRequest paymentRequest){
+        Transaction transaction = new Transaction(
+                paymentRequest.getId(),
+                paymentRequest.getExternalId(),
+                paymentRequest.getAmount(),
+                Transaction.Type.CHARGE,
+                PaymentStatesGraph.initialState());
+        logger.info("Created transaction for payment request {}", paymentRequest.getExternalId());
+        Long id = transactionDao.insert(transaction);
+        transaction.setId(id);
+        paymentRequestEventService.insertEventFor(paymentRequest, chargeCreated(paymentRequest.getId()));
+        return transaction;
+    }
+
+    private Transaction updateStateFor(Transaction charge, PaymentRequestEvent.SupportedEvent event){
+        PaymentState newState = getStates().getNextStateForEvent(charge.getState(),
+                event);
+        transactionDao.updateState(charge.getId(), newState);
+        charge.setState(newState);
+        logger.info("Updated charge {} - from {} to {}",
+                charge.getPaymentRequestExternalId(),
+                charge.getState(),
+                newState);
+        return charge;
+    }
+
+    public Optional<Transaction> findChargeForToken(String token) {
+        return transactionDao
+                .findByTokenId(token).map(c -> {
+                    Transaction newCharge = updateStateFor(c, PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED);
+                    paymentRequestEventService.registerTokenExchangedEventFor(newCharge);
+                    return newCharge;
+                });
+    }
+
+    public Transaction receiveDirectDebitDetailsFor(String paymentRequestExternalId) {
+        Transaction transaction = findChargeForExternalId(paymentRequestExternalId);
+        paymentRequestEventService.registerDirectDebitReceivedEventFor(transaction);
+        return updateStateFor(transaction, PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED);
+    }
+
+    public Transaction payerCreatedFor(Transaction transaction) {
+        Transaction newTransaction = updateStateFor(transaction, PaymentRequestEvent.SupportedEvent.PAYER_CREATED);
+        paymentRequestEventService.registerPayerCreatedEventFor(transaction);
+        return newTransaction;
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/tokens/services/TokenService.java
+++ b/src/main/java/uk/gov/pay/directdebit/tokens/services/TokenService.java
@@ -2,68 +2,43 @@ package uk.gov.pay.directdebit.tokens.services;
 
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
-import uk.gov.pay.directdebit.payments.dao.PaymentRequestEventDao;
-import uk.gov.pay.directdebit.payments.dao.TransactionDao;
-import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
-import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+import uk.gov.pay.directdebit.payments.model.Token;
 import uk.gov.pay.directdebit.payments.model.Transaction;
+import uk.gov.pay.directdebit.payments.services.TransactionService;
 import uk.gov.pay.directdebit.tokens.dao.TokenDao;
 import uk.gov.pay.directdebit.tokens.exception.TokenNotFoundException;
 
-import java.time.ZonedDateTime;
-
-import static uk.gov.pay.directdebit.payments.model.PaymentStatesGraph.getStates;
-
 public class TokenService {
-    private static final Logger LOGGER = PayLoggerFactory.getLogger(TokenService.class);
+    private static final Logger logger = PayLoggerFactory.getLogger(TokenService.class);
 
     private final TokenDao tokenDao;
-    private final TransactionDao transactionDao;
-    private final PaymentRequestEventDao paymentRequestEventDao;
+    private final TransactionService transactionService;
 
-    public TokenService(TokenDao tokenDao, PaymentRequestEventDao paymentRequestEventDao, TransactionDao transactionDao) {
+    public TokenService(TokenDao tokenDao, TransactionService transactionService) {
         this.tokenDao = tokenDao;
-        this.paymentRequestEventDao = paymentRequestEventDao;
-        this.transactionDao = transactionDao;
+        this.transactionService = transactionService;
+    }
+
+    public Token generateNewTokenFor(PaymentRequest paymentRequest) {
+        Token token = Token.generateNewTokenFor(paymentRequest.getId());
+        logger.info("Generating new one-time token for payment request {}", paymentRequest.getExternalId());
+        Long id = tokenDao.insert(token);
+        token.setId(id);
+        return token;
     }
 
     public Transaction validateChargeWithToken(String token) {
-        return transactionDao
-                .findByTokenId(token)
-                .map(charge -> {
-                    LOGGER.info("Found one-time token for charge {}", charge.getPaymentRequestExternalId());
-                    updateChargeState(charge);
-                    insertTokenExchangedEventFor(charge);
-                    return charge;
-                })
+        return transactionService
+                .findChargeForToken(token)
                 .orElseThrow(TokenNotFoundException::new);
     }
 
     public void deleteToken(String token){
         int numOfDeletedTokens = tokenDao.deleteToken(token);
         if (numOfDeletedTokens == 0) {
-            LOGGER.warn("Tried to delete token which was not in db");
+            logger.warn("Tried to delete token which was not in db");
         }
     }
 
-    private void insertTokenExchangedEventFor(Transaction charge) {
-        PaymentRequestEvent paymentRequestEvent = new PaymentRequestEvent(
-                charge.getPaymentRequestId(),
-                PaymentRequestEvent.Type.CHARGE,
-                PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED,
-                ZonedDateTime.now());
-        LOGGER.info("Token Exchanged event for payment request {}", charge.getPaymentRequestId());
-        paymentRequestEventDao.insert(paymentRequestEvent);
-    }
-
-    private void updateChargeState(Transaction charge) {
-        PaymentState newState = getStates().getNextStateForEvent(charge.getState(),
-                PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED);
-        transactionDao.updateState(charge.getId(), newState);
-        charge.setState(newState);
-        LOGGER.info("Updated charge {} - from {} to {}",
-                charge.getPaymentRequestId(),
-                charge.getState(),
-                newState);
-    }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -22,6 +22,9 @@ proxy:
 links:
   frontendUrl: ${FRONTEND_URL:-}
 
+encryption:
+  encryptDBSalt: ${TOKEN_DB_BCRYPT_SALT}
+
 goCardless:
   # For initial integration we will use sandbox access token.
   # When in live mode: access token should be removed from the config and we should use partner integration instead.

--- a/src/main/resources/migrations/00005_create_table_payers.sql
+++ b/src/main/resources/migrations/00005_create_table_payers.sql
@@ -1,0 +1,30 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-payers
+CREATE TABLE payers (
+    id BIGSERIAL PRIMARY KEY,
+    payment_request_id BIGSERIAL NOT NULL,
+    external_id VARCHAR(26),
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(254) NOT NULL,
+    bank_account_number_last_two_digits VARCHAR(2) NOT NULL,
+    bank_account_requires_authorisation BOOLEAN DEFAULT FALSE,
+    bank_account_number TEXT NOT NULL,
+    bank_account_sort_code TEXT NOT NULL,
+    address_line1 VARCHAR(255) NOT NULL,
+    address_line2 VARCHAR(255),
+    address_postcode VARCHAR(25) NOT NULL,
+    address_city VARCHAR(255) NOT NULL,
+    address_country VARCHAR(255) NOT NULL,
+    created_date TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'utc') NOT NULL,
+    version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table payers;
+
+--changeset uk.gov.pay:add_payers_payment_requests_fk
+ALTER TABLE payers ADD CONSTRAINT payers_payment_requests_fk FOREIGN KEY (payment_request_id) REFERENCES payment_requests (id);
+--rollback drop constraint payers_payment_requests_fk;
+
+--changeset uk.gov.pay:add_index-payers_payment_external_id
+CREATE INDEX payers_external_id_idx ON payers(external_id)
+--rollback drop index payers_payment_external_id_idx;

--- a/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
@@ -1,0 +1,127 @@
+package uk.gov.pay.directdebit.payers.dao;
+
+import liquibase.exception.LiquibaseException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.junit.DropwizardConfig;
+import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
+import uk.gov.pay.directdebit.junit.DropwizardTestContext;
+import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.aPaymentRequestFixture;
+import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.isDate;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
+public class PayerDaoIT {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    private PayerDao payerDao;
+
+    private PaymentRequestFixture testPaymentRequest;
+    private PayerFixture testPayer;
+
+    @Before
+    public void setup() throws IOException, LiquibaseException {
+        payerDao = testContext.getJdbi().onDemand(PayerDao.class);
+        this.testPaymentRequest = aPaymentRequestFixture()
+                .insert(testContext.getJdbi());
+        this.testPayer = PayerFixture.aPayerFixture()
+                .withPaymentRequestId(testPaymentRequest.getId())
+                .insert(testContext.getJdbi());
+    }
+
+    @Test
+    public void shouldInsertAPayer() {
+        Payer aPayer = PayerFixture.aPayerFixture().withPaymentRequestId(testPaymentRequest.getId()).toEntity();
+        Long id = payerDao.insert(aPayer);
+        Map<String, Object> foundPayer = testContext.getDatabaseTestHelper().getPayerById(id);
+        assertThat(foundPayer.get("id"), is(id));
+        assertThat(foundPayer.get("payment_request_id"), is(aPayer.getPaymentRequestId()));
+        assertThat(foundPayer.get("external_id"), is(aPayer.getExternalId()));
+        assertThat(foundPayer.get("name"), is(aPayer.getName()));
+        assertThat(foundPayer.get("email"), is(aPayer.getEmail()));
+        assertThat(foundPayer.get("bank_account_number_last_two_digits"), is(aPayer.getAccountNumberLastTwoDigits()));
+        assertThat(foundPayer.get("bank_account_requires_authorisation"), is(aPayer.getAccountRequiresAuthorisation()));
+        assertThat(foundPayer.get("bank_account_number"), is(aPayer.getAccountNumber()));
+        assertThat(foundPayer.get("bank_account_sort_code"), is(aPayer.getSortCode()));
+        assertThat(foundPayer.get("address_line1"), is(aPayer.getAddressLine1()));
+        assertThat(foundPayer.get("address_line2"), is(aPayer.getAddressLine2()));
+        assertThat(foundPayer.get("address_postcode"), is(aPayer.getAddressPostcode()));
+        assertThat(foundPayer.get("address_city"), is(aPayer.getAddressCity()));
+        assertThat(foundPayer.get("address_country"), is(aPayer.getAddressCountry()));
+        assertThat((Timestamp) foundPayer.get("created_date"), isDate(aPayer.getCreatedDate()));
+
+    }
+    @Test
+    public void shouldGetAPayerById() {
+        Payer payer = payerDao.findById(testPayer.getId()).get();
+        assertThat(payer.getId(), is(testPayer.getId()));
+        assertThat(payer.getPaymentRequestId(), is(testPayer.getPaymentRequestId()));
+        assertThat(payer.getExternalId(), is(testPayer.getExternalId()));
+        assertThat(payer.getName(), is(testPayer.getName()));
+        assertThat(payer.getEmail(), is(testPayer.getEmail()));
+        assertThat(payer.getAccountRequiresAuthorisation(), is(testPayer.getAccountRequiresAuthorisation()));
+        assertThat(payer.getAccountNumber(), is(testPayer.getAccountNumber()));
+        assertThat(payer.getSortCode(), is(testPayer.getSortCode()));
+        assertThat(payer.getAddressLine1(), is(testPayer.getAddressLine1()));
+        assertThat(payer.getAddressLine2(), is(testPayer.getAddressLine2()));
+        assertThat(payer.getAddressPostcode(), is(testPayer.getAddressPostcode()));
+        assertThat(payer.getAddressCity(), is(testPayer.getAddressCity()));
+        assertThat(payer.getAddressCountry(), is(testPayer.getAddressCountry()));
+        assertThat(payer.getCreatedDate(), is(testPayer.getCreatedDate()));
+    }
+    @Test
+    public void shouldGetAPayerByExternalId() {
+        Payer payer = payerDao.findByExternalId(testPayer.getExternalId()).get();
+        assertThat(payer.getId(), is(testPayer.getId()));
+        assertThat(payer.getPaymentRequestId(), is(testPayer.getPaymentRequestId()));
+        assertThat(payer.getExternalId(), is(testPayer.getExternalId()));
+        assertThat(payer.getName(), is(testPayer.getName()));
+        assertThat(payer.getEmail(), is(testPayer.getEmail()));
+        assertThat(payer.getAccountRequiresAuthorisation(), is(testPayer.getAccountRequiresAuthorisation()));
+        assertThat(payer.getAccountNumber(), is(testPayer.getAccountNumber()));
+        assertThat(payer.getSortCode(), is(testPayer.getSortCode()));
+        assertThat(payer.getAddressLine1(), is(testPayer.getAddressLine1()));
+        assertThat(payer.getAddressLine2(), is(testPayer.getAddressLine2()));
+        assertThat(payer.getAddressPostcode(), is(testPayer.getAddressPostcode()));
+        assertThat(payer.getAddressCity(), is(testPayer.getAddressCity()));
+        assertThat(payer.getAddressCountry(), is(testPayer.getAddressCountry()));
+        assertThat(payer.getCreatedDate(), is(testPayer.getCreatedDate()));
+    }
+    @Test
+    public void shouldGetAPayerByPaymentRequestId() {
+        Payer payer = payerDao.findByPaymentRequestId(testPaymentRequest.getId()).get();
+        assertThat(payer.getId(), is(testPayer.getId()));
+        assertThat(payer.getPaymentRequestId(), is(testPayer.getPaymentRequestId()));
+        assertThat(payer.getExternalId(), is(testPayer.getExternalId()));
+        assertThat(payer.getName(), is(testPayer.getName()));
+        assertThat(payer.getEmail(), is(testPayer.getEmail()));
+        assertThat(payer.getAccountRequiresAuthorisation(), is(testPayer.getAccountRequiresAuthorisation()));
+        assertThat(payer.getAccountNumber(), is(testPayer.getAccountNumber()));
+        assertThat(payer.getSortCode(), is(testPayer.getSortCode()));
+        assertThat(payer.getAddressLine1(), is(testPayer.getAddressLine1()));
+        assertThat(payer.getAddressLine2(), is(testPayer.getAddressLine2()));
+        assertThat(payer.getAddressPostcode(), is(testPayer.getAddressPostcode()));
+        assertThat(payer.getAddressCity(), is(testPayer.getAddressCity()));
+        assertThat(payer.getAddressCountry(), is(testPayer.getAddressCountry()));
+        assertThat(payer.getCreatedDate(), is(testPayer.getCreatedDate()));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payers/fixtures/PayerFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/fixtures/PayerFixture.java
@@ -1,0 +1,227 @@
+package uk.gov.pay.directdebit.payers.fixtures;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.pay.directdebit.common.fixtures.DbFixture;
+import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class PayerFixture implements DbFixture<PayerFixture, Payer> {
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private Long paymentRequestId = RandomUtils.nextLong(1, 99999);
+    private String externalId = RandomIdGenerator.newId();
+    private String name = RandomStringUtils.randomAlphabetic(7);
+    private String email = generateEmail();
+    private String sortCode = RandomStringUtils.randomNumeric(6);
+    private String accountNumber = RandomStringUtils.randomNumeric(8);
+    private String accountNumberLastTwoDigits = accountNumber.substring(accountNumber.length()-2);
+    private boolean accountRequiresAuthorisation = true;
+    private String addressLine1 = RandomStringUtils.randomAlphanumeric(10);
+    private String addressLine2 = RandomStringUtils.randomAlphanumeric(10);
+    private String addressPostcode = RandomStringUtils.randomAlphanumeric(6);
+    private String addressCity = RandomStringUtils.randomAlphabetic(10);
+    private String addressCountry = RandomStringUtils.randomAlphabetic(10);;
+    private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+
+    private PayerFixture() { }
+
+    public static PayerFixture aPayerFixture() {
+        return new PayerFixture();
+    }
+
+    public PayerFixture withId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public PayerFixture withPaymentRequestId(Long paymentRequestId) {
+        this.paymentRequestId = paymentRequestId;
+        return this;
+    }
+
+    public PayerFixture withExternalId(String externalId) {
+        this.externalId = externalId;
+        return this;
+    }
+
+    public PayerFixture withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public PayerFixture withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public PayerFixture withSortCode(String sortCode) {
+        this.sortCode = sortCode;
+        return this;
+    }
+
+    public PayerFixture withAccountNumberLastTwoDigits(String accountNumberLastTwoDigits) {
+        this.accountNumberLastTwoDigits = accountNumberLastTwoDigits;
+        return this;
+    }
+
+    public PayerFixture withAccountRequiresAuthorisation(boolean accountRequiresAuthorisation) {
+        this.accountRequiresAuthorisation = accountRequiresAuthorisation;
+        return this;
+    }
+
+    public PayerFixture withAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+        return this;
+    }
+
+    public PayerFixture withAddressLine1(String addressLine1) {
+        this.addressLine1 = addressLine1;
+        return this;
+    }
+
+    public PayerFixture withAddressLine2(String addressLine2) {
+        this.addressLine2 = addressLine2;
+        return this;
+    }
+
+    public PayerFixture withAddressPostcode(String addressPostcode) {
+        this.addressPostcode = addressPostcode;
+        return this;
+    }
+
+    public PayerFixture withAddressCity(String addressCity) {
+        this.addressCity = addressCity;
+        return this;
+    }
+
+    public PayerFixture withAddressCountry(String addressCountry) {
+        this.addressCountry = addressCountry;
+        return this;
+    }
+
+    public PayerFixture withCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getPaymentRequestId() {
+        return paymentRequestId;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getSortCode() {
+        return sortCode;
+    }
+
+    public String getAccountNumberLastTwoDigits() {
+        return accountNumberLastTwoDigits;
+    }
+
+    public boolean getAccountRequiresAuthorisation() {
+        return accountRequiresAuthorisation;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public String getAddressPostcode() {
+        return addressPostcode;
+    }
+
+    public String getAddressCity() {
+        return addressCity;
+    }
+
+    public String getAddressCountry() {
+        return addressCountry;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    @Override
+    public PayerFixture insert(DBI jdbi) {
+        jdbi.withHandle(h ->
+                h.update(
+                        "INSERT INTO" +
+                                "    payers(\n" +
+                                "        id,\n" +
+                                "        payment_request_id,\n" +
+                                "        external_id,\n" +
+                                "        name,\n" +
+                                "        email,\n" +
+                                "        bank_account_number_last_two_digits,\n" +
+                                "        bank_account_requires_authorisation,\n" +
+                                "        bank_account_number,\n" +
+                                "        bank_account_sort_code,\n" +
+                                "        address_line1,\n" +
+                                "        address_line2,\n" +
+                                "        address_postcode,\n" +
+                                "        address_city,\n" +
+                                "        address_country,\n" +
+                                "        created_date\n" +
+                                "    )\n" +
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
+                        id,
+                        paymentRequestId,
+                        externalId,
+                        name,
+                        email,
+                        accountNumberLastTwoDigits,
+                        accountRequiresAuthorisation,
+                        accountNumber,
+                        sortCode,
+                        addressLine1,
+                        addressLine2,
+                        addressPostcode,
+                        addressCity,
+                        addressCountry,
+                        Timestamp.from(createdDate.toInstant())
+                )
+        );
+        return this;
+    }
+
+    @Override
+    public Payer toEntity() {
+        return new Payer(id, paymentRequestId, externalId, name, email, sortCode, accountNumber, accountNumberLastTwoDigits, accountRequiresAuthorisation, addressLine1, addressLine2, addressPostcode, addressCity, addressCountry, createdDate);
+    }
+
+    private String generateEmail() {
+        return RandomStringUtils.randomAlphanumeric(20) + "@" + RandomStringUtils.randomAlphanumeric(10) + ".com";
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
@@ -1,0 +1,166 @@
+package uk.gov.pay.directdebit.payers.resources;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.junit.DropwizardConfig;
+import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
+import uk.gov.pay.directdebit.junit.DropwizardTestContext;
+import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.aPaymentRequestFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
+public class PayerResourceIT {
+    private final static String ACCOUNT_NUMBER_KEY = "account_number";
+    private final static String SORTCODE_KEY = "sort_code";
+    private final static String NAME_KEY = "account_holder_name";
+    private final static String EMAIL_KEY = "email";
+    private final static String ADDRESS_LINE1_KEY = "address_line1";
+    private final static String ADDRESS_LINE2_KEY = "address_line2";
+    private final static String ADDRESS_CITY_KEY = "city";
+    private final static String ADDRESS_COUNTRY_KEY = "country_code";
+    private final static String ADDRESS_POSTCODE_KEY = "postcode";
+
+    private Gson gson = new Gson();
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    private PaymentRequestFixture testPaymentRequest;
+    private PayerFixture payerFixture;
+
+    String requestPath;
+    @Before
+    public void setUp() {
+        testPaymentRequest = aPaymentRequestFixture().insert(testContext.getJdbi());
+        aTransactionFixture()
+                .withState(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS)
+                .withPaymentRequestId(testPaymentRequest.getId())
+                .withExternalId(testPaymentRequest.getExternalId()).insert(testContext.getJdbi());
+        payerFixture = aPayerFixture().withAccountNumber("12345678");
+        requestPath = "/v1/api/payment_requests/{paymentRequestExternalId}/payers"
+                .replace("{paymentRequestExternalId}", testPaymentRequest.getExternalId());
+
+    }
+    @Test
+    public void shouldCreateAPayer() throws Exception {
+        String postBody = gson.toJson(ImmutableMap.builder()
+                .put(ACCOUNT_NUMBER_KEY, payerFixture.getAccountNumber())
+                .put(SORTCODE_KEY, payerFixture.getSortCode())
+                .put(NAME_KEY, payerFixture.getName())
+                .put(EMAIL_KEY, payerFixture.getEmail())
+                .put(ADDRESS_LINE1_KEY, payerFixture.getAddressLine1())
+                .put(ADDRESS_CITY_KEY, payerFixture.getAddressCity())
+                .put(ADDRESS_COUNTRY_KEY, payerFixture.getAddressCountry())
+                .put(ADDRESS_POSTCODE_KEY, payerFixture.getAddressPostcode())
+                .build());
+
+        ValidatableResponse response = givenSetup()
+                .body(postBody)
+                .post(requestPath)
+                .then()
+                .statusCode(Response.Status.CREATED.getStatusCode());
+
+        Map<String, Object> createdPayer = testContext.getDatabaseTestHelper().getPayerByPaymentRequestExternalId(testPaymentRequest.getExternalId());
+        String createdPayerExternalId = (String) createdPayer.get("external_id");
+        String documentLocation = expectedPayerRequestLocationFor(testPaymentRequest.getExternalId(), createdPayerExternalId);
+
+        response
+                .header("Location", is(documentLocation))
+                .body("payer_external_id", is(createdPayerExternalId))
+                .contentType(JSON);
+    }
+    private String expectedPayerRequestLocationFor(String paymentRequestExternalId, String payerExternalId) {
+        return "http://localhost:" + testContext.getPort() + "/v1/api/payment_requests/{paymentRequestExternalId}/payers/{payerExternalId}"
+                .replace("{paymentRequestExternalId}", paymentRequestExternalId)
+                .replace("{payerExternalId}", payerExternalId);
+    }
+    @Test
+    public void shouldReturn400IfMandatoryFieldsMissing() {
+        String postBody = gson.toJson(ImmutableMap.builder()
+                .put(SORTCODE_KEY, payerFixture.getSortCode())
+                .put(NAME_KEY, payerFixture.getName())
+                .put(EMAIL_KEY, payerFixture.getEmail())
+                .put(ADDRESS_LINE1_KEY, payerFixture.getAddressLine1())
+                .put(ADDRESS_LINE2_KEY, payerFixture.getAddressLine2())
+                .put(ADDRESS_CITY_KEY, payerFixture.getAddressCity())
+                .put(ADDRESS_POSTCODE_KEY, payerFixture.getAddressPostcode())
+                .build());
+
+        givenSetup()
+                .body(postBody)
+                .post(requestPath)
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(JSON)
+                .body("message", is("Field(s) missing: [account_number, country_code]"));
+    }
+
+    @Test
+    public void shouldReturn400IfFieldsInvalidSize() {
+        String postBody = gson.toJson(ImmutableMap.builder()
+                .put(ACCOUNT_NUMBER_KEY, payerFixture.getAccountNumber())
+                .put(SORTCODE_KEY, payerFixture.getSortCode())
+                .put(NAME_KEY, payerFixture.getName())
+                .put(EMAIL_KEY, RandomStringUtils.randomAlphabetic(255))
+                .put(ADDRESS_LINE1_KEY, payerFixture.getAddressLine1())
+                .put(ADDRESS_CITY_KEY, payerFixture.getAddressCity())
+                .put(ADDRESS_COUNTRY_KEY, payerFixture.getAddressCountry())
+                .put(ADDRESS_POSTCODE_KEY, payerFixture.getAddressPostcode())
+                .build());
+
+        givenSetup()
+                .body(postBody)
+                .post(requestPath)
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(JSON)
+                .body("message", is("Field(s) are too big: [email]"));
+    }
+
+    @Test
+    public void shouldReturn400IfFieldsInvalid() {
+        String postBody = gson.toJson(ImmutableMap.builder()
+                .put(ACCOUNT_NUMBER_KEY, "123c5678")
+                .put(SORTCODE_KEY, "123a56")
+                .put(NAME_KEY, payerFixture.getName())
+                .put(EMAIL_KEY, payerFixture.getEmail())
+                .put(ADDRESS_LINE1_KEY, payerFixture.getAddressLine1())
+                .put(ADDRESS_CITY_KEY, payerFixture.getAddressCity())
+                .put(ADDRESS_COUNTRY_KEY, payerFixture.getAddressCountry())
+                .put(ADDRESS_POSTCODE_KEY, payerFixture.getAddressPostcode())
+                .build());
+
+        givenSetup()
+                .body(postBody)
+                .post(requestPath)
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(JSON)
+                .body("message", is("Field(s) are invalid: [account_number, sort_code]"));
+    }
+
+    private RequestSpecification givenSetup() {
+        return given().port(testContext.getPort())
+                .contentType(JSON);
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payers/services/PayerServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/services/PayerServiceTest.java
@@ -1,0 +1,95 @@
+package uk.gov.pay.directdebit.payers.services;
+
+import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mindrot.jbcrypt.BCrypt;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.app.config.EncryptionConfig;
+import uk.gov.pay.directdebit.payers.dao.PayerDao;
+import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.services.TransactionService;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PayerServiceTest {
+    private static final String SALT = "$2a$10$IhaXo6LIBhKIWOiGpbtPOu";
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private PayerDao mockedPayerDao;
+
+    @Mock
+    private TransactionService mockedTransactionService;
+
+    @Mock
+    private EncryptionConfig mockedEncryptionConfig;
+
+    private PayerService service;
+    private PaymentRequestFixture paymentRequestFixture = PaymentRequestFixture.aPaymentRequestFixture();
+
+    private TransactionFixture transactionFixture = TransactionFixture.aTransactionFixture()
+            .withState(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS)
+            .withPaymentRequestId(paymentRequestFixture.getId());
+
+    private PayerFixture testPayer = PayerFixture.aPayerFixture();
+    private Map<String, String> createPaymentRequest = new HashMap<String, String>() {{
+        put("account_holder_name", testPayer.getName());
+        put("account_number", "12345678");
+        put("sort_code", testPayer.getSortCode());
+        put("email", testPayer.getEmail());
+        put("address_line1", testPayer.getAddressLine1());
+        put("address_line2", testPayer.getAddressLine2());
+        put("city", testPayer.getAddressCity());
+        put("postcode", testPayer.getAddressPostcode());
+        put("country_code", testPayer.getAddressCountry());
+        put("requires_authorisation", String.valueOf(testPayer.getAccountRequiresAuthorisation()));
+    }};
+    @Before
+    public void setUp() throws Exception {
+        when(mockedEncryptionConfig.getEncryptDBSalt()).thenReturn(SALT);
+        service = new PayerService(mockedEncryptionConfig, mockedPayerDao, mockedTransactionService);
+    }
+
+    @Test
+    public void shouldCreateAPayer() {
+        when(mockedTransactionService.receiveDirectDebitDetailsFor(paymentRequestFixture.getExternalId()))
+                .thenReturn(transactionFixture.toEntity());
+        Payer payer = service.create(paymentRequestFixture.getExternalId(), createPaymentRequest);
+        assertThat(payer.getId(), is(notNullValue()));
+        assertThat(payer.getExternalId(), is(notNullValue()));
+        assertThat(payer.getPaymentRequestId(), is(paymentRequestFixture.getId()));
+        assertThat(payer.getName(), is(testPayer.getName()));
+        assertThat(payer.getEmail(), is(testPayer.getEmail()));
+        assertThat(payer.getAccountNumberLastTwoDigits(), is("78"));
+        assertThat(payer.getAccountRequiresAuthorisation(), is(testPayer.getAccountRequiresAuthorisation()));
+        assertThat(payer.getAccountNumber(), is(BCrypt.hashpw("12345678", SALT)));
+        assertThat(payer.getSortCode(), is(BCrypt.hashpw(testPayer.getSortCode(), SALT)));
+        assertThat(payer.getAddressLine1(), is(testPayer.getAddressLine1()));
+        assertThat(payer.getAddressLine2(), is(testPayer.getAddressLine2()));
+        assertThat(payer.getAddressPostcode(), is(testPayer.getAddressPostcode()));
+        assertThat(payer.getAddressCity(), is(testPayer.getAddressCity()));
+        assertThat(payer.getAddressCountry(), is(testPayer.getAddressCountry()));
+        assertThat(payer.getCreatedDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+        verify(mockedTransactionService).payerCreatedFor(transactionFixture.toEntity());
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoIT.java
@@ -49,17 +49,14 @@ public class PaymentRequestEventDaoIT {
     @Test
     public void shouldInsertAnEvent() {
         Long paymentRequestId = testPaymentRequest.getId();
-        PaymentRequestEvent.Type eventType = PaymentRequestEvent.Type.CHARGE;
-        PaymentRequestEvent.SupportedEvent event = PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
-        ZonedDateTime eventDate = ZonedDateTime.now();
-        PaymentRequestEvent paymentRequestEvent = new PaymentRequestEvent(paymentRequestId, eventType, event, eventDate);
+        PaymentRequestEvent paymentRequestEvent = PaymentRequestEvent.payerCreated(paymentRequestId);
         Long id = paymentRequestEventDao.insert(paymentRequestEvent);
         Map<String, Object> foundPaymentRequestEvent = testContext.getDatabaseTestHelper().getPaymentRequestEventById(id);
         assertThat(foundPaymentRequestEvent.get("id"), is(id));
         assertThat(foundPaymentRequestEvent.get("payment_request_id"), is(paymentRequestId));
-        assertThat(foundPaymentRequestEvent.get("event_type"), is(eventType.toString()));
-        assertThat(foundPaymentRequestEvent.get("event"), is(event.toString()));
-        assertThat((Timestamp) foundPaymentRequestEvent.get("event_date"), isDate(eventDate));
+        assertThat(foundPaymentRequestEvent.get("event_type"), is(paymentRequestEvent.getEventType().toString()));
+        assertThat(foundPaymentRequestEvent.get("event"), is(paymentRequestEvent.getEvent().toString()));
+        assertThat((Timestamp) foundPaymentRequestEvent.get("event_date"), isDate(paymentRequestEvent.getEventDate()));
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
@@ -1,0 +1,71 @@
+package uk.gov.pay.directdebit.payments.services;
+
+import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.payments.dao.PaymentRequestEventDao;
+import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaymentRequestEventServiceTest {
+
+    @Mock
+    private PaymentRequestEventDao mockedPaymentRequestEventDao;
+
+    private PaymentRequestEventService service;
+
+    private TransactionFixture transactionFixture = TransactionFixture.aTransactionFixture();
+    @Before
+    public void setUp() throws Exception {
+        service = new PaymentRequestEventService(mockedPaymentRequestEventDao);
+    }
+
+    @Test
+    public void shouldInsertAnEventWhenTokenIsExchanged() {
+        service.registerTokenExchangedEventFor(transactionFixture.toEntity());
+        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED));
+        assertThat(paymentRequestEvent.getEventType(), is(PaymentRequestEvent.Type.CHARGE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void shouldInsertAnEventWhenDDDetailsAreReceived() {
+        service.registerDirectDebitReceivedEventFor(transactionFixture.toEntity());
+        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED));
+        assertThat(paymentRequestEvent.getEventType(), is(PaymentRequestEvent.Type.CHARGE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void shouldInsertAnEventWhenPayerIsCreated() {
+        service.registerPayerCreatedEventFor(transactionFixture.toEntity());
+        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PaymentRequestEvent.SupportedEvent.PAYER_CREATED));
+        assertThat(paymentRequestEvent.getEventType(), is(PaymentRequestEvent.Type.PAYER));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -1,0 +1,152 @@
+package uk.gov.pay.directdebit.payments.services;
+
+import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.payments.dao.TransactionDao;
+import uk.gov.pay.directdebit.payments.exception.ChargeNotFoundException;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
+import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TransactionServiceTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private TransactionDao mockedTransactionDao;
+
+    private TransactionService service;
+    @Mock
+    private PaymentRequestEventService mockedPaymentRequestEventService;
+
+    private PaymentRequestFixture paymentRequestFixture = PaymentRequestFixture.aPaymentRequestFixture();
+    @Before
+    public void setUp() throws Exception {
+        service = new TransactionService(mockedTransactionDao, mockedPaymentRequestEventService);
+    }
+
+    @Test
+    public void shouldCreateATransactionAndEvent() {
+        ArgumentCaptor<PaymentRequest> prCaptor = forClass(PaymentRequest.class);
+        ArgumentCaptor<PaymentRequestEvent> preCaptor = forClass(PaymentRequestEvent.class);
+        Transaction transaction = service.createChargeFor(paymentRequestFixture.toEntity());
+        verify(mockedPaymentRequestEventService).insertEventFor(prCaptor.capture(), preCaptor.capture());
+
+        PaymentRequestEvent createdPaymentRequestEvent = preCaptor.getValue();
+
+        assertThat(transaction.getId(), is(notNullValue()));
+        assertThat(transaction.getPaymentRequestId(), is(paymentRequestFixture.getId()));
+        assertThat(transaction.getPaymentRequestExternalId(), is(paymentRequestFixture.getExternalId()));
+        assertThat(transaction.getAmount(), is(paymentRequestFixture.getAmount()));
+        assertThat(transaction.getType(), is(Transaction.Type.CHARGE));
+        assertThat(transaction.getState(), is(PaymentState.NEW));
+        assertThat(createdPaymentRequestEvent.getPaymentRequestId(), is(paymentRequestFixture.getId()));
+        assertThat(createdPaymentRequestEvent.getEventType(), is(PaymentRequestEvent.Type.CHARGE));
+        assertThat(createdPaymentRequestEvent.getEvent(), is(PaymentRequestEvent.SupportedEvent.CHARGE_CREATED));
+        assertThat(createdPaymentRequestEvent.getEventDate(),
+                is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void shouldFindATransactionByExternalId() {
+        TransactionFixture transactionFixture = TransactionFixture
+                .aTransactionFixture();
+        when(mockedTransactionDao.findByPaymentRequestExternalId(paymentRequestFixture.getExternalId()))
+                .thenReturn(Optional.of(transactionFixture.toEntity()));
+        Transaction foundTransaction = service.findChargeForExternalId(paymentRequestFixture.getExternalId());
+        assertThat(foundTransaction.getId(), is(notNullValue()));
+        assertThat(foundTransaction.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(foundTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(foundTransaction.getAmount(), is(transactionFixture.getAmount()));
+        assertThat(foundTransaction.getType(), is(transactionFixture.getType()));
+        assertThat(foundTransaction.getState(), is(transactionFixture.getState()));
+    }
+    @Test
+    public void shouldThrow_ifNoTransactionExistsWithExternalId()  {
+        thrown.expect(ChargeNotFoundException.class);
+        thrown.expectMessage("No charges found for payment request with id: not-existing");
+        thrown.reportMissingExceptionWithMessage("ChargeNotFoundException expected");
+        service.findChargeForExternalId("not-existing");
+    }
+
+    @Test
+    public void shouldUpdateTransactionStateAndRegisterEventWhenAPayerIsCreated() throws Exception {
+        TransactionFixture transactionFixture = TransactionFixture
+                .aTransactionFixture()
+                .withState(PaymentState.PROCESSING_DIRECT_DEBIT_DETAILS);
+        Transaction newTransaction = service.payerCreatedFor(transactionFixture.toEntity());
+        assertThat(newTransaction.getId(), is(notNullValue()));
+        assertThat(newTransaction.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(newTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
+        assertThat(newTransaction.getType(), is(transactionFixture.getType()));
+        assertThat(newTransaction.getState(), is(PaymentState.AWAITING_CONFIRMATION));
+        verify(mockedPaymentRequestEventService).registerPayerCreatedEventFor(newTransaction);
+    }
+
+    @Test
+    public void shouldUpdateTransactionStateAndRegisterEventWhenReceivingDDDetails() throws Exception {
+        TransactionFixture transactionFixture = TransactionFixture
+                .aTransactionFixture()
+                .withState(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS);
+        when(mockedTransactionDao.findByPaymentRequestExternalId(transactionFixture.getPaymentRequestExternalId()))
+                .thenReturn(Optional.of(transactionFixture.toEntity()));
+        Transaction newTransaction = service.receiveDirectDebitDetailsFor(transactionFixture.getPaymentRequestExternalId());
+        assertThat(newTransaction.getId(), is(notNullValue()));
+        assertThat(newTransaction.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(newTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
+        assertThat(newTransaction.getType(), is(transactionFixture.getType()));
+        assertThat(newTransaction.getState(), is(PaymentState.PROCESSING_DIRECT_DEBIT_DETAILS));
+        verify(mockedPaymentRequestEventService).registerDirectDebitReceivedEventFor(newTransaction);
+    }
+
+    @Test
+    public void shouldUpdateTransactionStateAndRegisterEventWhenExchangingTokens() throws Exception {
+        String token = "token";
+        TransactionFixture transactionFixture = TransactionFixture
+                .aTransactionFixture()
+                .withState(PaymentState.NEW);
+        when(mockedTransactionDao.findByTokenId(token))
+                .thenReturn(Optional.of(transactionFixture.toEntity()));
+        Transaction newTransaction = service.findChargeForToken(token).get();
+        assertThat(newTransaction.getId(), is(notNullValue()));
+        assertThat(newTransaction.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(newTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
+        assertThat(newTransaction.getType(), is(transactionFixture.getType()));
+        assertThat(newTransaction.getState(), is(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS));
+        verify(mockedPaymentRequestEventService).registerTokenExchangedEventFor(newTransaction);
+    }
+
+    @Test
+    public void shouldNotReturnATransactionIfNoTransactionExistsForToken() throws Exception {
+        when(mockedTransactionDao.findByTokenId("not-existing"))
+                .thenReturn(Optional.empty());
+        assertThat(service.findChargeForToken("not-existing").isPresent(), is(false));
+        verifyNoMoreInteractions(mockedPaymentRequestEventService);
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/tokens/services/TokenServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/tokens/services/TokenServiceTest.java
@@ -9,13 +9,14 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.directdebit.payments.dao.PaymentRequestEventDao;
-import uk.gov.pay.directdebit.payments.dao.TransactionDao;
-import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.Token;
 import uk.gov.pay.directdebit.payments.model.Transaction;
+import uk.gov.pay.directdebit.payments.services.PaymentRequestEventService;
+import uk.gov.pay.directdebit.payments.services.TransactionService;
 import uk.gov.pay.directdebit.tokens.dao.TokenDao;
 import uk.gov.pay.directdebit.tokens.exception.TokenNotFoundException;
 
@@ -24,8 +25,10 @@ import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
@@ -39,65 +42,44 @@ public class TokenServiceTest {
     private TokenDao mockedTokenDao;
 
     @Mock
-    private TransactionDao mockedTransactionDao;
+    private TransactionService mockedTransactionService;
 
     @Mock
-    private PaymentRequestEventDao mockedPaymentRequestEventDao;
+    private PaymentRequestEventService mockedPaymentRequestEventService;
 
     private TokenService service;
+    TransactionFixture transactionFixture = aTransactionFixture().withState(PaymentState.NEW);
+    String token = "token";
 
     @Before
     public void setUp() throws Exception {
-        service = new TokenService(mockedTokenDao, mockedPaymentRequestEventDao, mockedTransactionDao);
+        service = new TokenService(mockedTokenDao, mockedTransactionService);
+        when(mockedTransactionService.findChargeForToken(token))
+                .thenReturn(Optional.of(transactionFixture.toEntity()));
+    }
+
+    @Test
+    public void shouldGenerateANewToken() {
+        PaymentRequestFixture paymentRequestFixture = PaymentRequestFixture.aPaymentRequestFixture();
+        Token token = service.generateNewTokenFor(paymentRequestFixture.toEntity());
+        assertThat(token.getId(), is(notNullValue()));
+        assertThat(token.getToken(), is(notNullValue()));
+        assertThat(token.getPaymentRequestId(), is(paymentRequestFixture.getId()));
     }
 
     @Test
     public void shouldValidateAPaymentRequestWithAToken() {
-        TransactionFixture transactionFixture = aTransactionFixture().withState(PaymentState.NEW);
-        String token = "token";
-        when(mockedTransactionDao.findByTokenId(token))
-                .thenReturn(Optional.of(transactionFixture.toEntity()));
         Transaction charge = service.validateChargeWithToken(token);
         assertThat(charge.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(charge.getState(), is(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS));
-    }
-
-    @Test
-    public void shouldCreateATokenExchangedEvent_whenTokenIsValid() throws Exception{
-        TransactionFixture transactionFixture = aTransactionFixture();
-        String token = "token";
-        when(mockedTransactionDao.findByTokenId(token))
-                .thenReturn(Optional.of(transactionFixture.toEntity()));
-        service.validateChargeWithToken(token);
-
-        ArgumentCaptor<PaymentRequestEvent> paymentRequestEventArgumentCaptor = forClass(PaymentRequestEvent.class);
-        verify(mockedPaymentRequestEventDao).insert(paymentRequestEventArgumentCaptor.capture());
-        PaymentRequestEvent createdPaymentRequestEvent = paymentRequestEventArgumentCaptor.getValue();
-        assertThat(createdPaymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(createdPaymentRequestEvent.getEventType(), is(PaymentRequestEvent.Type.CHARGE));
-        assertThat(createdPaymentRequestEvent.getEvent(), is(PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED));
-        assertThat(createdPaymentRequestEvent.getEventDate(),
-                is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS,  ZonedDateTime.now())));
     }
 
     @Test
     public void shouldThrowIfTokenDoesNotExist() {
+        when(mockedTransactionService.findChargeForToken("not-existing")).thenReturn(Optional.empty());
         thrown.expect(TokenNotFoundException.class);
         thrown.expectMessage("No one-time token found for payment request");
         thrown.reportMissingExceptionWithMessage("TokenNotFoundException.class expected");
         service.validateChargeWithToken("not-existing");
-    }
-
-    @Test
-    public void shouldThrowIfChargeIsInInvalidState() {
-        thrown.expect(InvalidStateTransitionException.class);
-        thrown.expectMessage("Transition TOKEN_EXCHANGED from state AWAITING_DIRECT_DEBIT_DETAILS is not valid");
-        thrown.reportMissingExceptionWithMessage("InvalidStateTransitionException.class expected");
-        TransactionFixture transactionFixture = aTransactionFixture().withState(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS);
-        String token = "token";
-        when(mockedTransactionDao.findByTokenId(token))
-                .thenReturn(Optional.of(transactionFixture.toEntity()));
-        service.validateChargeWithToken(token);
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -58,4 +58,22 @@ public class DatabaseTestHelper {
                         .first()
         );
     }
+
+    public Map<String, Object> getPayerById(Long id) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT * from payers p WHERE p.id = :id")
+                        .bind("id", id)
+                        .first()
+        );
+    }
+
+    public Map<String, Object> getPayerByPaymentRequestExternalId(String externalId) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT p.* from payers p INNER JOIN payment_requests r ON p.payment_request_id = r.id WHERE r.external_id = :externalId")
+                        .bind("externalId", externalId)
+                        .first()
+        );
+    }
 }

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -26,6 +26,9 @@ goCardless:
   webhookSecret: secret
   environment: sandbox
 
+encryption:
+  encryptDBSalt: $2a$10$IhaXo6LIBhKIWOiGpbtPOu
+
 database:
   driverClass: org.postgresql.Driver
   user:


### PR DESCRIPTION
##WHAT
 
- Data is parsed and a Payer object is created. Together with two events - one
   when details are received and one when the actual Payer is stored in the
   database
 - Account number and sortcode are stored in the db as one way hashes,
   encrypted  with a salt (coming from our secret store).
   This will allow us to validate those details, without being able to obtain
   the clear text version.
 - We still have to do the work to retrieve `TOKEN_DB_BCRYPT_SALT` from ParameterStore