### PR TITLE
PP-2886 Check that a charge belongs to a gateway account in every resource

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResource.java
@@ -23,9 +23,9 @@ public class ConfirmPaymentResource {
 
     @POST
     @Path("/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/confirm")
-    public Response confirm(@PathParam("accountId") String accountExternalId, @PathParam("paymentRequestExternalId") String paymentRequestId) {
+    public Response confirm(@PathParam("accountId") Long accountInternalId, @PathParam("paymentRequestExternalId") String paymentRequestId) {
         logger.info("Confirming payment - {}", paymentRequestId);
-        paymentConfirmService.confirm(paymentRequestId);
+        paymentConfirmService.confirm(accountInternalId, paymentRequestId);
         return noContent().build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
@@ -25,8 +25,8 @@ public class PaymentConfirmService {
      * Creates a mandate and updates the transaction to a pending (Sandbox)
      * @param paymentExternalId
      */
-    public void confirm(String paymentExternalId) {
-        Transaction transaction = transactionService.confirmedDirectDebitDetailsFor(paymentExternalId);
+    public void confirm(Long accountId, String paymentExternalId) {
+        Transaction transaction = transactionService.confirmedDirectDebitDetailsFor(accountId, paymentExternalId);
         payerDao.findByPaymentRequestId(transaction.getPaymentRequestId())
                 .map(payer -> {
                     mandateDao.insert(new Mandate(payer.getId()));

--- a/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
@@ -37,11 +37,12 @@ public class PayerResource {
     @Path(PAYERS_API_PATH)
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    public Response createPayer(@PathParam("accountId") String accountExternalId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, Map<String, String> createPayerRequest, @Context UriInfo uriInfo) {
+    public Response createPayer(@PathParam("accountId") Long internalAccountId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, Map<String, String> createPayerRequest, @Context UriInfo uriInfo) {
         createPayerValidator.validate(paymentRequestExternalId, createPayerRequest);
         LOGGER.info("Create new payer request received for payment request {} ", paymentRequestExternalId);
-        CreatePayerResponse createPayerResponse = CreatePayerResponse.from(payerService.create(paymentRequestExternalId, createPayerRequest));
-        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, accountExternalId, paymentRequestExternalId, createPayerResponse.getPayerExternalId());
+        CreatePayerResponse createPayerResponse = CreatePayerResponse.from(payerService.create(internalAccountId, paymentRequestExternalId, createPayerRequest));
+        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, internalAccountId.toString(), paymentRequestExternalId, createPayerResponse.getPayerExternalId());
+        //need gateway name
         return Response.created(newPayerLocation).entity(createPayerResponse).build();
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
@@ -23,8 +23,8 @@ public class PayerService {
         this.payerParser = payerParser;
     }
 
-    public Payer create(String paymentRequestExternalId, Map<String, String> createPayerMap) {
-        Transaction transaction = transactionService.receiveDirectDebitDetailsFor(paymentRequestExternalId);
+    public Payer create(Long accountId, String paymentRequestExternalId, Map<String, String> createPayerMap) {
+        Transaction transaction = transactionService.receiveDirectDebitDetailsFor(accountId, paymentRequestExternalId);
         Payer payer = payerParser.parse(createPayerMap, transaction);
         Long id = payerDao.insert(payer);
         payer.setId(id);

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
@@ -20,9 +20,9 @@ public interface PaymentRequestDao {
     @SingleValueResult(PaymentRequest.class)
     Optional<PaymentRequest> findById(@Bind("id") Long id);
 
-    @SqlQuery("SELECT * FROM payment_requests p WHERE p.external_id = :externalId")
+    @SqlQuery("SELECT * FROM payment_requests p JOIN gateway_accounts g ON p.gateway_account_id = g.id WHERE p.external_id = :externalId AND g.external_id = :accountExternalId" )
     @SingleValueResult(PaymentRequest.class)
-    Optional<PaymentRequest> findByExternalId(@Bind("externalId") String externalId);
+    Optional<PaymentRequest> findByExternalIdAndAccountExternalId(@Bind("externalId") String externalId, @Bind("accountExternalId") String accountExternalId);
 
     @SqlUpdate("INSERT INTO payment_requests(external_id, gateway_account_id, amount, reference, description, return_url, created_date) VALUES (:externalId, :gatewayAccountId, :amount, :reference, :description, :returnUrl, :createdDate)")
     @GetGeneratedKeys

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
@@ -17,9 +17,9 @@ import java.util.Optional;
 @RegisterMapper(TransactionMapper.class)
 public interface TransactionDao {
 
-    @SqlQuery("SELECT * FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id WHERE p.external_id = :paymentRequestExternalId")
+    @SqlQuery("SELECT * FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id WHERE p.external_id = :paymentRequestExternalId AND p.gateway_account_id = :accountId")
     @SingleValueResult(Transaction.class)
-    Optional<Transaction> findByPaymentRequestExternalId(@Bind("paymentRequestExternalId") String paymentRequestExternalId);
+    Optional<Transaction> findByPaymentRequestExternalIdAndAccountId(@Bind("paymentRequestExternalId") String paymentRequestExternalId, @Bind("accountId") Long accountId);
 
     @SqlQuery("SELECT * FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id WHERE t.payment_request_id = :paymentRequestId")
     @SingleValueResult(Transaction.class)

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/PaymentRequestNotFoundException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/PaymentRequestNotFoundException.java
@@ -6,7 +6,7 @@ import static java.lang.String.format;
 
 public class PaymentRequestNotFoundException extends NotFoundException {
 
-    public PaymentRequestNotFoundException(String paymentRequestExternalId) {
-        super(format("No payment request found with id: %s", paymentRequestExternalId));
+    public PaymentRequestNotFoundException(String paymentRequestExternalId, String accountExternalId) {
+        super(format("No payment request found with id: %s for gateway account with external id: %s", paymentRequestExternalId, accountExternalId));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
@@ -95,12 +95,12 @@ public class PaymentRequestService {
 
     public PaymentRequestResponse getPaymentWithExternalId(String accountExternalId, String paymentExternalId, UriInfo uriInfo) {
         return paymentRequestDao
-                .findByExternalId(paymentExternalId)
+                .findByExternalIdAndAccountExternalId(paymentExternalId, accountExternalId)
                 .map(paymentRequest ->  {
-                    Transaction transaction = transactionService.findChargeForExternalId(paymentExternalId);
+                    Transaction transaction = transactionService.findChargeForExternalIdAndGatewayAccountId(paymentExternalId, paymentRequest.getGatewayAccountId());
                     return populateResponseWith(paymentRequest, accountExternalId, transaction, uriInfo);
                 })
-                .orElseThrow(() -> new PaymentRequestNotFoundException(paymentExternalId));
+                .orElseThrow(() -> new PaymentRequestNotFoundException(paymentExternalId, accountExternalId));
     }
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -28,10 +28,10 @@ public class TransactionService {
         this.transactionDao = transactionDao;
     }
 
-    Transaction findChargeForExternalId(String paymentRequestExternalId) {
-        Transaction transaction = transactionDao.findByPaymentRequestExternalId(paymentRequestExternalId)
+    Transaction findChargeForExternalIdAndGatewayAccountId(String paymentRequestExternalId, Long accountId) {
+        Transaction transaction = transactionDao.findByPaymentRequestExternalIdAndAccountId(paymentRequestExternalId, accountId)
                 .orElseThrow(() -> new ChargeNotFoundException(paymentRequestExternalId));
-        LOGGER.info("Found charge for payment request with id: {}", paymentRequestExternalId);
+        LOGGER.info("Found charge for payment request with id: {} for gateway account id: {}", paymentRequestExternalId, accountId);
         return transaction;
     }
 
@@ -65,14 +65,14 @@ public class TransactionService {
                 });
     }
 
-    public Transaction receiveDirectDebitDetailsFor(String paymentRequestExternalId) {
-        Transaction transaction = findChargeForExternalId(paymentRequestExternalId);
+    public Transaction receiveDirectDebitDetailsFor(Long accountId, String paymentRequestExternalId) {
+        Transaction transaction = findChargeForExternalIdAndGatewayAccountId(paymentRequestExternalId, accountId);
         paymentRequestEventService.registerDirectDebitReceivedEventFor(transaction);
         return updateStateFor(transaction, PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED);
     }
 
-    public Transaction confirmedDirectDebitDetailsFor(String paymentRequestExternalId) {
-        Transaction transaction = findChargeForExternalId(paymentRequestExternalId);
+    public Transaction confirmedDirectDebitDetailsFor(Long accountId, String paymentRequestExternalId) {
+        Transaction transaction = findChargeForExternalIdAndGatewayAccountId(paymentRequestExternalId, accountId);
         paymentRequestEventService.registerDirectDebitConfirmedEventFor(transaction);
         return updateStateFor(transaction, PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED);
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmServiceTest.java
@@ -46,10 +46,11 @@ public class PaymentConfirmServiceTest {
         String paymentRequestExternalId = "test-payment-ext-id";
         long paymentRequestId = 1L;
         Long payerId = 2L;
+        Long accountId = 6L;
         Long mandateId = 3L;
 
         Transaction transaction = aTransactionFixture().withPaymentRequestId(paymentRequestId).toEntity();
-        when(mockTransactionService.confirmedDirectDebitDetailsFor(paymentRequestExternalId))
+        when(mockTransactionService.confirmedDirectDebitDetailsFor(accountId, paymentRequestExternalId))
                 .thenReturn(transaction);
 
         when(mockPayerDao.findByPaymentRequestId(paymentRequestId))
@@ -58,7 +59,7 @@ public class PaymentConfirmServiceTest {
 
         when(mockMandateDao.insert(any(Mandate.class))).thenReturn(mandateId);
 
-        service.confirm(paymentRequestExternalId);
+        service.confirm(accountId, paymentRequestExternalId);
 
         verify(mockMandateDao)
                 .insert(argThat(mandate -> mandate.getId() == null &&
@@ -73,16 +74,17 @@ public class PaymentConfirmServiceTest {
 
         String paymentRequestExternalId = "test-payment-ext-id";
         long paymentRequestId = 1L;
+        long accountId = 2L;
 
         Transaction transaction = aTransactionFixture().withPaymentRequestId(paymentRequestId).toEntity();
-        when(mockTransactionService.confirmedDirectDebitDetailsFor(paymentRequestExternalId))
+        when(mockTransactionService.confirmedDirectDebitDetailsFor(accountId, paymentRequestExternalId))
                 .thenReturn(transaction);
 
         when(mockPayerDao.findByPaymentRequestId(paymentRequestId))
                 .thenReturn(Optional.empty());
 
         try {
-            service.confirm(paymentRequestExternalId);
+            service.confirm(accountId, paymentRequestExternalId);
             fail("Expected PayerConflictException to be thrown");
         } catch (PayerConflictException e) {
             verify(mockMandateDao, never()).insert(any(Mandate.class));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
@@ -154,9 +154,9 @@ public class PaymentRequestServiceTest {
 
     @Test
     public void getPaymentWithExternalId_shouldPopulateAResponse_ifPaymentExistsAndTransactionIsInProgress() throws URISyntaxException {
-        when(mockedPaymentRequestDao.findByExternalId(paymentRequest.getExternalId()))
+        when(mockedPaymentRequestDao.findByExternalIdAndAccountExternalId(paymentRequest.getExternalId(), gatewayAccount.getExternalId()))
                 .thenReturn(Optional.of(paymentRequest.toEntity()));
-        when(mockTransactionService.findChargeForExternalId(paymentRequest.getExternalId()))
+        when(mockTransactionService.findChargeForExternalIdAndGatewayAccountId(paymentRequest.getExternalId(), gatewayAccount.getId()))
                 .thenReturn(transaction.toEntity());
         when(uriInfo.getBaseUriBuilder())
                 .thenReturn(UriBuilder.fromUri(SERVICE_HOST));
@@ -201,8 +201,8 @@ public class PaymentRequestServiceTest {
     @Ignore("Not final states defined yet")
     public void getPaymentWithExternalId_shouldPopulateAResponse_ifPaymentExistsAndChargeIsInFinalState() throws URISyntaxException {
         transaction.withState(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS);
-        when(mockedPaymentRequestDao.findByExternalId(paymentRequest.getExternalId())).thenReturn(Optional.of(paymentRequest.toEntity()));
-        when(mockTransactionService.findChargeForExternalId(paymentRequest.getExternalId()))
+        when(mockedPaymentRequestDao.findByExternalIdAndAccountExternalId(paymentRequest.getExternalId(), gatewayAccount.getExternalId())).thenReturn(Optional.of(paymentRequest.toEntity()));
+        when(mockTransactionService.findChargeForExternalIdAndGatewayAccountId(paymentRequest.getExternalId(), gatewayAccount.getId()))
                 .thenReturn(transaction.toEntity());
         when(uriInfo.getBaseUriBuilder())
                 .thenReturn(UriBuilder.fromUri(SERVICE_HOST));
@@ -224,7 +224,7 @@ public class PaymentRequestServiceTest {
     @Test
     public void getPaymentWithExternalId_shouldThrow_ifPaymentDoesNotExist() throws URISyntaxException {
         String externalPaymentId = "not_existing";
-        when(mockedPaymentRequestDao.findByExternalId(externalPaymentId)).thenReturn(Optional.empty());
+        when(mockedPaymentRequestDao.findByExternalIdAndAccountExternalId(externalPaymentId, gatewayAccount.getExternalId())).thenReturn(Optional.empty());
         thrown.expect(PaymentRequestNotFoundException.class);
         thrown.expectMessage("No payment request found with id: " + externalPaymentId);
         thrown.reportMissingExceptionWithMessage("PaymentNotFoundException expected");


### PR DESCRIPTION
## WHAT
 - After introducing gateway accounts in dd connector, we started by validating that a gateway account exists when creating a payment request.
 It is also necessary  to check that a charge belongs to a specific gateway account before acting on it later on (e.g. retrieving it, checking all the transactions, and so on)
 - This PR introduces additional checks in all endpoints which are of the shape of `/accounts/{account_id}/someresource/{charge_id}` by making sure that the gateway account associated to the charge is the correct one
