### PR TITLE
PP-3061 Add gateway accounts services and resource

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.directdebit.gatewayaccounts.api;
+
+import com.google.common.collect.ImmutableMap;
+import uk.gov.pay.directdebit.common.validation.ApiValidation;
+import uk.gov.pay.directdebit.common.validation.FieldSize;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class CreateGatewayAccountValidator extends ApiValidation {
+
+    private static final String PAYMENT_PROVIDER_KEY = "payment_provider";
+    private static final String SERVICE_NAME_KEY = "service_name";
+    private static final String TYPE_KEY = "type";
+
+    private static final int SERVICE_NAME_FIELD_LENGTH = 50;
+
+    private final static String[] requiredFields = {PAYMENT_PROVIDER_KEY, SERVICE_NAME_KEY, TYPE_KEY};
+
+    private final static Map<String, FieldSize> fieldSizes =
+            ImmutableMap.<String, FieldSize>builder()
+                    .put(SERVICE_NAME_KEY, new FieldSize(1, SERVICE_NAME_FIELD_LENGTH))
+                    .build();
+
+    private final static Map<String, Function<String, Boolean>> validators =
+            ImmutableMap.<String, Function<String, Boolean>>builder()
+                    .put(SERVICE_NAME_KEY, ApiValidation::isNotNullOrEmpty)
+                    .put(PAYMENT_PROVIDER_KEY, ApiValidation::isNotNullOrEmpty)
+                    .put(TYPE_KEY, ApiValidation::isNotNullOrEmpty)
+                    .build();
+
+    public CreateGatewayAccountValidator() {
+        super(requiredFields, fieldSizes, validators);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/GatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/GatewayAccountResponse.java
@@ -1,0 +1,125 @@
+package uk.gov.pay.directdebit.gatewayaccounts.api;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static javax.ws.rs.HttpMethod.GET;
+import static uk.gov.pay.directdebit.common.util.URIBuilder.createLink;
+import static uk.gov.pay.directdebit.common.util.URIBuilder.selfUriFor;
+import static uk.gov.pay.directdebit.gatewayaccounts.resources.GatewayAccountResource.GATEWAY_ACCOUNT_API_PATH;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public class GatewayAccountResponse {
+    @JsonProperty("gateway_account_id")
+    private Long gatewayAccountId;
+    @JsonProperty("gateway_account_external_id")
+    private String gatewayAccountExternalId;
+    @JsonProperty("payment_method")
+    private final String paymentMethod="DIRECT_DEBIT";
+    @JsonProperty("service_name")
+    private String serviceName;
+    @JsonProperty("payment_provider")
+    private String paymentProvider;
+    @JsonProperty("description")
+    private String description;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("analytics_id")
+    private String analyticsId;
+    @JsonProperty("links")
+    private List<Map<String, Object>> links = new ArrayList<>();
+
+    public GatewayAccountResponse(Long gatewayAccountId, String gatewayAccountExternalId, String serviceName, String paymentProvider, String description, String type, String analyticsId) {
+        this.gatewayAccountId = gatewayAccountId;
+        this.gatewayAccountExternalId = gatewayAccountExternalId;
+        this.serviceName = serviceName;
+        this.paymentProvider = paymentProvider;
+        this.description = description;
+        this.type = type;
+        this.analyticsId = analyticsId;
+    }
+
+    public static GatewayAccountResponse from(GatewayAccount gatewayAccount) {
+        return new GatewayAccountResponse(
+                gatewayAccount.getId(),
+                gatewayAccount.getExternalId(),
+                gatewayAccount.getServiceName(),
+                gatewayAccount.getPaymentProvider().toString(),
+                gatewayAccount.getDescription(),
+                gatewayAccount.getType().toString(),
+                gatewayAccount.getAnalyticsId()
+        );
+    }
+
+    public GatewayAccountResponse withSelfLink(UriInfo uriInfo) {
+        this.links.add(createLink(
+                "self",
+                GET,
+                selfUriFor(uriInfo, GATEWAY_ACCOUNT_API_PATH, gatewayAccountId.toString())));
+        return this;
+    }
+
+    public URI getSelfLink() {
+        return this.links.stream()
+                .filter(link -> link.get("rel").equals("self"))
+                .findFirst()
+                .map(link -> (URI) link.get("href"))
+                .orElse(URI.create(""));
+    }
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getAnalyticsId() {
+        return analyticsId;
+    }
+
+    public List<Map<String, Object>> getLinks() {
+        return links;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GatewayAccountResponse that = (GatewayAccountResponse) o;
+        return Objects.equal(gatewayAccountId, that.gatewayAccountId) &&
+                Objects.equal(gatewayAccountExternalId, that.gatewayAccountExternalId) &&
+                Objects.equal(paymentProvider, that.paymentProvider) &&
+                Objects.equal(description, that.description) &&
+                Objects.equal(type, that.type) &&
+                Objects.equal(analyticsId, that.analyticsId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(gatewayAccountId, gatewayAccountExternalId, paymentProvider, description, type, analyticsId);
+    }
+}
+

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/GatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/GatewayAccountResponse.java
@@ -65,7 +65,7 @@ public class GatewayAccountResponse {
         this.links.add(createLink(
                 "self",
                 GET,
-                selfUriFor(uriInfo, GATEWAY_ACCOUNT_API_PATH, gatewayAccountId.toString())));
+                selfUriFor(uriInfo, GATEWAY_ACCOUNT_API_PATH, gatewayAccountExternalId)));
         return this;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/exception/GatewayAccountNotFoundException.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/exception/GatewayAccountNotFoundException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.directdebit.gatewayaccounts.exception;
+
+import uk.gov.pay.directdebit.common.exception.NotFoundException;
+
+import static java.lang.String.format;
+
+public class GatewayAccountNotFoundException extends NotFoundException {
+
+    public GatewayAccountNotFoundException(String gatewayAccountId) {
+        super(format("Unknown gateway account: %s", gatewayAccountId));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/GatewayAccount.java
@@ -36,9 +36,12 @@ public class GatewayAccount {
     }
 
     public GatewayAccount(PaymentProvider paymentProvider, Type type, String serviceName, String description, String analyticsId) {
-        this(null, RandomIdGenerator.newId(), paymentProvider, type, serviceName, description, analyticsId);
+        this(null, generateExternalId(), paymentProvider, type, serviceName, description, analyticsId);
     }
 
+    private static String generateExternalId() {
+        return "DIRECT_DEBIT:" + RandomIdGenerator.newId();
+    }
     public Long getId() {
         return id;
     }

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResource.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.directdebit.gatewayaccounts.resources;
+
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.gatewayaccounts.api.CreateGatewayAccountValidator;
+import uk.gov.pay.directdebit.gatewayaccounts.api.GatewayAccountResponse;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.gatewayaccounts.services.GatewayAccountService;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+@Path("/")
+public class GatewayAccountResource {
+    public static final String GATEWAY_ACCOUNT_API_PATH = "/v1/api/accounts/{accountId}";
+    static final String GATEWAY_ACCOUNTS_API_PATH = "/v1/api/accounts";
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(GatewayAccountResource.class);
+
+    private GatewayAccountService gatewayAccountService;
+    private final CreateGatewayAccountValidator createGatewayAccountValidator = new CreateGatewayAccountValidator();
+
+
+    public GatewayAccountResource(GatewayAccountService gatewayAccountService) {
+        this.gatewayAccountService = gatewayAccountService;
+    }
+
+    @GET
+    @Path(GATEWAY_ACCOUNT_API_PATH)
+    @Produces(APPLICATION_JSON)
+    public Response getGatewayAccount(@PathParam("accountId") String accountExternalId) {
+        LOGGER.debug("Getting gateway account for account external id {}", accountExternalId);
+        GatewayAccountResponse gatewayAccountResponse = GatewayAccountResponse.from(gatewayAccountService.getGatewayAccount(accountExternalId));
+        return Response.ok().entity(gatewayAccountResponse).build();
+    }
+
+    @GET
+    @Path(GATEWAY_ACCOUNTS_API_PATH)
+    @Produces(APPLICATION_JSON)
+    public Response getGatewayAccounts(@Context UriInfo uriInfo) {
+        LOGGER.debug("Getting all gateway accounts");
+        List<GatewayAccountResponse> gatewayAccounts = gatewayAccountService.getAllGatewayAccounts()
+                .stream()
+                .map(gatewayAccount -> GatewayAccountResponse.from(gatewayAccount).withSelfLink(uriInfo))
+                .collect(Collectors.toList());
+        return Response
+                .ok(ImmutableMap.of("accounts", gatewayAccounts))
+                .build();
+    }
+
+    @POST
+    @Path(GATEWAY_ACCOUNTS_API_PATH)
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public Response createNewGatewayAccount(Map<String, String> request, @Context UriInfo uriInfo) {
+        createGatewayAccountValidator.validate(request);
+        GatewayAccount gatewayAccount = gatewayAccountService.create(request);
+        GatewayAccountResponse gatewayAccountResponse = GatewayAccountResponse.from(gatewayAccount).withSelfLink(uriInfo);
+        return Response.created(gatewayAccountResponse.getSelfLink()).entity(gatewayAccountResponse).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountParser.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountParser.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.directdebit.gatewayaccounts.services;
+
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+
+import java.util.Map;
+
+public class GatewayAccountParser {
+    GatewayAccount parse(Map<String, String> createGatewayAccountPayload) {
+        return new GatewayAccount(
+                PaymentProvider.fromString(createGatewayAccountPayload.get("payment_provider")),
+                GatewayAccount.Type.fromString(createGatewayAccountPayload.get("type")),
+                createGatewayAccountPayload.get("service_name"),
+                createGatewayAccountPayload.get("description"),
+                createGatewayAccountPayload.get("analytics_id")
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountService.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.directdebit.gatewayaccounts.services;
+
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
+import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountNotFoundException;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+
+import java.util.List;
+import java.util.Map;
+
+public class GatewayAccountService {
+
+    private GatewayAccountDao gatewayAccountDao;
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(GatewayAccountService.class);
+
+    private GatewayAccountParser gatewayAccountParser;
+
+    public GatewayAccountService(GatewayAccountDao gatewayAccountDao, GatewayAccountParser gatewayAccountParser) {
+        this.gatewayAccountDao = gatewayAccountDao;
+        this.gatewayAccountParser = gatewayAccountParser;
+    }
+
+    public GatewayAccount getGatewayAccount(String accountExternalId) {
+        return gatewayAccountDao
+                .findByExternalId(accountExternalId)
+                .orElseThrow(() -> new GatewayAccountNotFoundException(accountExternalId));
+    }
+
+    public List<GatewayAccount> getAllGatewayAccounts() {
+        return gatewayAccountDao.findAll();
+    }
+
+    public GatewayAccount create(Map<String, String> createGatewayAccountRequest) {
+        GatewayAccount gatewayAccount = gatewayAccountParser.parse(createGatewayAccountRequest);
+        Long id = gatewayAccountDao.insert(gatewayAccount);
+        gatewayAccount.setId(id);
+        LOGGER.info("Created Gateway Account with id {}", id);
+        return gatewayAccount;
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResource.java
@@ -23,7 +23,7 @@ public class ConfirmPaymentResource {
 
     @POST
     @Path("/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/confirm")
-    public Response confirm(@PathParam("accountId") Long accountId, @PathParam("paymentRequestExternalId") String paymentRequestId) {
+    public Response confirm(@PathParam("accountId") String accountExternalId, @PathParam("paymentRequestExternalId") String paymentRequestId) {
         logger.info("Confirming payment - {}", paymentRequestId);
         paymentConfirmService.confirm(paymentRequestId);
         return noContent().build();

--- a/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
@@ -37,11 +37,11 @@ public class PayerResource {
     @Path(PAYERS_API_PATH)
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    public Response createPayer(@PathParam("accountId") Long accountId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, Map<String, String> createPayerRequest, @Context UriInfo uriInfo) {
+    public Response createPayer(@PathParam("accountId") String accountExternalId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, Map<String, String> createPayerRequest, @Context UriInfo uriInfo) {
         createPayerValidator.validate(paymentRequestExternalId, createPayerRequest);
         LOGGER.info("Create new payer request received for payment request {} ", paymentRequestExternalId);
         CreatePayerResponse createPayerResponse = CreatePayerResponse.from(payerService.create(paymentRequestExternalId, createPayerRequest));
-        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, String.valueOf(accountId), paymentRequestExternalId, createPayerResponse.getPayerExternalId());
+        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, accountExternalId, paymentRequestExternalId, createPayerResponse.getPayerExternalId());
         return Response.created(newPayerLocation).entity(createPayerResponse).build();
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
@@ -28,16 +28,16 @@ public class PaymentRequestResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(PaymentRequestResource.class);
     private final PaymentRequestService paymentRequestService;
     private final PaymentRequestValidator paymentRequestValidator = new PaymentRequestValidator();
-    private final String ACCOUNT_ID = "accountId";
 
     public PaymentRequestResource(PaymentRequestService paymentRequestService) {
         this.paymentRequestService = paymentRequestService;
     }
 
+
     @GET
     @Path(CHARGE_API_PATH)
     @Produces(APPLICATION_JSON)
-    public Response getCharge(@PathParam(ACCOUNT_ID) Long accountId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, @Context UriInfo uriInfo) {
+    public Response getCharge(@PathParam("accountId") Long accountId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, @Context UriInfo uriInfo) {
         PaymentRequestResponse response = paymentRequestService.getPaymentWithExternalId(paymentRequestExternalId, uriInfo);
         return Response.ok(response).build();
     }
@@ -45,7 +45,7 @@ public class PaymentRequestResource {
     @POST
     @Path(CHARGES_API_PATH)
     @Produces(APPLICATION_JSON)
-    public Response createNewPaymentRequest(@PathParam(ACCOUNT_ID) Long accountId, Map<String, String> paymentRequest, @Context UriInfo uriInfo) {
+    public Response createNewPaymentRequest(@PathParam("accountId") Long accountId, Map<String, String> paymentRequest, @Context UriInfo uriInfo) {
         paymentRequestValidator.validate(paymentRequest);
         LOGGER.info("Creating new payment request - {}", paymentRequest.toString());
         PaymentRequestResponse response = paymentRequestService.createCharge(paymentRequest, accountId, uriInfo);

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
@@ -37,18 +37,18 @@ public class PaymentRequestResource {
     @GET
     @Path(CHARGE_API_PATH)
     @Produces(APPLICATION_JSON)
-    public Response getCharge(@PathParam("accountId") Long accountId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, @Context UriInfo uriInfo) {
-        PaymentRequestResponse response = paymentRequestService.getPaymentWithExternalId(paymentRequestExternalId, uriInfo);
+    public Response getCharge(@PathParam("accountId") String accountExternalId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, @Context UriInfo uriInfo) {
+        PaymentRequestResponse response = paymentRequestService.getPaymentWithExternalId(accountExternalId, paymentRequestExternalId, uriInfo);
         return Response.ok(response).build();
     }
 
     @POST
     @Path(CHARGES_API_PATH)
     @Produces(APPLICATION_JSON)
-    public Response createNewPaymentRequest(@PathParam("accountId") Long accountId, Map<String, String> paymentRequest, @Context UriInfo uriInfo) {
+    public Response createNewPaymentRequest(@PathParam("accountId") String accountExternalId, Map<String, String> paymentRequest, @Context UriInfo uriInfo) {
         paymentRequestValidator.validate(paymentRequest);
         LOGGER.info("Creating new payment request - {}", paymentRequest.toString());
-        PaymentRequestResponse response = paymentRequestService.createCharge(paymentRequest, accountId, uriInfo);
+        PaymentRequestResponse response = paymentRequestService.createCharge(paymentRequest, accountExternalId, uriInfo);
         return created(response.getLink("self")).entity(response).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
 import uk.gov.pay.directdebit.app.config.LinksConfig;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
+import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountNotFoundException;
 import uk.gov.pay.directdebit.payments.api.PaymentRequestResponse;
 import uk.gov.pay.directdebit.payments.dao.PaymentRequestDao;
 import uk.gov.pay.directdebit.payments.exception.PaymentRequestNotFoundException;
@@ -21,8 +23,9 @@ import java.util.Map;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
-import static uk.gov.pay.directdebit.common.util.URIBuilder.*;
+import static uk.gov.pay.directdebit.common.util.URIBuilder.createLink;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.nextUrl;
+import static uk.gov.pay.directdebit.common.util.URIBuilder.selfUriFor;
 import static uk.gov.pay.directdebit.payments.resources.PaymentRequestResource.CHARGE_API_PATH;
 
 public class PaymentRequestService {
@@ -32,11 +35,13 @@ public class PaymentRequestService {
     private final PaymentRequestDao paymentRequestDao;
     private final TokenService tokenService;
     private final TransactionService transactionService;
+    private final GatewayAccountDao gatewayAccountDao;
 
-    public PaymentRequestService(DirectDebitConfig config, PaymentRequestDao paymentRequestDao, TokenService tokenService, TransactionService transactionService) {
+    public PaymentRequestService(DirectDebitConfig config, PaymentRequestDao paymentRequestDao, TokenService tokenService, TransactionService transactionService, GatewayAccountDao gatewayAccountDao) {
         this.paymentRequestDao = paymentRequestDao;
         this.tokenService = tokenService;
         this.transactionService = transactionService;
+        this.gatewayAccountDao = gatewayAccountDao;
         this.linksConfig = config.getLinks();
     }
 
@@ -68,21 +73,26 @@ public class PaymentRequestService {
     }
 
     public PaymentRequestResponse createCharge(Map<String, String> paymentRequestMap, Long accountId, UriInfo uriInfo) {
-        //todo when we check the account id, return  notFoundResponse("Unknown gateway account: " + accountId)) if not found
-        PaymentRequest paymentRequest = new PaymentRequest(new Long(paymentRequestMap.get("amount")),
-                paymentRequestMap.get("return_url"),
-                accountId,
-                paymentRequestMap.get("description"),
-                paymentRequestMap.get("reference"));
-        LOGGER.info("Creating payment request with external id {}", paymentRequest.getExternalId());
-        Long id = paymentRequestDao.insert(paymentRequest);
-        paymentRequest.setId(id);
-        Transaction createdTransaction = transactionService.createChargeFor(paymentRequest);
-        return populateResponseWith(paymentRequest, createdTransaction, uriInfo);
+        return gatewayAccountDao.findById(accountId)
+                .map(gatewayAccount -> {
+                    PaymentRequest paymentRequest = new PaymentRequest(new Long(paymentRequestMap.get("amount")),
+                            paymentRequestMap.get("return_url"),
+                            accountId,
+                            paymentRequestMap.get("description"),
+                            paymentRequestMap.get("reference"));
+                    LOGGER.info("Creating payment request with external id {}", paymentRequest.getExternalId());
+                    Long id = paymentRequestDao.insert(paymentRequest);
+                    paymentRequest.setId(id);
+                    Transaction createdTransaction = transactionService.createChargeFor(paymentRequest);
+                    return populateResponseWith(paymentRequest, createdTransaction, uriInfo);
+                })
+                .orElseThrow(() -> {
+                    LOGGER.error("Gateway account with id {} not found", accountId);
+                    return new GatewayAccountNotFoundException(String.valueOf(accountId));
+                });
     }
 
 
-    //todo refactor this to get the transaction immediately and put the gateway account id there
     public PaymentRequestResponse getPaymentWithExternalId(String paymentExternalId, UriInfo uriInfo) {
         return paymentRequestDao
                 .findByExternalId(paymentExternalId)

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountValidatorTest.java
@@ -1,0 +1,172 @@
+package uk.gov.pay.directdebit.gatewayaccounts.api;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.directdebit.common.exception.validation.InvalidFieldsException;
+import uk.gov.pay.directdebit.common.exception.validation.InvalidSizeFieldsException;
+import uk.gov.pay.directdebit.common.exception.validation.MissingMandatoryFieldsException;
+import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CreateGatewayAccountValidatorTest {
+
+    private CreateGatewayAccountValidator createGatewayAccountValidator = new CreateGatewayAccountValidator();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldNotThrowExceptionIfRequestIsValid() {
+        Map<String, String> request = generateValidRequest();
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowMissingMandatoryFieldsExceptionIfMissingRequiredFields() {
+        Map<String, String> request = new HashMap<>();
+        thrown.expect(MissingMandatoryFieldsException.class);
+        thrown.expectMessage("Field(s) missing: [" +
+                "payment_provider, " +
+                "service_name, " +
+                "type" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowMissingMandatoryFieldsExceptionIfPaymentProviderFieldIsMissing() {
+        Map<String, String> request = generateValidRequest();
+        request.remove("payment_provider");
+        thrown.expect(MissingMandatoryFieldsException.class);
+        thrown.expectMessage("Field(s) missing: [" +
+                "payment_provider" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidFieldsExceptionIfPaymentProviderFieldIsEmptyString() {
+        Map<String, String> request = generateValidRequest();
+        request.put("payment_provider", "");
+        thrown.expect(InvalidFieldsException.class);
+        thrown.expectMessage("Field(s) are invalid: [" +
+                "payment_provider" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidFieldsExceptionIfPaymentProviderFieldIsNull() {
+        Map<String, String> request = generateValidRequest();
+        request.put("payment_provider", null);
+        thrown.expect(InvalidFieldsException.class);
+        thrown.expectMessage("Field(s) are invalid: [" +
+                "payment_provider" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowMissingMandatoryFieldsExceptionIfServiceNameFieldIsMissing() {
+        Map<String, String> request = generateValidRequest();
+        request.remove("service_name");
+        thrown.expect(MissingMandatoryFieldsException.class);
+        thrown.expectMessage("Field(s) missing: [" +
+                "service_name" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidSizeFieldsExceptionIfServiceNameFieldIsEmptyString() {
+        Map<String, String> request = generateValidRequest();
+        request.put("service_name", "");
+        thrown.expect(InvalidSizeFieldsException.class);
+        thrown.expectMessage("The size of a field(s) is invalid: [" +
+                "service_name" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidFieldsExceptionIfServiceNameFieldIsNull() {
+        Map<String, String> request = generateValidRequest();
+        request.put("service_name", null);
+        thrown.expect(InvalidFieldsException.class);
+        thrown.expectMessage("Field(s) are invalid: [" +
+                "service_name" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidSizeFieldsExceptionIfServiceNameFieldHasSizeAboveMaximum() {
+        Map<String, String> request = generateValidRequest();
+        request.put("service_name", RandomStringUtils.randomAlphabetic(51));
+        thrown.expect(InvalidSizeFieldsException.class);
+        thrown.expectMessage("The size of a field(s) is invalid: [" +
+                "service_name" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowMissingMandatoryFieldsExceptionIfTypeFieldIsMissing() {
+        Map<String, String> request = generateValidRequest();
+        request.remove("type");
+        thrown.expect(MissingMandatoryFieldsException.class);
+        thrown.expectMessage("Field(s) missing: [" +
+                "type" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidSizeFieldsExceptionIfTypeFieldIsEmptyString() {
+        Map<String, String> request = generateValidRequest();
+        request.put("type", "");
+        thrown.expect(InvalidFieldsException.class);
+        thrown.expectMessage("Field(s) are invalid: [" +
+                "type" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidFieldsExceptionIfTypeFieldIsNull() {
+        Map<String, String> request = generateValidRequest();
+        request.put("type", null);
+        thrown.expect(InvalidFieldsException.class);
+        thrown.expectMessage("Field(s) are invalid: [" +
+                "type" +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+        createGatewayAccountValidator.validate(request);
+    }
+
+    private Map<String, String> generateValidRequest() {
+        GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture();
+        Map<String, String> request = new HashMap<>();
+        request.put("payment_provider", gatewayAccountFixture.getPaymentProvider().toString());
+        request.put("type", gatewayAccountFixture.getType().toString());
+        request.put("service_name", gatewayAccountFixture.getServiceName());
+        request.put("description", gatewayAccountFixture.getDescription());
+        request.put("analytics_id", gatewayAccountFixture.getAnalyticsId());
+        return request;
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
@@ -1,0 +1,203 @@
+package uk.gov.pay.directdebit.gatewayaccounts.resources;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.junit.DropwizardConfig;
+import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
+import uk.gov.pay.directdebit.junit.DropwizardTestContext;
+import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
+
+import javax.ws.rs.core.Response;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.directdebit.gatewayaccounts.resources.GatewayAccountResource.GATEWAY_ACCOUNTS_API_PATH;
+import static uk.gov.pay.directdebit.gatewayaccounts.resources.GatewayAccountResource.GATEWAY_ACCOUNT_API_PATH;
+import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
+import static uk.gov.pay.directdebit.util.ResponseContainsLinkMatcher.containsLink;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
+public class GatewayAccountResourceIT {
+
+    private static final PaymentProvider PAYMENT_PROVIDER = PaymentProvider.SANDBOX;
+    private static final String SERVICE_NAME = "alex";
+    private static final String DESCRIPTION = "is awesome";
+    private static final String ANALYTICS_ID = "DD_234098_BBBLA";
+    private static final GatewayAccount.Type TYPE = GatewayAccount.Type.TEST;
+
+    private static final String EXTERNAL_ID = "osiuoisajd";
+    private static final String PAYMENT_PROVIDER_KEY = "payment_provider";
+    private static final String TYPE_KEY = "type";
+    private static final String SERVICE_NAME_KEY = "service_name";
+    private static final String DESCRIPTION_KEY = "description";
+    private static final String ANALYTICS_ID_KEY = "analytics_id";
+
+    Gson gson = new Gson();
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    private GatewayAccountFixture testGatewayAccount;
+
+    @Before
+    public void setUp() {
+        testGatewayAccount =
+                aGatewayAccountFixture()
+                        .withExternalId(EXTERNAL_ID)
+                        .withPaymentProvider(PAYMENT_PROVIDER)
+                        .withServiceName(SERVICE_NAME)
+                        .withDescription(DESCRIPTION)
+                        .withType(TYPE)
+                        .withAnalyticsId(ANALYTICS_ID)
+                        .insert(testContext.getJdbi());
+    }
+
+    @Test
+    public void shouldReturnAGatewayAccountIfItExists() {
+        String requestPath = GATEWAY_ACCOUNT_API_PATH.replace("{accountId}", testGatewayAccount.getExternalId());
+        givenSetup()
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body(PAYMENT_PROVIDER_KEY, is(PAYMENT_PROVIDER.toString()))
+                .body(TYPE_KEY, is(TYPE.toString()))
+                .body(SERVICE_NAME_KEY, is(SERVICE_NAME))
+                .body(DESCRIPTION_KEY, is(DESCRIPTION))
+                .body(ANALYTICS_ID_KEY, is(ANALYTICS_ID));
+    }
+
+    @Test
+    public void shouldReturnAGatewayAccountWithMinimalFields() {
+        GatewayAccountFixture testGatewayAccount2 = GatewayAccountFixture.aGatewayAccountFixture()
+                .withServiceName("service")
+                .withPaymentProvider(PaymentProvider.GOCARDLESS)
+                .withType(GatewayAccount.Type.LIVE)
+                .withDescription(null)
+                .withAnalyticsId(null)
+                .insert(testContext.getJdbi());
+
+        String requestPath = GATEWAY_ACCOUNT_API_PATH.replace("{accountId}", testGatewayAccount2.getExternalId());
+        givenSetup()
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body(PAYMENT_PROVIDER_KEY, is(PaymentProvider.GOCARDLESS.toString()))
+                .body(TYPE_KEY, is(GatewayAccount.Type.LIVE.toString()))
+                .body(SERVICE_NAME_KEY, is("service"))
+                .body("payment_method", is("DIRECT_DEBIT"))
+                .body("containsKey('description')", is(false))
+                .body("containsKey('analytics_id')", is(false));
+    }
+
+    private String expectedGatewayAccountLocationFor(Long accountId) {
+        return "http://localhost:" + testContext.getPort() + GATEWAY_ACCOUNT_API_PATH
+                .replace("{accountId}", accountId.toString());
+    }
+    @Test
+    public void shouldReturnAllGatewayAccounts() {
+        PaymentProvider paymentProvider2 = PaymentProvider.GOCARDLESS;
+        String serviceName2 = "silvia";
+        String description2 = "can't type and is not drunk maybe";
+        String analyticsId2 = "DD_234098_BBBLABLA";
+
+        GatewayAccountFixture testGatewayAccount2 = GatewayAccountFixture.aGatewayAccountFixture()
+                .withServiceName(serviceName2)
+                .withDescription(description2)
+                .withPaymentProvider(paymentProvider2)
+                .withAnalyticsId(analyticsId2)
+                .insert(testContext.getJdbi());
+
+        givenSetup()
+                .get(GATEWAY_ACCOUNTS_API_PATH)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("accounts", hasSize(2))
+
+                .body(format("accounts[0].%s", PAYMENT_PROVIDER_KEY), is(PAYMENT_PROVIDER.toString()))
+                .body(format("accounts[0].%s", SERVICE_NAME_KEY), is(SERVICE_NAME))
+                .body(format("accounts[0].%s", DESCRIPTION_KEY), is(DESCRIPTION))
+                .body(format("accounts[0].%s", ANALYTICS_ID_KEY), is(ANALYTICS_ID))
+                .body(format("accounts[0].%s", TYPE_KEY), is(TYPE.toString()))
+                .body("accounts[0].links", containsLink("self",
+                        "GET",
+                        expectedGatewayAccountLocationFor(testGatewayAccount.getId())))
+
+                .body(format("accounts[1].%s", PAYMENT_PROVIDER_KEY), is(paymentProvider2.toString()))
+                .body(format("accounts[1].%s", SERVICE_NAME_KEY), is(serviceName2))
+                .body(format("accounts[1].%s", DESCRIPTION_KEY), is(description2))
+                .body(format("accounts[1].%s", ANALYTICS_ID_KEY), is(analyticsId2))
+                .body(format("accounts[1].%s", TYPE_KEY), is(TYPE.toString()))
+                .body("accounts[1].links", containsLink("self",
+                        "GET",
+                        expectedGatewayAccountLocationFor(testGatewayAccount2.getId())));
+
+    }
+
+    @Test
+    public void shouldCreateAGatewayAccount() {
+        String postBody = gson.toJson(ImmutableMap.builder()
+                .put(PAYMENT_PROVIDER_KEY, PAYMENT_PROVIDER.toString())
+                .put(TYPE_KEY, TYPE.toString())
+                .put(SERVICE_NAME_KEY, SERVICE_NAME)
+                .put(DESCRIPTION_KEY, DESCRIPTION)
+                .put(ANALYTICS_ID_KEY, ANALYTICS_ID)
+                .build());
+
+        ValidatableResponse response = givenSetup()
+                .body(postBody)
+                .post(GATEWAY_ACCOUNTS_API_PATH)
+                .then()
+                .contentType(JSON)
+                .statusCode(Response.Status.CREATED.getStatusCode());
+
+        Long id = response.extract().body().jsonPath().getLong("gateway_account_id");
+        String documentLocation = expectedGatewayAccountLocationFor(id);
+
+        response
+                .header("Location", is(documentLocation))
+                .body("service_name", is(SERVICE_NAME))
+                .body("payment_provider", is(PAYMENT_PROVIDER.toString()))
+                .body("type", is(TYPE.toString()))
+                .body("description", is(DESCRIPTION))
+                .body("analytics_id", is(ANALYTICS_ID));
+    }
+
+    @Test
+    public void shouldReturnBadRequestIfValidationFails() {
+        String postBody = gson.toJson(ImmutableMap.builder()
+                .put(PAYMENT_PROVIDER_KEY, PAYMENT_PROVIDER.toString())
+                .put(TYPE_KEY, TYPE.toString())
+                .put(DESCRIPTION_KEY, DESCRIPTION)
+                .put(ANALYTICS_ID_KEY, ANALYTICS_ID)
+                .build());
+
+        givenSetup()
+                .body(postBody)
+                .post(GATEWAY_ACCOUNTS_API_PATH)
+                .then()
+                .contentType(JSON)
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .body("message", is("Field(s) missing: [service_name]"));
+    }
+
+    private RequestSpecification givenSetup() {
+        return given().port(testContext.getPort())
+                .contentType(JSON);
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
@@ -22,6 +22,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.directdebit.gatewayaccounts.resources.GatewayAccountResource.GATEWAY_ACCOUNTS_API_PATH;
 import static uk.gov.pay.directdebit.gatewayaccounts.resources.GatewayAccountResource.GATEWAY_ACCOUNT_API_PATH;
@@ -37,9 +38,10 @@ public class GatewayAccountResourceIT {
     private static final String DESCRIPTION = "is awesome";
     private static final String ANALYTICS_ID = "DD_234098_BBBLA";
     private static final GatewayAccount.Type TYPE = GatewayAccount.Type.TEST;
-
     private static final String EXTERNAL_ID = "osiuoisajd";
+
     private static final String PAYMENT_PROVIDER_KEY = "payment_provider";
+    private static final String EXTERNAL_ID_KEY = "gateway_account_external_id";
     private static final String TYPE_KEY = "type";
     private static final String SERVICE_NAME_KEY = "service_name";
     private static final String DESCRIPTION_KEY = "description";
@@ -75,6 +77,7 @@ public class GatewayAccountResourceIT {
                 .contentType(JSON)
                 .body(PAYMENT_PROVIDER_KEY, is(PAYMENT_PROVIDER.toString()))
                 .body(TYPE_KEY, is(TYPE.toString()))
+                .body(EXTERNAL_ID_KEY, is(EXTERNAL_ID))
                 .body(SERVICE_NAME_KEY, is(SERVICE_NAME))
                 .body(DESCRIPTION_KEY, is(DESCRIPTION))
                 .body(ANALYTICS_ID_KEY, is(ANALYTICS_ID));
@@ -84,6 +87,7 @@ public class GatewayAccountResourceIT {
     public void shouldReturnAGatewayAccountWithMinimalFields() {
         GatewayAccountFixture testGatewayAccount2 = GatewayAccountFixture.aGatewayAccountFixture()
                 .withServiceName("service")
+                .withExternalId("externalId")
                 .withPaymentProvider(PaymentProvider.GOCARDLESS)
                 .withType(GatewayAccount.Type.LIVE)
                 .withDescription(null)
@@ -99,6 +103,7 @@ public class GatewayAccountResourceIT {
                 .body(PAYMENT_PROVIDER_KEY, is(PaymentProvider.GOCARDLESS.toString()))
                 .body(TYPE_KEY, is(GatewayAccount.Type.LIVE.toString()))
                 .body(SERVICE_NAME_KEY, is("service"))
+                .body(EXTERNAL_ID_KEY, is("externalId"))
                 .body("payment_method", is("DIRECT_DEBIT"))
                 .body("containsKey('description')", is(false))
                 .body("containsKey('analytics_id')", is(false));
@@ -114,8 +119,10 @@ public class GatewayAccountResourceIT {
         String serviceName2 = "silvia";
         String description2 = "can't type and is not drunk maybe";
         String analyticsId2 = "DD_234098_BBBLABLA";
+        String externalId2 = "DD_234098_BBBLABLA";
 
         GatewayAccountFixture testGatewayAccount2 = GatewayAccountFixture.aGatewayAccountFixture()
+                .withExternalId(externalId2)
                 .withServiceName(serviceName2)
                 .withDescription(description2)
                 .withPaymentProvider(paymentProvider2)
@@ -133,6 +140,7 @@ public class GatewayAccountResourceIT {
                 .body(format("accounts[0].%s", SERVICE_NAME_KEY), is(SERVICE_NAME))
                 .body(format("accounts[0].%s", DESCRIPTION_KEY), is(DESCRIPTION))
                 .body(format("accounts[0].%s", ANALYTICS_ID_KEY), is(ANALYTICS_ID))
+                .body(format("accounts[0].%s", EXTERNAL_ID_KEY), is(EXTERNAL_ID))
                 .body(format("accounts[0].%s", TYPE_KEY), is(TYPE.toString()))
                 .body("accounts[0].links", containsLink("self",
                         "GET",
@@ -142,6 +150,7 @@ public class GatewayAccountResourceIT {
                 .body(format("accounts[1].%s", SERVICE_NAME_KEY), is(serviceName2))
                 .body(format("accounts[1].%s", DESCRIPTION_KEY), is(description2))
                 .body(format("accounts[1].%s", ANALYTICS_ID_KEY), is(analyticsId2))
+                .body(format("accounts[1].%s", EXTERNAL_ID_KEY), is(externalId2))
                 .body(format("accounts[1].%s", TYPE_KEY), is(TYPE.toString()))
                 .body("accounts[1].links", containsLink("self",
                         "GET",
@@ -172,6 +181,7 @@ public class GatewayAccountResourceIT {
         response
                 .header("Location", is(documentLocation))
                 .body("service_name", is(SERVICE_NAME))
+                .body("gateway_account_external_id", startsWith("DIRECT_DEBIT:"))
                 .body("payment_provider", is(PAYMENT_PROVIDER.toString()))
                 .body("type", is(TYPE.toString()))
                 .body("description", is(DESCRIPTION))

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountParserTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountParserTest.java
@@ -1,0 +1,85 @@
+package uk.gov.pay.directdebit.gatewayaccounts.services;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.directdebit.gatewayaccounts.exception.InvalidGatewayAccountTypeException;
+import uk.gov.pay.directdebit.gatewayaccounts.exception.InvalidPaymentProviderException;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class GatewayAccountParserTest {
+    private static final PaymentProvider PAYMENT_PROVIDER = PaymentProvider.SANDBOX;
+    private static final String SERVICE_NAME = "alex";
+    private static final GatewayAccount.Type TYPE = GatewayAccount.Type.TEST;
+    private static final String DESCRIPTION = "is awesome";
+    private static final String ANALYTICS_ID = "DD_234098_BBBLA";
+
+    private GatewayAccountParser parser = new GatewayAccountParser();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldCreateGatewayAccountFromFullRequest() {
+        Map<String, String> request = ImmutableMap.of(
+                "payment_provider", PAYMENT_PROVIDER.toString(),
+                "service_name", SERVICE_NAME,
+                "type", TYPE.toString(),
+                "description", DESCRIPTION,
+                "analytics_id", ANALYTICS_ID
+        );
+        GatewayAccount gatewayAccount = parser.parse(request);
+        assertThat(gatewayAccount.getPaymentProvider(), is(PAYMENT_PROVIDER));
+        assertThat(gatewayAccount.getType(), is(TYPE));
+        assertThat(gatewayAccount.getServiceName(), is(SERVICE_NAME));
+        assertThat(gatewayAccount.getAnalyticsId(), is(ANALYTICS_ID));
+        assertThat(gatewayAccount.getDescription(), is(DESCRIPTION));
+    }
+
+    @Test
+    public void shouldCreateGatewayAccountFromMinimalRequest() {
+        Map<String, String> request = ImmutableMap.of(
+                "payment_provider", PAYMENT_PROVIDER.toString(),
+                "service_name", SERVICE_NAME,
+                "type", TYPE.toString()
+        );
+        GatewayAccount gatewayAccount = parser.parse(request);
+        assertThat(gatewayAccount.getPaymentProvider(), is(PAYMENT_PROVIDER));
+        assertThat(gatewayAccount.getType(), is(TYPE));
+        assertThat(gatewayAccount.getServiceName(), is(SERVICE_NAME));
+        assertThat(gatewayAccount.getAnalyticsId(), is(nullValue()));
+        assertThat(gatewayAccount.getDescription(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldThrowIfTypeIsNotSupported() {
+        Map<String, String> request = ImmutableMap.of(
+          "payment_provider", "SANDBOX",
+          "service_name", "blabla",
+          "type", "something"
+        );
+        thrown.expect(InvalidGatewayAccountTypeException.class);
+        thrown.expectMessage("Unsupported gateway account type: something");
+        parser.parse(request);
+    }
+
+    @Test
+    public void shouldThrowIfPaymentProviderIsNotSupported() {
+        Map<String, String> request = ImmutableMap.of(
+                "payment_provider", "something",
+                "service_name", "blabla",
+                "type", "TEST"
+        );
+        thrown.expect(InvalidPaymentProviderException.class);
+        thrown.expectMessage("Unsupported payment provider: something");
+        parser.parse(request);
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java
@@ -1,0 +1,103 @@
+package uk.gov.pay.directdebit.gatewayaccounts.services;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
+import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountNotFoundException;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GatewayAccountServiceTest {
+    private static final PaymentProvider PAYMENT_PROVIDER = PaymentProvider.SANDBOX;
+    private static final String SERVICE_NAME = "alex";
+    private static final String DESCRIPTION = "is awesome";
+    private static final String ANALYTICS_ID = "DD_234098_BBBLA";
+    private static final GatewayAccount.Type TYPE = GatewayAccount.Type.TEST;
+
+    private GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
+                .withPaymentProvider(PAYMENT_PROVIDER)
+                        .withServiceName(SERVICE_NAME)
+                        .withDescription(DESCRIPTION)
+                        .withType(TYPE)
+                        .withAnalyticsId(ANALYTICS_ID);
+
+    @Mock
+    private GatewayAccountDao mockedGatewayAccountDao;
+
+    @Mock
+    private GatewayAccountParser mockedGatewayAccountParser;
+
+    private GatewayAccountService service;
+
+    private Map<String, String> createPaymentRequest = new HashMap<>();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() throws Exception {
+        service = new GatewayAccountService(mockedGatewayAccountDao, mockedGatewayAccountParser);
+    }
+
+    @Test
+    public void shouldReturnGatewayAccountIfItExists() {
+        String accountId = "10sadsadsadL";
+        when(mockedGatewayAccountDao.findByExternalId(accountId)).thenReturn(Optional.of(gatewayAccountFixture.toEntity()));
+        GatewayAccount gatewayAccount = service.getGatewayAccount(accountId);
+        assertThat(gatewayAccount.getId(), is(gatewayAccountFixture.getId()));
+        assertThat(gatewayAccount.getPaymentProvider(), is(PAYMENT_PROVIDER));
+        assertThat(gatewayAccount.getAnalyticsId(), is(ANALYTICS_ID));
+        assertThat(gatewayAccount.getDescription(), is(DESCRIPTION));
+        assertThat(gatewayAccount.getServiceName(), is(SERVICE_NAME));
+        assertThat(gatewayAccount.getType(), is(TYPE));
+    }
+
+    @Test
+    public void shouldThrowIfGatewayAccountDoesNotExist() {
+        String accountId = "10sadsadsadL";
+        when(mockedGatewayAccountDao.findByExternalId(accountId)).thenReturn(Optional.empty());
+        thrown.expect(GatewayAccountNotFoundException.class);
+        thrown.expectMessage("Unknown gateway account: 10");
+        thrown.reportMissingExceptionWithMessage("GatewayAccountNotFoundException expected");
+        service.getGatewayAccount(accountId);
+    }
+
+    @Test
+    public void shouldReturnAListOfGatewayAccounts() {
+        when(mockedGatewayAccountDao.findAll())
+                .thenReturn(Arrays.asList(gatewayAccountFixture.toEntity(),
+                        gatewayAccountFixture.toEntity(),
+                        gatewayAccountFixture.toEntity()));
+
+        List<GatewayAccount> gatewayAccounts = service.getAllGatewayAccounts();
+
+        assertThat(gatewayAccounts.size(), is(3));
+    }
+
+    @Test
+    public void shouldStoreAGatewayAccount() {
+        GatewayAccount parsedGatewayAccount = GatewayAccountFixture.aGatewayAccountFixture().toEntity();
+        when(mockedGatewayAccountParser.parse(createPaymentRequest)).thenReturn(parsedGatewayAccount);
+        service.create(createPaymentRequest);
+        verify(mockedGatewayAccountDao).insert(parsedGatewayAccount);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResourceIT.java
@@ -57,7 +57,7 @@ public class PaymentRequestResourceIT {
     @Test
     public void shouldCreateAPaymentRequest() throws Exception {
 
-        String accountId = testGatewayAccount.getId().toString();
+        String accountExternalId = testGatewayAccount.getExternalId();
         String expectedReference = "Test reference";
         String expectedDescription = "Test description";
         String returnUrl = "http://service.url/success-page/";
@@ -65,12 +65,12 @@ public class PaymentRequestResourceIT {
                 .put(JSON_AMOUNT_KEY, AMOUNT)
                 .put(JSON_REFERENCE_KEY, expectedReference)
                 .put(JSON_DESCRIPTION_KEY, expectedDescription)
-                .put(JSON_GATEWAY_ACC_KEY, accountId)
+                .put(JSON_GATEWAY_ACC_KEY, accountExternalId)
                 .put(JSON_RETURN_URL_KEY, returnUrl)
                 .build());
 
         String requestPath = CHARGES_API_PATH
-                .replace("{accountId}", accountId);
+                .replace("{accountId}", accountExternalId);
 
         ValidatableResponse response = givenSetup()
                 .body(postBody)
@@ -85,7 +85,7 @@ public class PaymentRequestResourceIT {
                 .contentType(JSON);
 
         String externalPaymentRequestId = response.extract().path(JSON_CHARGE_KEY).toString();
-        String documentLocation = expectedPaymentRequestLocationFor(accountId, externalPaymentRequestId);
+        String documentLocation = expectedPaymentRequestLocationFor(accountExternalId, externalPaymentRequestId);
         String token = testContext.getDatabaseTestHelper().getTokenByPaymentRequestExternalId(externalPaymentRequestId);
 
         String hrefNextUrl = "http://Frontend" + FRONTEND_CARD_DETAILS_URL + "/" + token;
@@ -99,7 +99,7 @@ public class PaymentRequestResourceIT {
                     put("chargeTokenId", token);
                 }}));
         String requestPath2 = CHARGE_API_PATH
-                .replace("{accountId}", accountId)
+                .replace("{accountId}", accountExternalId)
                 .replace("{paymentRequestExternalId}", externalPaymentRequestId);
 
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResourceIT.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
@@ -12,7 +13,7 @@ import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
-import uk.gov.pay.directdebit.payments.api.ExternalPaymentState;
+import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 
 import javax.ws.rs.core.Response;
@@ -43,16 +44,20 @@ public class PaymentRequestResourceIT {
     private static final String JSON_CHARGE_KEY = "charge_id";
     private static final String JSON_STATE_KEY = "state.status";
     private static final long AMOUNT = 6234L;
-    private static final String accountId = "20";
-
+    private GatewayAccountFixture testGatewayAccount;
     private Gson gson = new Gson();
 
     @DropwizardTestContext
     private TestContext testContext;
 
+    @Before
+    public void setUp() {
+        testGatewayAccount = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
+    }
     @Test
     public void shouldCreateAPaymentRequest() throws Exception {
 
+        String accountId = testGatewayAccount.getId().toString();
         String expectedReference = "Test reference";
         String expectedDescription = "Test description";
         String returnUrl = "http://service.url/success-page/";
@@ -129,6 +134,8 @@ public class PaymentRequestResourceIT {
 
     @Test
     public void shouldReturn400IfMandatoryFieldsMissing() {
+        String accountId = testGatewayAccount.getId().toString();
+
         String postBody = gson.toJson(ImmutableMap.builder()
                 .put(JSON_AMOUNT_KEY, AMOUNT)
                 .put(JSON_DESCRIPTION_KEY, "desc")
@@ -149,6 +156,8 @@ public class PaymentRequestResourceIT {
 
     @Test
     public void shouldReturn400IfFieldsInvalidSize() {
+        String accountId = testGatewayAccount.getId().toString();
+
         String postBody = gson.toJson(ImmutableMap.builder()
                 .put(JSON_AMOUNT_KEY, AMOUNT)
                 .put(JSON_REFERENCE_KEY, "reference")
@@ -170,6 +179,8 @@ public class PaymentRequestResourceIT {
 
     @Test
     public void shouldReturn400IfFieldsInvalid() {
+        String accountId = testGatewayAccount.getId().toString();
+
         String postBody = gson.toJson(ImmutableMap.builder()
                 .put(JSON_AMOUNT_KEY, 10000001)
                 .put(JSON_REFERENCE_KEY, "reference")


### PR DESCRIPTION
## WHAT
 - We are generating an *external id* for the gateway account, and assuming that scripts / self service / public auth will use that, rather than the internal id. This is needed because we now have gateway accounts in two places (cc and dd connectors), and using  internal ids will cause clashes in accounts, as the ids are generated sequentially from two different dbs.
We are going to raise a few other PRs in those microservices to handle external ids and internal ids at the same time.
- When we have to do any operation on a charge/payment request, we first check if the gateway account associated to that resource exists. If not, we throw a `GatewayAccountNotFoundException`
- When creating a gateway account, we are assuming `service_name`, `payment_provider` and `type` are mandatory.

 Note: The gateway account support is not complete: it needs a few extra endpoints (ie. a PATCH endpoint to change service name and so on). 
This will be addressed in another story, as it is not a blocker for creating API keys.

with @alexbishop1
