### PR TITLE
PP-2850 Don't hardcode db port

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -36,7 +36,7 @@ database:
   driverClass: org.postgresql.Driver
   user: ${DB_USER}
   password: ${DB_PASSWORD}
-  url: jdbc:postgresql://${DB_HOST}:5432/${DB_NAME:-directdebitconnector}?sslfactory=uk.gov.pay.directdebit.app.ssl.TrustingSSLSocketFactory&${DB_SSL_OPTION}
+  url: jdbc:postgresql://${DB_HOST}/${DB_NAME:-directdebitconnector}?sslfactory=uk.gov.pay.directdebit.app.ssl.TrustingSSLSocketFactory&${DB_SSL_OPTION}
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s


### PR DESCRIPTION
Providing a database host as url + port makes things easier
for ecs, and is also nicer anyway I reckon.