### PR TITLE
PP-3061 Add gateway accounts table to the db

### DIFF
--- a/src/main/resources/migrations/00007_create_table_gateway_accounts.sql
+++ b/src/main/resources/migrations/00007_create_table_gateway_accounts.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-gateway_accounts
+CREATE TABLE gateway_accounts (
+    id BIGSERIAL PRIMARY KEY,
+    external_id VARCHAR(26) NOT NULL,
+    payment_provider VARCHAR(255) NOT NULL,
+    service_name VARCHAR(50) NOT NULL,
+    type VARCHAR(10) NOT NULL,
+    description VARCHAR(255),
+    analytics_id VARCHAR(255),
+    version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table gateway_accounts;
+
+--changeset uk.gov.pay:add_gateway_accounts_external_id_idx
+CREATE UNIQUE INDEX gateway_accounts_external_id_idx ON gateway_accounts(external_id)
+--rollback drop index gateway_accounts_external_id_idx;


### PR DESCRIPTION
## WHAT
Adding the `gateway accounts` table to dd connector. The gateway account, in addition to all the fields already present in connector, has an external id we generate.

with @alexbishop1 