### PR TITLE
BAU: Use govukpay openjdk image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM govukpay/openjdk:8-jre-alpine
 
 
 RUN apk update


### PR DESCRIPTION
We should use the openjdk image from govukpay, this will give us chamber as well as our other additions.