### PR TITLE
PP-2886 Add db table for gocardless' customers

### DIFF
--- a/src/main/resources/migrations/00009_create_table_gocardless_customers.sql
+++ b/src/main/resources/migrations/00009_create_table_gocardless_customers.sql
@@ -1,0 +1,15 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-gocardless_customers
+CREATE TABLE gocardless_customers (
+    id BIGSERIAL PRIMARY KEY,
+    payer_id BIGINT NOT NULL,
+    customer_id VARCHAR(255),
+    customer_bank_account_id VARCHAR(255),
+    version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table gocardless_customers;
+
+--changeset uk.gov.pay:add_payers_gocardless_customers_fk
+ALTER TABLE gocardless_customers ADD CONSTRAINT payers_gocardless_customers_fk FOREIGN KEY (payer_id) REFERENCES payers (id);
+--rollback drop constraint payers_gocardless_customers_fk;


### PR DESCRIPTION
## WHAT
This will be used to store gocardless-specific ids, so that we don't pollute our domain model.