### PR TITLE
PP-3174 Implement database migrations for ECS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh
 ADD run-with-chamber.sh /app/run-with-chamber.sh
 
-CMD bash ./run-with-chamber.sh
+CMD bash ./docker-startup.sh


### PR DESCRIPTION
run-with-chamber.sh should only be referenced in the ECS task
definition files, docker-startup.sh should be the default
script.