### PR TITLE
PP-2890 Add flow for creating mandate and payment 

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDao.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.directdebit.mandate.dao;
+
+import org.skife.jdbi.v2.sqlobject.BindBean;
+import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import uk.gov.pay.directdebit.mandate.dao.mapper.GoCardlessMandateMapper;
+import uk.gov.pay.directdebit.mandate.dao.mapper.MandateMapper;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+
+@RegisterMapper(GoCardlessMandateMapper.class)
+public interface GoCardlessMandateDao {
+
+    @SqlUpdate("INSERT INTO gocardless_mandates(mandate_id, gocardless_mandate_id) VALUES (:mandateId, :goCardlessMandateId)")
+    @GetGeneratedKeys
+    Long insert(@BindBean GoCardlessMandate mandate);
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessPaymentDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessPaymentDao.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.directdebit.mandate.dao;
+
+import org.skife.jdbi.v2.sqlobject.BindBean;
+import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import uk.gov.pay.directdebit.mandate.dao.mapper.GoCardlessPaymentMapper;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
+
+@RegisterMapper(GoCardlessPaymentMapper.class)
+public interface GoCardlessPaymentDao {
+
+    @SqlUpdate("INSERT INTO gocardless_payments(transaction_id, payment_id) VALUES (:transactionId, :paymentId)")
+    @GetGeneratedKeys
+    Long insert(@BindBean GoCardlessPayment payment);
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessMandateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessMandateMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.directdebit.mandate.dao.mapper;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class GoCardlessMandateMapper implements ResultSetMapper<GoCardlessMandate> {
+    private static final String ID_COLUMN = "id";
+    private static final String MANDATE_ID_COLUMN = "mandate_id";
+    private static final String GOCARDLESS_MANDATE_ID_COLUMN = "gocardless_mandate_id";
+
+    @Override
+    public GoCardlessMandate map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        return new GoCardlessMandate(
+                resultSet.getLong(ID_COLUMN),
+                resultSet.getLong(MANDATE_ID_COLUMN),
+                resultSet.getString(GOCARDLESS_MANDATE_ID_COLUMN));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessPaymentMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessPaymentMapper.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.directdebit.mandate.dao.mapper;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class GoCardlessPaymentMapper implements ResultSetMapper<GoCardlessPayment> {
+    private static final String ID_COLUMN = "id";
+    private static final String TRANSACTION_ID_COLUMN = "transaction_id";
+    private static final String PAYMENT_ID_COLUMN = "payment_id";
+
+    @Override
+    public GoCardlessPayment map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        return new GoCardlessPayment(
+                resultSet.getLong(ID_COLUMN),
+                resultSet.getLong(TRANSACTION_ID_COLUMN),
+                resultSet.getString(PAYMENT_ID_COLUMN));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandate.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandate.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import com.google.common.base.Objects;
+
+public class GoCardlessMandate {
+
+    private Long id;
+    private Long mandateId;
+    private String goCardlessMandateId;
+
+
+    public GoCardlessMandate(Long id, Long mandateId, String goCardlessMandateId) {
+        this.id = id;
+        this.mandateId = mandateId;
+        this.goCardlessMandateId = goCardlessMandateId;
+    }
+    public GoCardlessMandate(Long mandateId, String goCardlessMandateId) {
+        this(null, mandateId, goCardlessMandateId);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getMandateId() {
+        return mandateId;
+    }
+
+    public void setMandateId(Long mandateId) {
+        this.mandateId = mandateId;
+    }
+
+    public String getGoCardlessMandateId() {
+        return goCardlessMandateId;
+    }
+
+    public void setGoCardlessMandateId(String goCardlessMandateId) {
+        this.goCardlessMandateId = goCardlessMandateId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GoCardlessMandate that = (GoCardlessMandate) o;
+        return Objects.equal(id, that.id) &&
+                Objects.equal(mandateId, that.mandateId) &&
+                Objects.equal(goCardlessMandateId, that.goCardlessMandateId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, mandateId, goCardlessMandateId);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessPayment.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessPayment.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import com.google.common.base.Objects;
+
+public class GoCardlessPayment {
+
+    private Long id;
+    private Long transactionId;
+    private String paymentId;
+
+    public GoCardlessPayment(Long id, Long transactionId, String paymentId) {
+        this.id = id;
+        this.transactionId = transactionId;
+        this.paymentId = paymentId;
+    }
+
+    public GoCardlessPayment(Long transactionId, String paymentId) {
+        this(null, transactionId, paymentId);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(Long transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public String getPaymentId() {
+        return paymentId;
+    }
+
+    public void setPaymentId(String paymentId) {
+        this.paymentId = paymentId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GoCardlessPayment that = (GoCardlessPayment) o;
+        return Objects.equal(id, that.id) &&
+                Objects.equal(transactionId, that.transactionId) &&
+                Objects.equal(paymentId, that.paymentId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, transactionId, paymentId);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
@@ -8,16 +8,14 @@ public class Mandate {
     private Long payerId;
     private String externalId;
 
-    public Mandate(Long payerId) {
-        this.id = id;
-        this.externalId = RandomIdGenerator.newId();
-        this.payerId = payerId;
-    }
-
     public Mandate(Long id, String externalId, Long payerId) {
         this.id = id;
         this.externalId = externalId;
         this.payerId = payerId;
+    }
+
+    public Mandate(Long payerId) {
+        this(null,  RandomIdGenerator.newId(), payerId);
     }
 
     public Long getId() {

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
@@ -4,6 +4,8 @@ import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.exception.PayerConflictException;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.payers.dao.PayerDao;
+import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
+import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 
@@ -11,6 +13,31 @@ import java.util.Optional;
 
 public class PaymentConfirmService {
 
+    public static class ConfirmationDetails {
+        private Transaction transaction;
+        private Mandate mandate;
+
+        public ConfirmationDetails(Transaction transaction, Mandate mandate) {
+            this.transaction = transaction;
+            this.mandate = mandate;
+        }
+
+        public Transaction getTransaction() {
+            return transaction;
+        }
+
+        public void setTransaction(Transaction transaction) {
+            this.transaction = transaction;
+        }
+
+        public Mandate getMandate() {
+            return mandate;
+        }
+
+        public void setMandate(Mandate mandate) {
+            this.mandate = mandate;
+        }
+    }
     private final MandateDao mandateDao;
     private final PayerDao payerDao;
     private final TransactionService transactionService;
@@ -21,18 +48,24 @@ public class PaymentConfirmService {
         this.mandateDao = mandateDao;
     }
 
+
     /**
      * Creates a mandate and updates the transaction to a pending (Sandbox)
      * @param paymentExternalId
      */
-    public void confirm(Long accountId, String paymentExternalId) {
+    public ConfirmationDetails confirm(Long accountId, String paymentExternalId) {
         Transaction transaction = transactionService.confirmedDirectDebitDetailsFor(accountId, paymentExternalId);
-        payerDao.findByPaymentRequestId(transaction.getPaymentRequestId())
-                .map(payer -> {
-                    mandateDao.insert(new Mandate(payer.getId()));
-                    return Optional.of(payer.getPaymentRequestId());
-                })
+        Mandate createdMandate = payerDao.findByPaymentRequestId(transaction.getPaymentRequestId())
+                .map(this::createMandateFor)
                 .orElseThrow(() -> new PayerConflictException(String.format("Expected payment request %s to be already associated with a payer", paymentExternalId)));
         transactionService.mandateCreatedFor(transaction);
+        return new ConfirmationDetails(transaction, createdMandate);
+    }
+
+    private Mandate createMandateFor(Payer payer) {
+        Mandate mandate = new Mandate(payer.getId());
+        Long id = mandateDao.insert(mandate);
+        mandate.setId(id);
+        return mandate;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payers/dao/GoCardlessCustomerDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/dao/GoCardlessCustomerDao.java
@@ -14,9 +14,9 @@ import java.util.Optional;
 
 @RegisterMapper(GoCardlessCustomerMapper.class)
 public interface GoCardlessCustomerDao {
-    @SqlQuery("SELECT * FROM gocardless_customers g WHERE g.id = :id")
+    @SqlQuery("SELECT * FROM gocardless_customers g WHERE g.payer_id = :id")
     @SingleValueResult(GoCardlessCustomer.class)
-    Optional<GoCardlessCustomer> findById(@Bind("id") Long id);
+    Optional<GoCardlessCustomer> findByPayerId(@Bind("id") Long id);
 
     @SqlUpdate("INSERT INTO gocardless_customers(payer_id, customer_id, customer_bank_account_id) VALUES (:payerId, :customerId, :customerBankAccountId)")
     @GetGeneratedKeys

--- a/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
@@ -3,8 +3,14 @@ package uk.gov.pay.directdebit.payments.clients;
 
 import com.gocardless.resources.Customer;
 import com.gocardless.resources.CustomerBankAccount;
+import com.gocardless.resources.Payment;
+import com.gocardless.services.PaymentService;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
 import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.model.Transaction;
 
 //thin abstraction over the client provided in the SDK
 public class GoCardlessClientWrapper {
@@ -40,5 +46,31 @@ public class GoCardlessClientWrapper {
                 .execute();
         customer.setCustomerBankAccountId(goCardlessCustomerBankAccount.getId());
         return customer;
+    }
+
+    public GoCardlessMandate createMandate(String paymentRequestExternalId, Mandate mandate, GoCardlessCustomer customer) {
+        com.gocardless.resources.Mandate goCardlessMandate = goCardlessClient.mandates()
+                .create()
+                .withLinksCustomerBankAccount(customer.getCustomerBankAccountId())
+                .withIdempotencyKey(paymentRequestExternalId)
+                .execute();
+        return new GoCardlessMandate(
+                mandate.getId(),
+                goCardlessMandate.getId());
+    }
+
+    public GoCardlessPayment createPayment(String paymentRequestExternalId, GoCardlessMandate mandate, Transaction transaction) {
+        //todo check which reference we want to send
+        Payment goCardlessPayment = goCardlessClient.payments()
+                .create()
+                .withAmount(Math.toIntExact(transaction.getAmount()))
+                .withCurrency(PaymentService.PaymentCreateRequest.Currency.GBP)
+                .withReference(transaction.getPaymentRequestDescription())
+                .withLinksMandate(mandate.getGoCardlessMandateId())
+                .withIdempotencyKey(paymentRequestExternalId)
+                .execute();
+        return new GoCardlessPayment(
+                transaction.getId(),
+                goCardlessPayment.getId());
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
@@ -7,6 +7,7 @@ import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.payments.dao.mapper.TransactionMapper;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.Transaction;
@@ -30,8 +31,8 @@ public interface TransactionDao {
     @SingleValueResult(Transaction.class)
     Optional<Transaction> findByTokenId(@Bind("tokenId") String tokenId);
 
-    @SqlQuery("SELECT * FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id JOIN gateway_accounts g ON p.gateway_account_id = g.id WHERE t.state = :state")
-    List<Transaction> findAllByPaymentState(@Bind("state") PaymentState paymentState);
+    @SqlQuery("SELECT * FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id JOIN gateway_accounts g ON p.gateway_account_id = g.id WHERE t.state = :state AND g.payment_provider = :paymentProvider")
+    List<Transaction> findAllByPaymentStateAndProvider(@Bind("state") PaymentState paymentState, @Bind("paymentProvider") PaymentProvider paymentProvider);
 
     @SqlUpdate("UPDATE transactions t SET state = :state WHERE t.id = :id")
     int updateState(@Bind("id") Long id, @Bind("state") PaymentState paymentState);

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/CreateMandateFailedException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/CreateMandateFailedException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.directdebit.payments.exception;
+
+import uk.gov.pay.directdebit.common.exception.InternalServerErrorException;
+
+import static java.lang.String.format;
+
+public class CreateMandateFailedException extends InternalServerErrorException {
+
+    public CreateMandateFailedException(String paymentRequestExternalId, String mandateId) {
+        super(format("Failed to create mandate in gocardless, payment request id: %s, mandate id: %s", paymentRequestExternalId, mandateId));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/CreatePaymentFailedException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/CreatePaymentFailedException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.directdebit.payments.exception;
+
+import uk.gov.pay.directdebit.common.exception.InternalServerErrorException;
+
+import static java.lang.String.format;
+
+public class CreatePaymentFailedException extends InternalServerErrorException {
+
+    public CreatePaymentFailedException(String paymentRequestExternalId) {
+        super(format("Failed to create payment in gocardless, payment request id: %s", paymentRequestExternalId));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/CustomerNotFoundException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/CustomerNotFoundException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.directdebit.payments.exception;
+
+import uk.gov.pay.directdebit.common.exception.NotFoundException;
+
+import static java.lang.String.format;
+
+public class CustomerNotFoundException extends NotFoundException {
+
+    public CustomerNotFoundException(String paymentRequestExternalId, String mandateId) {
+        super(format("Customer not found in gocardless, payment request id: %s, mandate id: %s", paymentRequestExternalId, mandateId));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitPaymentProvider.java
@@ -8,4 +8,6 @@ import java.util.Map;
 public interface DirectDebitPaymentProvider {
 
     Payer createPayer(String paymentRequestExternalId, GatewayAccount gatewayAccount, Map<String, String> createPayerRequest);
+
+    void confirm(String paymentRequestExternalId, GatewayAccount gatewayAccount);
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
@@ -3,6 +3,12 @@ package uk.gov.pay.directdebit.payments.services;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.dao.GoCardlessMandateDao;
+import uk.gov.pay.directdebit.mandate.dao.GoCardlessPaymentDao;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.services.PaymentConfirmService;
 import uk.gov.pay.directdebit.payers.dao.GoCardlessCustomerDao;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
 import uk.gov.pay.directdebit.payers.model.Payer;
@@ -10,7 +16,11 @@ import uk.gov.pay.directdebit.payers.services.PayerService;
 import uk.gov.pay.directdebit.payments.clients.GoCardlessClientWrapper;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerBankAccountFailedException;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreateMandateFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreatePaymentFailedException;
+import uk.gov.pay.directdebit.payments.exception.CustomerNotFoundException;
 import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProvider;
+import uk.gov.pay.directdebit.payments.model.Transaction;
 
 import java.util.Map;
 
@@ -18,15 +28,23 @@ public class GoCardlessService implements DirectDebitPaymentProvider {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(GoCardlessService.class);
 
     private final PayerService payerService;
+    private final PaymentConfirmService paymentConfirmService;
     private final GoCardlessClientWrapper goCardlessClientWrapper;
     private final GoCardlessCustomerDao goCardlessCustomerDao;
-
+    private final GoCardlessMandateDao goCardlessMandateDao;
+    private final GoCardlessPaymentDao goCardlessPaymentDao;
     public GoCardlessService(PayerService payerService,
+                             PaymentConfirmService paymentConfirmService,
                              GoCardlessClientWrapper goCardlessClientWrapper,
-                             GoCardlessCustomerDao goCardlessCustomerDao) {
+                             GoCardlessCustomerDao goCardlessCustomerDao,
+                             GoCardlessPaymentDao goCardlessPaymentDao,
+                             GoCardlessMandateDao goCardlessMandateDao) {
         this.payerService = payerService;
+        this.paymentConfirmService = paymentConfirmService;
         this.goCardlessClientWrapper = goCardlessClientWrapper;
         this.goCardlessCustomerDao = goCardlessCustomerDao;
+        this.goCardlessMandateDao = goCardlessMandateDao;
+        this.goCardlessPaymentDao = goCardlessPaymentDao;
     }
 
     @Override
@@ -35,6 +53,13 @@ public class GoCardlessService implements DirectDebitPaymentProvider {
         GoCardlessCustomer customer = createCustomer(paymentRequestExternalId, payer);
         createCustomerBankAccount(paymentRequestExternalId, customer, payer, createPayerRequest);
         return payer;
+    }
+
+    @Override
+    public void confirm(String paymentRequestExternalId, GatewayAccount gatewayAccount) {
+        PaymentConfirmService.ConfirmationDetails confirmationDetails = paymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId);
+        GoCardlessMandate goCardlessMandate = createMandate(paymentRequestExternalId, confirmationDetails.getMandate());
+        createPayment(paymentRequestExternalId, confirmationDetails.getTransaction(), goCardlessMandate);
     }
 
     private GoCardlessCustomer createCustomer(String paymentRequestExternalId, Payer payer) {
@@ -73,6 +98,43 @@ public class GoCardlessService implements DirectDebitPaymentProvider {
         } catch (Exception exc) {
             LOGGER.error("Failed to create a customer bank account in gocardless, payment request id: {}, error: {}", paymentRequestExternalId, exc.getMessage());
             throw new CreateCustomerBankAccountFailedException(paymentRequestExternalId, payer.getExternalId());
+        }
+    }
+
+    private GoCardlessMandate createMandate(String paymentRequestExternalId, Mandate payMandate) {
+        GoCardlessCustomer goCardlessCustomer = goCardlessCustomerDao
+                .findByPayerId(payMandate.getPayerId())
+                .orElseThrow(() -> new CustomerNotFoundException(paymentRequestExternalId, payMandate.getExternalId()));
+        try {
+
+            LOGGER.info("Attempting to call gocardless to create a mandate, payment request id: {}", paymentRequestExternalId);
+
+            GoCardlessMandate mandate = goCardlessClientWrapper.createMandate(paymentRequestExternalId, payMandate, goCardlessCustomer);
+            LOGGER.info("Created mandate in gocardless, payment request id: {}", paymentRequestExternalId);
+
+            Long id = goCardlessMandateDao.insert(mandate);
+            mandate.setId(id);
+            return mandate;
+
+        } catch (Exception exc) {
+            LOGGER.error("Failed to create a mandate in gocardless, payment request id: {}, error: {}", paymentRequestExternalId, exc.getMessage());
+            throw new CreateMandateFailedException(paymentRequestExternalId, payMandate.getExternalId());
+        }
+    }
+
+    private String createPayment(String paymentRequestExternalId, Transaction transaction, GoCardlessMandate goCardlessMandate) {
+        try {
+            LOGGER.info("Attempting to call gocardless to create a payment, payment request id: {}", paymentRequestExternalId);
+
+            GoCardlessPayment goCardlessPayment = goCardlessClientWrapper.createPayment(paymentRequestExternalId, goCardlessMandate, transaction);
+
+            LOGGER.info("Created payment in gocardless, payment request id: {}", paymentRequestExternalId);
+
+            return goCardlessPaymentDao.insert(goCardlessPayment).toString();
+
+        } catch (Exception exc) {
+            LOGGER.error("Failed to create a customer bank account in gocardless, payment request id: {}, error: {}", paymentRequestExternalId, exc.getMessage());
+            throw new CreatePaymentFailedException(paymentRequestExternalId);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
@@ -1,6 +1,9 @@
 package uk.gov.pay.directdebit.payments.services;
 
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.services.PaymentConfirmService;
 import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payers.services.PayerService;
 import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProvider;
@@ -8,14 +11,26 @@ import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProvider;
 import java.util.Map;
 
 public class SandboxService implements DirectDebitPaymentProvider {
-    private final PayerService payerService;
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(SandboxService.class);
 
-    public SandboxService(PayerService payerService) {
+    private final PayerService payerService;
+    private final PaymentConfirmService paymentConfirmService;
+
+    public SandboxService(PayerService payerService,
+                          PaymentConfirmService paymentConfirmService) {
         this.payerService = payerService;
+        this.paymentConfirmService = paymentConfirmService;
     }
 
     @Override
     public Payer createPayer(String paymentRequestExternalId, GatewayAccount gatewayAccount, Map<String, String> createPayerRequest) {
+        LOGGER.info("Creating payer for SANDBOX, payment with id: {}", paymentRequestExternalId);
         return payerService.create(paymentRequestExternalId, gatewayAccount.getId(), createPayerRequest);
+    }
+
+    @Override
+    public void confirm(String paymentRequestExternalId, GatewayAccount gatewayAccount) {
+        LOGGER.info("Confirming payment for SANDBOX, payment with id: {}", paymentRequestExternalId);
+        paymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.payments.services;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.payments.dao.TransactionDao;
 import uk.gov.pay.directdebit.payments.exception.ChargeNotFoundException;
 import uk.gov.pay.directdebit.payments.model.PaymentRequest;
@@ -54,8 +55,8 @@ public class TransactionService {
         return transaction;
     }
 
-    public List<Transaction> findAllByPaymentState(PaymentState paymentState) {
-        return transactionDao.findAllByPaymentState(paymentState);
+    public List<Transaction> findAllByPaymentStateAndProvider(PaymentState paymentState, PaymentProvider paymentProvider) {
+        return transactionDao.findAllByPaymentStateAndProvider(paymentState, paymentProvider);
     }
 
     public Optional<Transaction> findChargeForToken(String token) {

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/config/GoCardlessFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/config/GoCardlessFactory.java
@@ -24,8 +24,12 @@ public class GoCardlessFactory extends Configuration {
     @NotNull
     private GoCardlessClient.Environment environment;
 
+    public Boolean isCallingStubs() {
+        return clientUrl != null;
+    }
+
     public GoCardlessClient buildClient() {
-        if (clientUrl != null) {
+        if (isCallingStubs()) {
             return GoCardlessClient.create(accessToken, clientUrl);
         }
         return GoCardlessClient.create(accessToken, environment);

--- a/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.webhook.sandbox.resources;
 
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
@@ -23,7 +24,7 @@ public class WebhookSandboxResource {
 
     @POST
     public Response handleWebhook() {
-        List<Transaction> pendingTransactions = transactionService.findAllByPaymentState(PaymentState.PENDING_DIRECT_DEBIT_PAYMENT);
+        List<Transaction> pendingTransactions = transactionService.findAllByPaymentStateAndProvider(PaymentState.PENDING_DIRECT_DEBIT_PAYMENT, PaymentProvider.SANDBOX);
 
         pendingTransactions.forEach(transactionService::paidOutFor);
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -29,8 +29,8 @@ graphite:
 goCardless:
   # For initial integration we will use sandbox access token.
   # When in live mode: access token should be removed from the config and we should use partner integration instead.
-  accessToken: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ACCESS_TOKEN:-change-me}
-  clientUrl: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_URL:-https://stubs.pymnt.localdomain/stub/gocardless}
+  accessToken: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ACCESS_TOKEN:-}
+  clientUrl: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_URL:-}
   webhookSecret: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_WEBHOOK_SECRET:-change-me}
   environment: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ENVIRONMENT:-sandbox}
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDaoIT.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.directdebit.mandate.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.junit.DropwizardConfig;
+import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
+import uk.gov.pay.directdebit.junit.DropwizardTestContext;
+import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
+public class GoCardlessMandateDaoIT {
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    private GoCardlessMandateDao mandateDao;
+    private MandateFixture mandateFixture;
+    @Before
+    public void setup()  {
+        mandateDao = testContext.getJdbi().onDemand(GoCardlessMandateDao.class);
+        PaymentRequestFixture paymentRequestFixture = PaymentRequestFixture.aPaymentRequestFixture().insert(testContext.getJdbi());
+        PayerFixture payerFixture = PayerFixture.aPayerFixture().withPaymentRequestId(paymentRequestFixture.getId()).insert(testContext.getJdbi());
+        mandateFixture = MandateFixture.aMandateFixture().withPayerId(payerFixture.getId()).insert(testContext.getJdbi());
+    }
+
+    @Test
+    public void shouldInsertAGoCardlessMandate() {
+        String goCardlessMandateId = "NA23434";
+        Long id = mandateDao.insert(new GoCardlessMandate(mandateFixture.getId(), goCardlessMandateId));
+        Map<String, Object> mandate = testContext.getDatabaseTestHelper().getGoCardlessMandateById(id);
+        assertThat(mandate.get("id"), is(id));
+        assertThat(mandate.get("mandate_id"), is(mandateFixture.getId()));
+        assertThat(mandate.get("gocardless_mandate_id"), is(goCardlessMandateId));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessPaymentDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessPaymentDaoIT.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.directdebit.mandate.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.junit.DropwizardConfig;
+import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
+import uk.gov.pay.directdebit.junit.DropwizardTestContext;
+import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
+public class GoCardlessPaymentDaoIT {
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    private GoCardlessPaymentDao goCardlessPaymentDao;
+
+    private TransactionFixture transactionFixture;
+    @Before
+    public void setup()  {
+        PaymentRequestFixture paymentRequestFixture = PaymentRequestFixture.aPaymentRequestFixture().insert(testContext.getJdbi());
+        transactionFixture = TransactionFixture.aTransactionFixture().withPaymentRequestId(paymentRequestFixture.getId()).insert(testContext.getJdbi());
+        goCardlessPaymentDao = testContext.getJdbi().onDemand(GoCardlessPaymentDao.class);
+    }
+
+    @Test
+    public void shouldInsertAGoCardlessMandate() {
+        String goCardlessPaymentId = "NA23434";
+        Long id = goCardlessPaymentDao.insert(new GoCardlessPayment(transactionFixture.getId(), goCardlessPaymentId));
+        Map<String, Object> goCardlessPayment = testContext.getDatabaseTestHelper().getGoCardlessPaymentById(id);
+        assertThat(goCardlessPayment.get("id"), is(id));
+        assertThat(goCardlessPayment.get("transaction_id"), is(transactionFixture.getId()));
+        assertThat(goCardlessPayment.get("payment_id"), is(goCardlessPaymentId));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -26,9 +26,6 @@ import static org.junit.Assert.assertThat;
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
 public class MandateDaoIT {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @DropwizardTestContext
     private TestContext testContext;
 
@@ -44,7 +41,6 @@ public class MandateDaoIT {
 
     @Test
     public void shouldInsertAMandate() {
-
         Long id = mandateDao.insert(new Mandate(payerId));
         Map<String, Object> mandate = testContext.getDatabaseTestHelper().getMandateById(id);
         assertThat(mandate.get("id"), is(id));

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessMandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessMandateFixture.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.directdebit.mandate.fixtures;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.pay.directdebit.common.fixtures.DbFixture;
+import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+
+public class GoCardlessMandateFixture implements DbFixture<GoCardlessMandateFixture, GoCardlessMandate> {
+
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private Long mandateId = RandomUtils.nextLong(1, 99999);
+    private String goCardlessMandateId = RandomIdGenerator.newId();
+
+    private GoCardlessMandateFixture() {
+
+    }
+
+    public static GoCardlessMandateFixture aGoCardlessMandateFixture() {
+        return new GoCardlessMandateFixture();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public GoCardlessMandateFixture setId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public Long getMandateId() {
+        return mandateId;
+    }
+
+    public GoCardlessMandateFixture withMandateId(Long mandateId) {
+        this.mandateId = mandateId;
+        return this;
+    }
+
+    public String getGoCardlessMandateId() {
+        return goCardlessMandateId;
+    }
+
+    public GoCardlessMandateFixture withGoCardlessMandateId(String goCardlessMandateId) {
+        this.goCardlessMandateId = goCardlessMandateId;
+        return this;
+    }
+
+    @Override
+    public GoCardlessMandateFixture insert(DBI jdbi) {
+        jdbi.withHandle(h ->
+                h.update(
+                        "INSERT INTO" +
+                                "    gocardless_mandates(\n" +
+                                "        id,\n" +
+                                "        mandate_id,\n" +
+                                "        gocardless_mandate_id\n" +
+                                "    )\n" +
+                                "   VALUES(?, ?, ?)\n",
+                        id,
+                        mandateId,
+                        goCardlessMandateId
+                )
+        );
+        return this;
+    }
+
+    @Override
+    public GoCardlessMandate toEntity() {
+        return new GoCardlessMandate(id, mandateId, goCardlessMandateId);
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessPaymentFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessPaymentFixture.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.directdebit.mandate.fixtures;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.pay.directdebit.common.fixtures.DbFixture;
+import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
+
+public class GoCardlessPaymentFixture implements DbFixture<GoCardlessPaymentFixture, GoCardlessPayment> {
+
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private Long transactionId = RandomUtils.nextLong(1, 99999);
+    private String paymentId = RandomIdGenerator.newId();
+
+    private GoCardlessPaymentFixture() {
+
+    }
+
+    public static GoCardlessPaymentFixture aGoCardlessPaymentFixture() {
+        return new GoCardlessPaymentFixture();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public GoCardlessPaymentFixture setId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public Long getTransactionId() {
+        return transactionId;
+    }
+
+    public GoCardlessPaymentFixture withTransactionId(Long transactionId) {
+        this.transactionId = transactionId;
+        return this;
+    }
+
+    public String getPaymentId() {
+        return paymentId;
+    }
+
+    public GoCardlessPaymentFixture withPaymentId(String paymentId) {
+        this.paymentId = paymentId;
+        return this;
+    }
+
+    @Override
+    public GoCardlessPaymentFixture insert(DBI jdbi) {
+        jdbi.withHandle(h ->
+                h.update(
+                        "INSERT INTO" +
+                                "    gocardless_payments(\n" +
+                                "        id,\n" +
+                                "        transaction_id,\n" +
+                                "        payment_id\n" +
+                                "    )\n" +
+                                "   VALUES(?, ?, ?)\n",
+                        id,
+                        transactionId,
+                        paymentId
+                )
+        );
+        return this;
+    }
+
+    @Override
+    public GoCardlessPayment toEntity() {
+        return new GoCardlessPayment(id, transactionId, paymentId);
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.directdebit.mandate.fixtures;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.pay.directdebit.common.fixtures.DbFixture;
+import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+
+public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
+
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private Long payerId = RandomUtils.nextLong(1, 99999);
+    private String externalId = RandomIdGenerator.newId();
+
+    private MandateFixture() {
+
+    }
+
+    public static MandateFixture aMandateFixture() {
+        return new MandateFixture();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public MandateFixture setId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public Long getPayerId() {
+        return payerId;
+    }
+
+    public MandateFixture withPayerId(Long payerId) {
+        this.payerId = payerId;
+        return this;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public MandateFixture withExternalId(String externalId) {
+        this.externalId = externalId;
+        return this;
+    }
+
+    @Override
+    public MandateFixture insert(DBI jdbi) {
+        jdbi.withHandle(h ->
+                h.update(
+                        "INSERT INTO" +
+                                "    mandates(\n" +
+                                "        id,\n" +
+                                "        payer_id,\n" +
+                                "        external_id\n" +
+                                "    )\n" +
+                                "   VALUES(?, ?, ?)\n",
+                        id,
+                        payerId,
+                        externalId
+                )
+        );
+        return this;
+    }
+
+    @Override
+    public Mandate toEntity() {
+        return new Mandate(id, externalId, payerId);
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResourceIT.java
@@ -1,16 +1,21 @@
 package uk.gov.pay.directdebit.mandate.resources;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.payers.fixtures.GoCardlessCustomerFixture;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+import uk.gov.pay.directdebit.util.GoCardlessStubs;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -19,8 +24,11 @@ import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.*;
+import static uk.gov.pay.directdebit.payers.fixtures.GoCardlessCustomerFixture.*;
 import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_CONFIRMATION;
+import static uk.gov.pay.directdebit.util.GoCardlessStubs.*;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
@@ -29,17 +37,51 @@ public class ConfirmPaymentResourceIT {
     @DropwizardTestContext
     private TestContext testContext;
 
+    //todo we should be able to override this in the test-it-config or else tests won't easily run in parallel. See https://payments-platform.atlassian.net/browse/PP-3374
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(10107);
+
     private GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture();
     private PaymentRequestFixture paymentRequestFixture = PaymentRequestFixture.aPaymentRequestFixture()
             .withGatewayAccountId(gatewayAccountFixture.getId());
     private TransactionFixture transactionFixture = aTransactionFixture().withPaymentRequestId(paymentRequestFixture.getId())
             .withPaymentRequestGatewayAccountId(gatewayAccountFixture.getId())
+            .withPaymentRequestDescription(paymentRequestFixture.getDescription())
             .withState(AWAITING_CONFIRMATION);
     @Test
     public void confirm_shouldCreateAMandateAndUpdateCharge() throws Exception {
         gatewayAccountFixture.insert(testContext.getJdbi());
         paymentRequestFixture.insert(testContext.getJdbi());
         transactionFixture.insert(testContext.getJdbi());
+        String paymentRequestExternalId = paymentRequestFixture.getExternalId();
+        PayerFixture.aPayerFixture().withPaymentRequestId(paymentRequestFixture.getId()).insert(testContext.getJdbi());
+
+        String requestPath = String.format("/v1/api/accounts/%s/payment-requests/%s/confirm", gatewayAccountFixture.getId().toString(), paymentRequestExternalId);
+        given().port(testContext.getPort())
+                .accept(APPLICATION_JSON)
+                .post(requestPath)
+                .then()
+                .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+
+        Map<String, Object> transaction = testContext.getDatabaseTestHelper().getTransactionById(transactionFixture.getId());
+        assertThat(transaction.get("state"), is("PENDING_DIRECT_DEBIT_PAYMENT"));
+    }
+
+    @Test
+    public void confirm_shouldCreateAMandateAndUpdateCharge_ForGoCardless() throws Exception {
+        paymentRequestFixture.insert(testContext.getJdbi());
+        PayerFixture payerFixture = PayerFixture.aPayerFixture()
+                .withPaymentRequestId(paymentRequestFixture.getId())
+                .insert(testContext.getJdbi());
+        GoCardlessCustomerFixture goCardlessCustomerFixture = aGoCardlessCustomerFixture().
+                withCustomerId("CU3498578")
+                .withPayerId(payerFixture.getId())
+                .insert(testContext.getJdbi());
+        stubCreateMandate(paymentRequestFixture.getExternalId(), goCardlessCustomerFixture);
+        stubCreatePayment(paymentRequestFixture.getExternalId(), transactionFixture);
+
+        gatewayAccountFixture.withPaymentProvider(GOCARDLESS).insert(testContext.getJdbi());
+        transactionFixture.withPaymentProvider(GOCARDLESS).insert(testContext.getJdbi());
         String paymentRequestExternalId = paymentRequestFixture.getExternalId();
         PayerFixture.aPayerFixture().withPaymentRequestId(paymentRequestFixture.getId()).insert(testContext.getJdbi());
 

--- a/src/test/java/uk/gov/pay/directdebit/payers/dao/GoCardlessCustomerDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/dao/GoCardlessCustomerDaoIT.java
@@ -59,9 +59,9 @@ public class GoCardlessCustomerDaoIT {
 
 
     @Test
-    public void shouldGetAGoCardlessCustomerById() {
+    public void shouldGetAGoCardlessCustomerByPayerId() {
         goCardlessCustomerFixture.insert(testContext.getJdbi());
-        GoCardlessCustomer goCardlessCustomer = goCardlessCustomerDao.findById(goCardlessCustomerFixture.getId()).get();
+        GoCardlessCustomer goCardlessCustomer = goCardlessCustomerDao.findByPayerId(payerFixture.getId()).get();
         assertThat(goCardlessCustomer.getId(), is(goCardlessCustomerFixture.getId()));
         assertThat(goCardlessCustomer.getPayerId(), is(payerFixture.getId()));
         assertThat(goCardlessCustomer.getCustomerId(), is(CUSTOMER_ID));
@@ -70,7 +70,7 @@ public class GoCardlessCustomerDaoIT {
 
     @Test
     public void shouldNotFindAPayerById_ifIdIsInvalid() {
-        assertThat(goCardlessCustomerDao.findById(9812L).isPresent(), is(false));
+        assertThat(goCardlessCustomerDao.findByPayerId(9812L).isPresent(), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
@@ -35,8 +35,8 @@ import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.aPa
 import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
-import static uk.gov.pay.directdebit.util.WiremockStubs.stubCreateCustomer;
-import static uk.gov.pay.directdebit.util.WiremockStubs.stubCreateCustomerBankAccount;
+import static uk.gov.pay.directdebit.util.GoCardlessStubs.stubCreateCustomer;
+import static uk.gov.pay.directdebit.util.GoCardlessStubs.stubCreateCustomerBankAccount;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
@@ -50,6 +50,7 @@ public class PayerResourceIT {
     private final static String ADDRESS_CITY_KEY = "city";
     private final static String ADDRESS_COUNTRY_KEY = "country_code";
     private final static String ADDRESS_POSTCODE_KEY = "postcode";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @DropwizardTestContext
     private TestContext testContext;
@@ -93,7 +94,7 @@ public class PayerResourceIT {
     public void shouldCreateAPayer() throws JsonProcessingException {
         testGatewayAccount.withPaymentProvider(SANDBOX).insert(testContext.getJdbi());
         insertTransactionFixtureWith(SANDBOX);
-        String postBody = new ObjectMapper().writeValueAsString(ImmutableMap.builder()
+        String postBody = OBJECT_MAPPER.writeValueAsString(ImmutableMap.builder()
                 .put(ACCOUNT_NUMBER_KEY, payerFixture.getAccountNumber())
                 .put(SORTCODE_KEY, payerFixture.getSortCode())
                 .put(NAME_KEY, payerFixture.getName())
@@ -130,7 +131,7 @@ public class PayerResourceIT {
         String requestPath = "/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/payers"
                 .replace("{accountId}", testGatewayAccount.getId().toString())
                 .replace("{paymentRequestExternalId}", testPaymentRequest.getExternalId());
-        String postBody = new ObjectMapper().writeValueAsString(ImmutableMap.builder()
+        String postBody = OBJECT_MAPPER.writeValueAsString(ImmutableMap.builder()
                 .put(ACCOUNT_NUMBER_KEY, payerFixture.getAccountNumber())
                 .put(SORTCODE_KEY, payerFixture.getSortCode())
                 .put(NAME_KEY, payerFixture.getName())
@@ -167,7 +168,7 @@ public class PayerResourceIT {
     @Test
     public void shouldReturn400IfMandatoryFieldsMissing() throws JsonProcessingException {
         testGatewayAccount.withPaymentProvider(SANDBOX).insert(testContext.getJdbi());
-        String postBody = new ObjectMapper().writeValueAsString(ImmutableMap.builder()
+        String postBody = OBJECT_MAPPER.writeValueAsString(ImmutableMap.builder()
                 .put(SORTCODE_KEY, payerFixture.getSortCode())
                 .put(NAME_KEY, payerFixture.getName())
                 .put(EMAIL_KEY, payerFixture.getEmail())
@@ -190,6 +191,4 @@ public class PayerResourceIT {
         return given().port(testContext.getPort())
                 .contentType(JSON);
     }
-
-
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -9,6 +9,15 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.dao.GoCardlessMandateDao;
+import uk.gov.pay.directdebit.mandate.dao.GoCardlessPaymentDao;
+import uk.gov.pay.directdebit.mandate.fixtures.GoCardlessMandateFixture;
+import uk.gov.pay.directdebit.mandate.fixtures.GoCardlessPaymentFixture;
+import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.services.PaymentConfirmService;
 import uk.gov.pay.directdebit.payers.dao.GoCardlessCustomerDao;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
@@ -17,14 +26,21 @@ import uk.gov.pay.directdebit.payers.services.PayerService;
 import uk.gov.pay.directdebit.payments.clients.GoCardlessClientWrapper;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerBankAccountFailedException;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreateMandateFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreatePaymentFailedException;
+import uk.gov.pay.directdebit.payments.exception.CustomerNotFoundException;
+import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
 import java.util.Map;
+import java.util.Optional;
 
+import static java.lang.String.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.directdebit.mandate.fixtures.GoCardlessMandateFixture.*;
+import static uk.gov.pay.directdebit.mandate.fixtures.GoCardlessPaymentFixture.*;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
-import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GoCardlessServiceTest {
@@ -35,8 +51,12 @@ public class GoCardlessServiceTest {
     GoCardlessClientWrapper mockedGoCardlessClientWrapper;
     @Mock
     GoCardlessCustomerDao mockedGoCardlessCustomerDao;
-
-
+    @Mock
+    GoCardlessMandateDao mockedGoCardlessMandateDao;
+    @Mock
+    GoCardlessPaymentDao mockedGoCardlessPaymentDao;
+    @Mock
+    PaymentConfirmService mockedPaymentConfirmService;
     GoCardlessCustomer goCardlessCustomer;
 
     private GoCardlessService service;
@@ -53,18 +73,25 @@ public class GoCardlessServiceTest {
 
     private Payer payer = PayerFixture.aPayerFixture()
             .withName("mr payment").toEntity();
+    private Mandate mandate = MandateFixture.aMandateFixture().withPayerId(payer.getId()).toEntity();
+    private Transaction transaction = TransactionFixture.aTransactionFixture().toEntity();
+    private GoCardlessMandate goCardlessMandate =
+            aGoCardlessMandateFixture()
+            .withMandateId(mandate.getId()).toEntity();
+    private GoCardlessPayment goCardlessPayment = aGoCardlessPaymentFixture().toEntity();
     private GatewayAccount gatewayAccount = aGatewayAccountFixture().toEntity();
 
-    private Transaction transaction = aTransactionFixture().toEntity();
+    private PaymentConfirmService.ConfirmationDetails confirmationDetails = new PaymentConfirmService.ConfirmationDetails(transaction, mandate);
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
-        service = new GoCardlessService(mockedPayerService, mockedGoCardlessClientWrapper, mockedGoCardlessCustomerDao);
+        service = new GoCardlessService(mockedPayerService, mockedPaymentConfirmService, mockedGoCardlessClientWrapper, mockedGoCardlessCustomerDao, mockedGoCardlessPaymentDao, mockedGoCardlessMandateDao);
         goCardlessCustomer = new GoCardlessCustomer(null, payer.getId(), CUSTOMER_ID, BANK_ACCOUNT_ID);
         when(mockedPayerService.create(paymentRequestExternalId, gatewayAccount.getId(), createPayerRequest)).thenReturn(payer);
         when(mockedGoCardlessClientWrapper.createCustomer(paymentRequestExternalId, payer)).thenReturn(goCardlessCustomer);
+
     }
 
     @Test
@@ -81,7 +108,7 @@ public class GoCardlessServiceTest {
         when(mockedGoCardlessClientWrapper.createCustomer(paymentRequestExternalId, payer))
                 .thenThrow(new RuntimeException("ooops"));
         thrown.expect(CreateCustomerFailedException.class);
-        thrown.expectMessage(String.format("Failed to create customer in gocardless, payment request id: %s, payer id: %s", paymentRequestExternalId, payer.getExternalId()));
+        thrown.expectMessage(format("Failed to create customer in gocardless, payment request id: %s, payer id: %s", paymentRequestExternalId, payer.getExternalId()));
         thrown.reportMissingExceptionWithMessage("CreateCustomerFailedException expected");
         service.createPayer(paymentRequestExternalId, gatewayAccount, createPayerRequest);
     }
@@ -93,8 +120,53 @@ public class GoCardlessServiceTest {
         when(mockedGoCardlessClientWrapper.createCustomerBankAccount(paymentRequestExternalId, goCardlessCustomer, payer.getName(), SORT_CODE, ACCOUNT_NUMBER))
                 .thenThrow(new RuntimeException("oops"));
         thrown.expect(CreateCustomerBankAccountFailedException.class);
-        thrown.expectMessage(String.format("Failed to create customer bank account in gocardless, payment request id: %s, payer id: %s", paymentRequestExternalId, payer.getExternalId()));
+        thrown.expectMessage(format("Failed to create customer bank account in gocardless, payment request id: %s, payer id: %s", paymentRequestExternalId, payer.getExternalId()));
         thrown.reportMissingExceptionWithMessage("CreateCustomerBankAccountFailedException expected");
         service.createPayer(paymentRequestExternalId, gatewayAccount, createPayerRequest);
+    }
+
+    @Test
+    public void shouldStoreAGoCardlessMandateAndPaymentWhenReceivingConfirmPaymentRequest() {
+        when(mockedGoCardlessCustomerDao.findByPayerId(payer.getId())).thenReturn(Optional.of(goCardlessCustomer));
+        when(mockedPaymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId)).thenReturn(confirmationDetails);
+        when(mockedGoCardlessClientWrapper.createMandate(paymentRequestExternalId, mandate, goCardlessCustomer)).thenReturn(goCardlessMandate);
+        when(mockedGoCardlessClientWrapper.createPayment(paymentRequestExternalId, goCardlessMandate, transaction)).thenReturn(goCardlessPayment);
+        service.confirm(paymentRequestExternalId, gatewayAccount);
+        verify(mockedGoCardlessMandateDao).insert(goCardlessMandate);
+        verify(mockedGoCardlessPaymentDao).insert(goCardlessPayment);
+        verify(mockedGoCardlessClientWrapper).createMandate(paymentRequestExternalId, mandate, goCardlessCustomer);
+        verify(mockedGoCardlessClientWrapper).createPayment(paymentRequestExternalId, goCardlessMandate, transaction);
+    }
+
+    @Test
+    public void shouldThrow_ifFailingToFindCustomerInGoCardless()  {
+        when(mockedGoCardlessCustomerDao.findByPayerId(payer.getId())).thenReturn(Optional.empty());
+        when(mockedPaymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId)).thenReturn(confirmationDetails);
+        thrown.expectMessage(format("Customer not found in gocardless, payment request id: %s, mandate id: %s", paymentRequestExternalId, mandate.getExternalId()));
+        thrown.reportMissingExceptionWithMessage("CustomerNotFoundException expected");
+        service.confirm(paymentRequestExternalId, gatewayAccount);
+    }
+
+    @Test
+    public void shouldThrow_ifFailingToCreateMandateInGoCardless()  {
+        when(mockedGoCardlessCustomerDao.findByPayerId(payer.getId())).thenReturn(Optional.of(goCardlessCustomer));
+        when(mockedPaymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId)).thenReturn(confirmationDetails);
+        when(mockedGoCardlessClientWrapper.createMandate(paymentRequestExternalId, mandate, goCardlessCustomer)).thenThrow(new RuntimeException("gocardless said no"));
+        thrown.expect(CreateMandateFailedException.class);
+        thrown.expectMessage(format("Failed to create mandate in gocardless, payment request id: %s, mandate id: %s", paymentRequestExternalId, mandate.getExternalId()));
+        thrown.reportMissingExceptionWithMessage("CreateMandateFailedException expected");
+        service.confirm(paymentRequestExternalId, gatewayAccount);
+    }
+
+    @Test
+    public void shouldThrow_ifFailingToCreatePaymentInGoCardless()  {
+        when(mockedGoCardlessCustomerDao.findByPayerId(payer.getId())).thenReturn(Optional.of(goCardlessCustomer));
+        when(mockedPaymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId)).thenReturn(confirmationDetails);
+        when(mockedGoCardlessClientWrapper.createMandate(paymentRequestExternalId, mandate, goCardlessCustomer)).thenReturn(goCardlessMandate);
+        when(mockedGoCardlessClientWrapper.createPayment(paymentRequestExternalId, goCardlessMandate, transaction)).thenThrow(new RuntimeException("gocardless said no"));
+        thrown.expect(CreatePaymentFailedException.class);
+        thrown.expectMessage(format("Failed to create payment in gocardless, payment request id: %s", paymentRequestExternalId));
+        thrown.reportMissingExceptionWithMessage("CreatePaymentFailedException expected");
+        service.confirm(paymentRequestExternalId, gatewayAccount);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.services.PaymentConfirmService;
 import uk.gov.pay.directdebit.payers.services.PayerService;
 
 import java.util.Map;
@@ -19,6 +20,8 @@ public class SandboxServiceTest {
 
     @Mock
     PayerService mockedPayerService;
+    @Mock
+    PaymentConfirmService mockedPaymentConfirmService;
 
     private SandboxService service;
     private String paymentRequestExternalId = "sdkfhsdkjfhjdks";
@@ -26,11 +29,11 @@ public class SandboxServiceTest {
     private GatewayAccount gatewayAccount = aGatewayAccountFixture().toEntity();
     @Before
     public void setUp() {
-        service = new SandboxService(mockedPayerService);
+        service = new SandboxService(mockedPayerService, mockedPaymentConfirmService);
     }
 
     @Test
-    public void shouldDelegateToPayerServiceWhenReceivingPayerRequest() {
+    public void shouldCreatePayerWhenReceivingPayerRequest() {
         Map<String, String> createPayerRequest = ImmutableMap.of();
         service.createPayer(paymentRequestExternalId, gatewayAccount, createPayerRequest);
         verify(mockedPayerService).create(paymentRequestExternalId, gatewayAccount.getId(), createPayerRequest);

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -103,4 +103,21 @@ public class DatabaseTestHelper {
                         .first()
         );
     }
+
+    public Map<String, Object> getGoCardlessMandateById(Long id) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT * from gocardless_mandates g WHERE g.id = :id")
+                        .bind("id", id)
+                        .first()
+        );
+    }
+    public Map<String, Object> getGoCardlessPaymentById(Long id) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT * from gocardless_payments g WHERE g.id = :id")
+                        .bind("id", id)
+                        .first()
+        );
+    }
 }

--- a/src/test/java/uk/gov/pay/directdebit/util/GoCardlessStubs.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/GoCardlessStubs.java
@@ -1,6 +1,8 @@
 package uk.gov.pay.directdebit.util;
 
+import uk.gov.pay.directdebit.payers.fixtures.GoCardlessCustomerFixture;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
+import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -14,9 +16,13 @@ import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.GOCARDLESS_
 import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.GOCARDLESS_CREATE_CUSTOMER_BANK_ACCOUNT_SUCCESS_RESPONSE;
 import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.GOCARDLESS_CREATE_CUSTOMER_REQUEST;
 import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.GOCARDLESS_CREATE_CUSTOMER_SUCCESS_RESPONSE;
+import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.GOCARDLESS_CREATE_MANDATE_REQUEST;
+import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.GOCARDLESS_CREATE_MANDATE_SUCCESS_RESPONSE;
+import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.GOCARDLESS_CREATE_PAYMENT_REQUEST;
+import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.GOCARDLESS_CREATE_PAYMENT_SUCCESS_RESPONSE;
 import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.load;
 
-public class WiremockStubs {
+public class GoCardlessStubs {
     public static void stubCreateCustomer(String paymentRequestExternalId, PayerFixture payerFixture, String goCardlessCustomerId) {
         String customerRequestExpectedBody = load(GOCARDLESS_CREATE_CUSTOMER_REQUEST)
                 .replace("{{email}}", payerFixture.getEmail())
@@ -45,6 +51,27 @@ public class WiremockStubs {
         stubCallsFor("/customer_bank_accounts", 200, paymentRequestExternalId, customerBankAccountRequestExpectedBody, customerBankAccountResponseBody);
     }
 
+    public static void stubCreateMandate(String paymentRequestExternalId, GoCardlessCustomerFixture goCardlessCustomerFixture) {
+        String mandateRequestExpectedBody = load(GOCARDLESS_CREATE_MANDATE_REQUEST)
+                .replace("{{customer_bank_account_id}}", goCardlessCustomerFixture.getCustomerBankAccountId());
+
+        String mandateResponseBody = load(GOCARDLESS_CREATE_MANDATE_SUCCESS_RESPONSE)
+                .replace("{{customer_bank_account_id}}", goCardlessCustomerFixture.getCustomerBankAccountId())
+                .replace("{{customer_id}}", goCardlessCustomerFixture.getCustomerId())
+                .replace("{{gocardless_customer_bank_account_id}}", goCardlessCustomerFixture.getCustomerBankAccountId());
+        stubCallsFor("/mandates", 200, paymentRequestExternalId, mandateRequestExpectedBody, mandateResponseBody);
+    }
+
+    public static void stubCreatePayment(String paymentRequestExternalId, TransactionFixture transactionFixture) {
+        String paymentRequestExpectedBody = load(GOCARDLESS_CREATE_PAYMENT_REQUEST)
+                .replace("{{amount}}", String.valueOf(transactionFixture.getAmount()))
+                .replace("{{reference}}", transactionFixture.getPaymentRequestDescription());
+
+        String paymentResponseBody = load(GOCARDLESS_CREATE_PAYMENT_SUCCESS_RESPONSE)
+                .replace("{{amount}}", String.valueOf(transactionFixture.getAmount()))
+                .replace("{{reference}}", transactionFixture.getPaymentRequestDescription());
+        stubCallsFor("/payments", 200, paymentRequestExternalId, paymentRequestExpectedBody, paymentResponseBody);
+    }
     private static void stubCallsFor(String url, int statusCode, String idempotencyKey, String requestBody, String responseBody) {
         stubFor(
                 post(urlPathEqualTo(url))

--- a/src/test/java/uk/gov/pay/directdebit/util/TestRequestResponsesLoader.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/TestRequestResponsesLoader.java
@@ -13,12 +13,16 @@ public class TestRequestResponsesLoader {
     private static final String REQUESTS_GOCARLDESS_BASE_NAME = REQUESTS_BASE_NAME + "/gocardless";
 
     //requests
-    public static final String GOCARDLESS_CREATE_CUSTOMER_REQUEST= REQUESTS_GOCARLDESS_BASE_NAME + "/create-customer.json";
+    public static final String GOCARDLESS_CREATE_CUSTOMER_REQUEST = REQUESTS_GOCARLDESS_BASE_NAME + "/create-customer.json";
     public static final String GOCARDLESS_CREATE_CUSTOMER_BANK_ACCOUNT_REQUEST = REQUESTS_GOCARLDESS_BASE_NAME + "/create-customer-bank-account.json";
+    public static final String GOCARDLESS_CREATE_MANDATE_REQUEST = REQUESTS_GOCARLDESS_BASE_NAME + "/create-mandate.json";
+    public static final String GOCARDLESS_CREATE_PAYMENT_REQUEST = REQUESTS_GOCARLDESS_BASE_NAME + "/create-payment.json";
 
     //responses
     public static final String GOCARDLESS_CREATE_CUSTOMER_SUCCESS_RESPONSE = RESPONSES_GOCARLDESS_BASE_NAME + "/create-customer-success.json";
     public static final String GOCARDLESS_CREATE_CUSTOMER_BANK_ACCOUNT_SUCCESS_RESPONSE = RESPONSES_GOCARLDESS_BASE_NAME + "/create-customer-bank-account-success.json";
+    public static final String GOCARDLESS_CREATE_MANDATE_SUCCESS_RESPONSE = RESPONSES_GOCARLDESS_BASE_NAME + "/create-mandate-success.json";
+    public static final String GOCARDLESS_CREATE_PAYMENT_SUCCESS_RESPONSE = RESPONSES_GOCARLDESS_BASE_NAME + "/create-payment-success.json";
 
     static public String load(String location) {
         try {

--- a/src/test/resources/it/requests/gocardless/create-mandate.json
+++ b/src/test/resources/it/requests/gocardless/create-mandate.json
@@ -1,0 +1,8 @@
+{
+  "mandates": {
+    "links": {
+      "customer_bank_account": "{{customer_bank_account_id}}"
+    }
+  }
+}
+

--- a/src/test/resources/it/requests/gocardless/create-payment.json
+++ b/src/test/resources/it/requests/gocardless/create-payment.json
@@ -1,0 +1,11 @@
+{
+  "payments": {
+    "amount": {{amount}},
+    "currency": "GBP",
+    "reference": "{{reference}}",
+    "links": {
+      "mandate": "MD123"
+    }
+  }
+}
+

--- a/src/test/resources/it/responses/gocardless/create-mandate-success.json
+++ b/src/test/resources/it/responses/gocardless/create-mandate-success.json
@@ -1,0 +1,18 @@
+{
+  "mandates": {
+    "id": "MD123",
+    "created_at": "2014-05-08T17:01:06.000Z",
+    "reference": "REF-123",
+    "status": "pending_submission",
+    "scheme": "bacs",
+    "next_possible_charge_date": "2014-11-10",
+    "metadata": {
+      "contract": "ABCD1234"
+    },
+    "links": {
+      "customer_bank_account": "{{customer_bank_account_id}}",
+      "creditor": "CR123",
+      "customer": "{{customer_id}}"
+    }
+  }
+}

--- a/src/test/resources/it/responses/gocardless/create-payment-success.json
+++ b/src/test/resources/it/responses/gocardless/create-payment-success.json
@@ -1,0 +1,17 @@
+{
+  "payments": {
+    "id": "PM123",
+    "created_at": "2014-05-08T17:01:06.000Z",
+    "charge_date": "2014-05-21",
+    "amount": {{amount}},
+    "description": null,
+    "currency": "GBP",
+    "status": "pending_submission",
+    "reference": "{{reference}}",
+    "amount_refunded": 0,
+    "links": {
+      "mandate": "MD123",
+      "creditor": "CR123"
+    }
+  }
+}


### PR DESCRIPTION
## WHAT
- After a customer and a customer bank account are created, and the user confirms the payment in frontend, we create a mandate with gocardless, followed by a payment. Both of these calls are asynchronous, this means we receive details about their status after days. Receiving webhooks is part of a different story.
- Overall, we have separate entities for our internal model (eg. `Payer`, `Mandate`, `Transaction`) and gocardless-specific ones, (eg. `Customer`, `CustomerBankAccount`). We also have "link objects" between our model and gocardless, (eg. `GoCardlessMandate`, `GoCardlessPayment`) which link our internal ids to the ones provided by GoCardless.
- We apply the 'hack' to inject a custom ssl trust store only when calling stubs, as this impacts talking to the real gocardless.