### PR TITLE
PP-3061 Make gateway_accounts.external_id a VARCHAR(255)

### DIFF
--- a/src/main/resources/migrations/00008_alter_table_gateway_accounts_external_id.sql
+++ b/src/main/resources/migrations/00008_alter_table_gateway_accounts_external_id.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-gateway_accounts-external_id
+ALTER TABLE gateway_accounts ALTER COLUMN external_id TYPE VARCHAR(255);
+--rollback ALTER TABLE gateway_accounts ALTER COLUMN external_id TYPE VARCHAR(26);


### PR DESCRIPTION
## WHAT
 - we want to be able to namespace external ids by prefixing them with `DIRECT_DEBIT:<token>`. We need a longer external id. Adminusers already stores gateway ids as a VARCHAR(255).