### PR TITLE
PP-2885 Add table for gocardless events

### DIFF
--- a/src/main/resources/migrations/00012_create_table_gocardless_events.sql
+++ b/src/main/resources/migrations/00012_create_table_gocardless_events.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-gocardless_events
+CREATE TABLE gocardless_events (
+    id BIGSERIAL PRIMARY KEY,
+    payment_request_events_id BIGINT,
+    event_id VARCHAR(255) NOT NULL,
+    action VARCHAR(255) NOT NULL,
+    resource_type VARCHAR(255) NOT NULL,
+    json jsonb NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'utc') NOT NULL,
+    version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table gocardless_events;
+
+--changeset uk.gov.pay:add_payment_request_events_gocardless_events_fk
+ALTER TABLE gocardless_events ADD CONSTRAINT payment_request_events_gocardless_events_fk FOREIGN KEY (payment_request_events_id) REFERENCES payment_request_events (id);
+--rollback drop constraint payment_request_events_gocardless_events_fk;


### PR DESCRIPTION

## WHAT
Adding a table to store gocardless events. This will be used to keep a record of every single webhook we receive from gocardless, even if we don't handle it.

- `payment_request_events_id` is a foreign key to the `payment_request_events` table.
  It is nullable because we are not going to always have an "internal" event, for a
  received gocardless event

## HOW 
_Steps to test or reproduce:_
