### PR TITLE
PP-3174 Implement database migrations for ECS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,7 @@ EXPOSE 8081
 
 WORKDIR /app
 
-ADD target/*.yaml /app/
-ADD target/pay-*-allinone.jar /app/
-ADD docker-startup.sh /app/docker-startup.sh
-ADD docker-startup-with-db-migration.sh /app/docker-startup-with-db-migration.sh
 ADD chamber.sha256sum /app/chamber.sha256sum
-
 RUN apk add openssl && \
     mkdir -p bin && \
     wget -qO bin/chamber $CHAMBER_URL && \
@@ -29,4 +24,10 @@ RUN apk add openssl && \
     chmod 755 bin/chamber && \
     apk del --purge openssl
 
-CMD bash ./docker-startup.sh
+ADD target/*.yaml /app/
+ADD target/pay-*-allinone.jar /app/
+ADD docker-startup.sh /app/docker-startup.sh
+ADD docker-startup-with-db-migration.sh /app/docker-startup-with-db-migration.sh
+ADD run-with-chamber.sh /app/run-with-chamber.sh
+
+CMD bash ./run-with-chamber.sh

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" -- ./docker-startup.sh


### PR DESCRIPTION
Cater for 3 different startup scenarios
- dev migrate db and start
- start only
- migrate db only

Ensure Docker deploys the new script run-with-chamber script
Chamber executes docker-startup.sh which has logic for the
above-mentioned scenarios
We are keeping the docker-startup-with-db-migration.sh to
prevent breakages whilst we transition

TODO once we are happy with the new system
- remove the docker-startup-with-db-migration.sh and reference
in Dockerfile
- remove the RUN_APP VALUE variable in docker-startup.sh to ensure the
    script fails in the event that the new variable is not set. The
    RUN_MIGRATION will only be set by microservices that have a db.