### PR TITLE
PP-2939 Run direct debit e2e tests on merges

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,11 @@ pipeline {
         }
       }
     }
+    stage('Test') {
+      steps {
+        runParameterisedEndToEnd("directdebitconnector", null, "end2end-tagged", false, false, "uk.gov.pay.endtoend.categories.End2EndDirectDebit")
+      }
+    }
     stage('Docker Tag') {
       steps {
         script {


### PR DESCRIPTION
## WHAT
We now have a e2e direct-debit-specific profile. This will run only direct debit end to end tests, similar to how's done with products.