### PR TITLE
PP-3237 Sandbox webhook

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -49,6 +49,7 @@ import uk.gov.pay.directdebit.tokens.resources.SecurityTokensResource;
 import uk.gov.pay.directdebit.tokens.services.TokenService;
 import uk.gov.pay.directdebit.webhook.gocardless.exception.InvalidWebhookExceptionMapper;
 import uk.gov.pay.directdebit.webhook.gocardless.resources.WebhookGoCardlessResource;
+import uk.gov.pay.directdebit.webhook.sandbox.resources.WebhookSandboxResource;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
@@ -123,6 +124,7 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
         jdbi.registerContainerFactory(new OptionalContainerFactory());
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
         environment.jersey().register(injector.getInstance(WebhookGoCardlessResource.class));
+        environment.jersey().register(injector.getInstance(WebhookSandboxResource.class));
         environment.jersey().register(new PaymentRequestResource(paymentRequestService));
         environment.jersey().register(new SecurityTokensResource(tokenService));
         environment.jersey().register(new PayerResource(payerService));

--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -124,7 +124,7 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
         jdbi.registerContainerFactory(new OptionalContainerFactory());
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
         environment.jersey().register(injector.getInstance(WebhookGoCardlessResource.class));
-        environment.jersey().register(injector.getInstance(WebhookSandboxResource.class));
+        environment.jersey().register(new WebhookSandboxResource(transactionService));
         environment.jersey().register(new PaymentRequestResource(paymentRequestService));
         environment.jersey().register(new SecurityTokensResource(tokenService));
         environment.jersey().register(new PayerResource(payerService));

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
@@ -22,7 +22,7 @@ public class PaymentConfirmService {
     }
 
     /**
-     * Creates a mandate and updates the transaction to a success (Sandbox) so there are not pending states
+     * Creates a mandate and updates the transaction to a pending (Sandbox)
      * @param paymentExternalId
      */
     public void confirm(String paymentExternalId) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
@@ -11,10 +11,12 @@ import uk.gov.pay.directdebit.payments.dao.mapper.TransactionMapper;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
+import java.util.List;
 import java.util.Optional;
 
 @RegisterMapper(TransactionMapper.class)
 public interface TransactionDao {
+
     @SqlQuery("SELECT * FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id WHERE p.external_id = :paymentRequestExternalId")
     @SingleValueResult(Transaction.class)
     Optional<Transaction> findByPaymentRequestExternalId(@Bind("paymentRequestExternalId") String paymentRequestExternalId);
@@ -27,12 +29,14 @@ public interface TransactionDao {
     @SingleValueResult(Transaction.class)
     Optional<Transaction> findByTokenId(@Bind("tokenId") String tokenId);
 
+    @SqlQuery("SELECT * FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id WHERE t.state = :state")
+    List<Transaction> findAllByPaymentState(@Bind("state") PaymentState paymentState);
+
     @SqlUpdate("UPDATE transactions t SET state = :state WHERE t.id = :id")
     int updateState(@Bind("id") Long id, @Bind("state") PaymentState paymentState);
 
     @SqlUpdate("INSERT INTO transactions(payment_request_id, amount, type, state) VALUES (:paymentRequestId, :amount, :type, :state)")
     @GetGeneratedKeys
     Long insert(@BindBean Transaction transaction);
-
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -10,6 +10,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_CREATED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 
@@ -56,6 +57,10 @@ public class PaymentRequestEvent {
 
     public static PaymentRequestEvent mandateCreated(Long paymentRequestId) {
         return new PaymentRequestEvent(paymentRequestId, Type.MANDATE, MANDATE_CREATED);
+    }
+
+    public static PaymentRequestEvent paidOut(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAID_OUT);
     }
 
     public Long getId() {
@@ -108,7 +113,8 @@ public class PaymentRequestEvent {
         DIRECT_DEBIT_DETAILS_RECEIVED,
         PAYER_CREATED,
         DIRECT_DEBIT_DETAILS_CONFIRMED,
-        MANDATE_CREATED;
+        MANDATE_CREATED,
+        PAID_OUT;
 
         public static SupportedEvent fromString(String event) throws UnsupportedPaymentRequestEventException {
             try {

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentState.java
@@ -2,6 +2,7 @@ package uk.gov.pay.directdebit.payments.model;
 
 import uk.gov.pay.directdebit.payments.api.ExternalPaymentState;
 
+import static uk.gov.pay.directdebit.payments.api.ExternalPaymentState.EXTERNAL_PENDING;
 import static uk.gov.pay.directdebit.payments.api.ExternalPaymentState.EXTERNAL_STARTED;
 import static uk.gov.pay.directdebit.payments.api.ExternalPaymentState.EXTERNAL_SUCCESS;
 
@@ -14,6 +15,8 @@ public enum PaymentState {
 
     AWAITING_CONFIRMATION(EXTERNAL_STARTED),
     PROCESSING_DIRECT_DEBIT_PAYMENT(EXTERNAL_STARTED),
+
+    PENDING_DIRECT_DEBIT_PAYMENT(EXTERNAL_PENDING),
 
     SUCCESS(EXTERNAL_SUCCESS);
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/SandboxPaymentStatesGraph.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/SandboxPaymentStatesGraph.java
@@ -9,6 +9,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_CREATED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_CONFIRMATION;
@@ -16,6 +17,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_DIRECT
 import static uk.gov.pay.directdebit.payments.model.PaymentState.NEW;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.PROCESSING_DIRECT_DEBIT_DETAILS;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.PROCESSING_DIRECT_DEBIT_PAYMENT;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.PENDING_DIRECT_DEBIT_PAYMENT;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.SUCCESS;
 
 public class SandboxPaymentStatesGraph {
@@ -23,7 +25,7 @@ public class SandboxPaymentStatesGraph {
     private final ImmutableValueGraph<PaymentState, SupportedEvent> graphStates;
 
     private SandboxPaymentStatesGraph() {
-        this.graphStates = buildGoCardlessStatesGraph();
+        this.graphStates = buildSandboxStatesGraph();
     }
 
     public static PaymentState initialState() {
@@ -34,7 +36,7 @@ public class SandboxPaymentStatesGraph {
         return new SandboxPaymentStatesGraph();
     }
 
-    private ImmutableValueGraph<PaymentState, PaymentRequestEvent.SupportedEvent> buildGoCardlessStatesGraph() {
+    private ImmutableValueGraph<PaymentState, PaymentRequestEvent.SupportedEvent> buildSandboxStatesGraph() {
         MutableValueGraph<PaymentState, SupportedEvent> graph = ValueGraphBuilder
                 .directed()
                 .build();
@@ -45,7 +47,8 @@ public class SandboxPaymentStatesGraph {
         graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, PROCESSING_DIRECT_DEBIT_DETAILS, DIRECT_DEBIT_DETAILS_RECEIVED);
         graph.putEdgeValue(PROCESSING_DIRECT_DEBIT_DETAILS, AWAITING_CONFIRMATION, PAYER_CREATED);
         graph.putEdgeValue(AWAITING_CONFIRMATION, PROCESSING_DIRECT_DEBIT_PAYMENT, DIRECT_DEBIT_DETAILS_CONFIRMED);
-        graph.putEdgeValue(PROCESSING_DIRECT_DEBIT_PAYMENT, SUCCESS, MANDATE_CREATED);
+        graph.putEdgeValue(PROCESSING_DIRECT_DEBIT_PAYMENT, PENDING_DIRECT_DEBIT_PAYMENT, MANDATE_CREATED);
+        graph.putEdgeValue(PENDING_DIRECT_DEBIT_PAYMENT, SUCCESS, PAID_OUT);
 
         return ImmutableValueGraph.copyOf(graph);
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -10,6 +10,7 @@ import uk.gov.pay.directdebit.payments.model.Transaction;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsConfirmed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsReceived;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandateCreated;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paidOut;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payerCreated;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.tokenExchanged;
 
@@ -52,6 +53,11 @@ public class PaymentRequestEventService {
 
     public void registerMandateCreatedEventFor(Transaction charge) {
         PaymentRequestEvent event = mandateCreated(charge.getPaymentRequestId());
+        insertEventFor(charge, event);
+    }
+
+    public void registerPaidOutEventFor(Transaction charge) {
+        PaymentRequestEvent event = paidOut(charge.getPaymentRequestId());
         insertEventFor(charge, event);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -89,6 +89,12 @@ public class TransactionService {
         return newTransaction;
     }
 
+    public Transaction paidOutFor(Transaction transaction) {
+        Transaction newTransaction = updateStateFor(transaction, PaymentRequestEvent.SupportedEvent.PAID_OUT);
+        paymentRequestEventService.registerPaidOutEventFor(transaction);
+        return newTransaction;
+    }
+
     private Transaction updateStateFor(Transaction charge, SupportedEvent event) {
         PaymentState newState = getStates().getNextStateForEvent(charge.getState(),
                 event);

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -11,6 +11,7 @@ import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.SandboxPaymentStatesGraph;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
+import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.chargeCreated;
@@ -49,6 +50,10 @@ public class TransactionService {
         transaction.setId(id);
         paymentRequestEventService.insertEventFor(paymentRequest, chargeCreated(paymentRequest.getId()));
         return transaction;
+    }
+
+    public List<Transaction> findAllByPaymentState(PaymentState paymentState) {
+        return transactionDao.findAllByPaymentState(paymentState);
     }
 
     public Optional<Transaction> findChargeForToken(String token) {

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResource.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.directdebit.webhook.gocardless.resources;
 
 import com.google.inject.Inject;
-import org.slf4j.Logger;
-import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.webhook.gocardless.support.WebhookVerifier;
 
 import javax.ws.rs.HeaderParam;
@@ -14,8 +12,6 @@ import static javax.ws.rs.core.Response.Status.OK;
 
 @Path("/v1/webhooks/gocardless")
 public class WebhookGoCardlessResource {
-
-    private static final Logger LOGGER = PayLoggerFactory.getLogger(WebhookGoCardlessResource.class);
 
     private WebhookVerifier webhookVerifier;
 

--- a/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.directdebit.webhook.sandbox.resources;
+
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.OK;
+
+@Path("/v1/webhooks/sandbox")
+public class WebhookSandboxResource {
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(WebhookSandboxResource.class);
+
+    @POST
+    public Response handleWebhook() {
+        return Response.status(OK).build();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
@@ -1,21 +1,32 @@
 package uk.gov.pay.directdebit.webhook.sandbox.resources;
 
-import org.slf4j.Logger;
-import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.Transaction;
+import uk.gov.pay.directdebit.payments.services.TransactionService;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
+
+import java.util.List;
 
 import static javax.ws.rs.core.Response.Status.OK;
 
 @Path("/v1/webhooks/sandbox")
 public class WebhookSandboxResource {
 
-    private static final Logger LOGGER = PayLoggerFactory.getLogger(WebhookSandboxResource.class);
+    private final TransactionService transactionService;
+
+    public WebhookSandboxResource(TransactionService transactionService) {
+        this.transactionService = transactionService;
+    }
 
     @POST
     public Response handleWebhook() {
+        List<Transaction> pendingTransactions = transactionService.findAllByPaymentState(PaymentState.PENDING_DIRECT_DEBIT_PAYMENT);
+
+        pendingTransactions.forEach(transactionService::paidOutFor);
+
         return Response.status(OK).build();
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResourceIT.java
@@ -45,7 +45,7 @@ public class ConfirmPaymentResourceIT {
                 .statusCode(Response.Status.NO_CONTENT.getStatusCode());
 
         Map<String, Object> transaction = testContext.getDatabaseTestHelper().getTransactionById(transactionId);
-        assertThat(transaction.get("state"), is("SUCCESS"));
+        assertThat(transaction.get("state"), is("PENDING_DIRECT_DEBIT_PAYMENT"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
@@ -11,6 +11,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_CREATED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
@@ -33,6 +34,17 @@ public class PaymentRequestEventTest {
         thrown.expectMessage("Event \"blabla\" is not supported");
         thrown.reportMissingExceptionWithMessage("UnknownPaymentRequestEventException expected");
         PaymentRequestEvent.SupportedEvent.fromString("blabla");
+    }
+
+    @Test
+    public void paidOut_shouldReturnExpectedEvent() {
+
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.paidOut(paymentRequestId);
+
+        assertThat(event.getEvent(), is(PAID_OUT));
+        assertThat(event.getEventType(), is(CHARGE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResourceIT.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.directdebit.webhook.sandbox.resources;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.junit.DropwizardConfig;
+import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
+import uk.gov.pay.directdebit.junit.DropwizardTestContext;
+import uk.gov.pay.directdebit.junit.TestContext;
+
+import javax.ws.rs.core.Response;
+
+import static io.restassured.RestAssured.given;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
+public class WebhookSandboxResourceIT {
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    @Test
+    public void handleWebhook_shouldReturn200() throws Exception {
+        String requestPath = "/v1/webhooks/sandbox";
+
+        given().port(testContext.getPort())
+                .accept(APPLICATION_JSON)
+                .post(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResourceIT.java
@@ -7,11 +7,19 @@ import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 
 import javax.ws.rs.core.Response;
 
+import java.util.Map;
+
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.PENDING_DIRECT_DEBIT_PAYMENT;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
@@ -21,7 +29,12 @@ public class WebhookSandboxResourceIT {
     private TestContext testContext;
 
     @Test
-    public void handleWebhook_shouldReturn200() throws Exception {
+    public void handleWebhook_shouldChangeTheStateToSuccessAndReturn200() throws Exception {
+        PaymentRequestFixture paymentRequestFixture = PaymentRequestFixture.aPaymentRequestFixture().insert(testContext.getJdbi());
+        PayerFixture.aPayerFixture().withPaymentRequestId(paymentRequestFixture.getId()).insert(testContext.getJdbi());
+        Long transactionId = aTransactionFixture().withPaymentRequestId(paymentRequestFixture.getId())
+                .withState(PENDING_DIRECT_DEBIT_PAYMENT).insert(testContext.getJdbi()).getId();
+
         String requestPath = "/v1/webhooks/sandbox";
 
         given().port(testContext.getPort())
@@ -29,6 +42,9 @@ public class WebhookSandboxResourceIT {
                 .post(requestPath)
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode());
+
+        Map<String, Object> transaction = testContext.getDatabaseTestHelper().getTransactionById(transactionId);
+        assertThat(transaction.get("state"), is("SUCCESS"));
     }
 
 }


### PR DESCRIPTION
## WHAT

This PR adds a new `POST /v1/webhooks/sandbox` endpoint which will be used to emulate the asynchronous behaviour of the states of transactions.
Once called it will change all `PENDING_DIRECT_DEBIT_PAYMENT` state transactions to their `SUCCESS` state.

Currently, we do not differentiate between sandbox and external providers in transactions. This will be added once we integrate the external provider.

with @rauligs 

Note: to be merged once https://github.com/alphagov/pay-endtoend/pull/502 and https://github.com/alphagov/pay-scripts/pull/570 and https://github.com/alphagov/pay-stubs/pull/71 are merged