### PR TITLE
PP-2939 Use the new direct debit run e2e job on PR merge

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
     }
     stage('Test') {
       steps {
-        runParameterisedEndToEnd("directdebitconnector", null, "end2end-tagged", false, false, "uk.gov.pay.endtoend.categories.End2EndDirectDebit")
+        runParameterisedEndToEnd("directdebitconnector", null, "end2end-tagged", false, false, "uk.gov.pay.endtoend.categories.End2EndDirectDebit", "run-end-to-end-direct-debit-tests")
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
## WHAT
The standard run-end-to-end-tests job is throttled to 2 concurrent builds max. This is slowing down a lot direct debit, as we often have to wait for 40+ min for other builds to finish, when we don't need to.
There is a new job in Jenkins which just runs dd tests, and it is not throttled.

## HOW 
_Steps to test or reproduce:_
