### PR TITLE
PP-3106 Reassign Payer resource to correct url

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResource.java
@@ -22,8 +22,8 @@ public class ConfirmPaymentResource {
     }
 
     @POST
-    @Path("/v1/api/accounts/{accountId}/payment-requests/{paymentRequestId}/confirm")
-    public Response confirm(@PathParam("accountId") Long accountId, @PathParam("paymentRequestId") String paymentRequestId) {
+    @Path("/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/confirm")
+    public Response confirm(@PathParam("accountId") Long accountId, @PathParam("paymentRequestExternalId") String paymentRequestId) {
         logger.info("Confirming payment - {}", paymentRequestId);
         paymentConfirmService.confirm(paymentRequestId);
         return noContent().build();

--- a/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
@@ -22,8 +22,8 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
 public class PayerResource {
-    private static final String PAYER_API_PATH = "/v1/api/payment_requests/{paymentRequestExternalId}/payers/{payerExternalId}";
-    private static final String PAYERS_API_PATH = "/v1/api/payment_requests/{paymentRequestExternalId}/payers";
+    private static final String PAYERS_API_PATH = "/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/payers";
+    private static final String PAYER_API_PATH = PAYERS_API_PATH + "/{payerExternalId}";
 
     private static final Logger LOGGER = PayLoggerFactory.getLogger(PayerResource.class);
     private final PayerService payerService;
@@ -37,11 +37,11 @@ public class PayerResource {
     @Path(PAYERS_API_PATH)
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    public Response createPayer(@PathParam("paymentRequestExternalId") String paymentRequestExternalId, Map<String, String> createPayerRequest, @Context UriInfo uriInfo) {
+    public Response createPayer(@PathParam("accountId") Long accountId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, Map<String, String> createPayerRequest, @Context UriInfo uriInfo) {
         createPayerValidator.validate(createPayerRequest);
         LOGGER.info("Create new payer request received for payment request {} ", paymentRequestExternalId);
         CreatePayerResponse createPayerResponse = CreatePayerResponse.from(payerService.create(paymentRequestExternalId, createPayerRequest));
-        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, paymentRequestExternalId, createPayerResponse.getPayerExternalId());
+        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, String.valueOf(accountId), paymentRequestExternalId, createPayerResponse.getPayerExternalId());
         return Response.created(newPayerLocation).entity(createPayerResponse).build();
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
@@ -55,7 +55,7 @@ public class PaymentRequestService {
                     POST,
                     nextUrl(linksConfig.getFrontendUrl(), "secure"),
                     APPLICATION_FORM_URLENCODED,
-                    ImmutableMap.of("chargeTokenId", token.getToken())));
+                    ImmutableMap.of("token", token.getToken())));
         }
         return new PaymentRequestResponse(paymentRequestExternalId,
                 paymentRequest.getAmount(),

--- a/src/main/java/uk/gov/pay/directdebit/tokens/resources/SecurityTokensResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/tokens/resources/SecurityTokensResource.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.directdebit.tokens.resources;
 
-import org.slf4j.Logger;
-import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.tokens.api.TokenResponse;
 import uk.gov.pay.directdebit.tokens.services.TokenService;
 
@@ -16,10 +14,9 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
 public class SecurityTokensResource {
-    static final String TOKEN_PATH = "/v1/tokens/{chargeTokenId}";
-    private static final String CHARGE_BY_TOKEN_PATH = TOKEN_PATH + "/charge";
+    static final String TOKEN_PATH = "/v1/tokens/{token}";
+    private static final String PAYMENT_REQUEST_BY_TOKEN_PATH = TOKEN_PATH + "/payment-request";
 
-    private final Logger logger = PayLoggerFactory.getLogger(SecurityTokensResource.class);
     private final TokenService tokenService;
 
     public SecurityTokensResource(TokenService tokenService) {
@@ -27,17 +24,17 @@ public class SecurityTokensResource {
     }
 
     @GET
-    @Path(CHARGE_BY_TOKEN_PATH)
+    @Path(PAYMENT_REQUEST_BY_TOKEN_PATH)
     @Produces(APPLICATION_JSON)
-    public Response getPaymentRequestForToken(@PathParam("chargeTokenId") String chargeTokenId) {
-        TokenResponse response = TokenResponse.from(tokenService.validateChargeWithToken(chargeTokenId));
+    public Response getPaymentRequestForToken(@PathParam("token") String token) {
+        TokenResponse response = TokenResponse.from(tokenService.validateChargeWithToken(token));
         return Response.ok().entity(response).build();
     }
 
     @DELETE
     @Path(TOKEN_PATH)
-    public Response deleteToken(@PathParam("chargeTokenId") String chargeTokenId) {
-        tokenService.deleteToken(chargeTokenId);
+    public Response deleteToken(@PathParam("token") String token) {
+        tokenService.deleteToken(token);
         return Response.noContent().build();
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
@@ -39,7 +39,7 @@ public class PayerResourceIT {
     private final static String ADDRESS_CITY_KEY = "city";
     private final static String ADDRESS_COUNTRY_KEY = "country_code";
     private final static String ADDRESS_POSTCODE_KEY = "postcode";
-
+    private final String accountId = "20";
     private Gson gson = new Gson();
 
     @DropwizardTestContext
@@ -57,7 +57,8 @@ public class PayerResourceIT {
                 .withPaymentRequestId(testPaymentRequest.getId())
                 .withPaymentRequestExternalId(testPaymentRequest.getExternalId()).insert(testContext.getJdbi());
         payerFixture = aPayerFixture().withAccountNumber("12345678");
-        requestPath = "/v1/api/payment_requests/{paymentRequestExternalId}/payers"
+        requestPath = "/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/payers"
+                .replace("{accountId}", accountId)
                 .replace("{paymentRequestExternalId}", testPaymentRequest.getExternalId());
 
     }
@@ -90,7 +91,8 @@ public class PayerResourceIT {
                 .contentType(JSON);
     }
     private String expectedPayerRequestLocationFor(String paymentRequestExternalId, String payerExternalId) {
-        return "http://localhost:" + testContext.getPort() + "/v1/api/payment_requests/{paymentRequestExternalId}/payers/{payerExternalId}"
+        return "http://localhost:" + testContext.getPort() + "/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/payers/{payerExternalId}"
+                .replace("{accountId}", accountId)
                 .replace("{paymentRequestExternalId}", paymentRequestExternalId)
                 .replace("{payerExternalId}", payerExternalId);
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResourceIT.java
@@ -78,9 +78,9 @@ public class PaymentRequestResourceIT {
 
         String externalPaymentRequestId = response.extract().path(JSON_CHARGE_KEY).toString();
         String documentLocation = expectedPaymentRequestLocationFor(accountId, externalPaymentRequestId);
-        String chargeTokenId = testContext.getDatabaseTestHelper().getTokenByPaymentRequestExternalId(externalPaymentRequestId);
+        String token = testContext.getDatabaseTestHelper().getTokenByPaymentRequestExternalId(externalPaymentRequestId);
 
-        String hrefNextUrl = "http://Frontend" + FRONTEND_CARD_DETAILS_URL + "/" + chargeTokenId;
+        String hrefNextUrl = "http://Frontend" + FRONTEND_CARD_DETAILS_URL + "/" + token;
         String hrefNextUrlPost = "http://Frontend" + FRONTEND_CARD_DETAILS_URL;
 
         response.header("Location", is(documentLocation))
@@ -88,7 +88,7 @@ public class PaymentRequestResourceIT {
                 .body("links", containsLink("self", "GET", documentLocation))
                 .body("links", containsLink("next_url", "GET", hrefNextUrl))
                 .body("links", containsLink("next_url_post", "POST", hrefNextUrlPost, "application/x-www-form-urlencoded", new HashMap<String, Object>() {{
-                    put("chargeTokenId", chargeTokenId);
+                    put("token", token);
                 }}));
         String requestPath2 = CHARGE_API_PATH
                 .replace("{accountId}", accountId)
@@ -109,16 +109,16 @@ public class PaymentRequestResourceIT {
 
         // Reload the charge token which as it should have changed
 
-        String newChargeTokenId = testContext.getDatabaseTestHelper().getTokenByPaymentRequestExternalId(externalPaymentRequestId);
+        String newChargeToken = testContext.getDatabaseTestHelper().getTokenByPaymentRequestExternalId(externalPaymentRequestId);
 
-        String newHrefNextUrl = "http://Frontend" + FRONTEND_CARD_DETAILS_URL + "/" + newChargeTokenId;
+        String newHrefNextUrl = "http://Frontend" + FRONTEND_CARD_DETAILS_URL + "/" + newChargeToken;
 
         getChargeResponse
                 .body("links", hasSize(3))
                 .body("links", containsLink("self", "GET", documentLocation))
                 .body("links", containsLink("next_url", "GET", newHrefNextUrl))
                 .body("links", containsLink("next_url_post", "POST", hrefNextUrlPost, "application/x-www-form-urlencoded", new HashMap<String, Object>() {{
-                    put("chargeTokenId", newChargeTokenId);
+                    put("token", newChargeToken);
                 }}));
 
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
@@ -171,7 +171,7 @@ public class PaymentRequestServiceTest {
                         .put("href", new URI("http://payments.com/secure"))
                         .put("type", "application/x-www-form-urlencoded")
                         .put("params", new HashMap<String, Object>() {{
-                            put("chargeTokenId", token.getToken());
+                            put("token", token.getToken());
                         }}).build()
         ));
     }

--- a/src/test/java/uk/gov/pay/directdebit/tokens/resources/SecurityTokensResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/tokens/resources/SecurityTokensResourceIT.java
@@ -44,8 +44,9 @@ public class SecurityTokensResourceIT {
 
     @Test
     public void shouldReturn200WithPaymentRequestForValidToken() {
+        String requestPath = "/v1/tokens/{token}/payment-request".replace("{token}", testToken.getToken());
         givenSetup()
-                .get(tokensUrlFor(testToken.getToken()) + "/charge")
+                .get(requestPath)
                 .then()
                 .statusCode(200)
                 .contentType(JSON)
@@ -57,8 +58,9 @@ public class SecurityTokensResourceIT {
 
     @Test
     public void shouldReturnNoContentWhenDeletingToken() {
+        String requestPath = "/v1/tokens/{token}".replace("{token}", testToken.getToken());
         givenSetup()
-                .delete(tokensUrlFor(testToken.getToken()))
+                .delete(requestPath)
                 .then()
                 .statusCode(204);
     }
@@ -67,9 +69,4 @@ public class SecurityTokensResourceIT {
         return given().port(testContext.getPort())
                 .contentType(JSON);
     }
-
-    private String tokensUrlFor(String id) {
-        return SecurityTokensResource.TOKEN_PATH.replace("{chargeTokenId}", id);
-    }
-
 }


### PR DESCRIPTION
## WHAT
- Partition payment requests by `/{accountId}`
- Use dash instead of underscore for consistency with the confirm resource
- Renamed chargeTokenId to just `token`