### PR TITLE
PP-3479 Make address non required

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidator.java
@@ -30,7 +30,7 @@ public class CreatePayerValidator extends ApiValidation {
                     .put(EMAIL_KEY, ApiValidation::isNotNullOrEmpty)
                     .build();
 
-    private final static String[] requiredFields = {NAME_KEY, SORTCODE_KEY, ACCOUNT_NUMBER_KEY, ADDRESS_COUNTRY_KEY, ADDRESS_LINE1_KEY, ADDRESS_CITY_KEY, ADDRESS_POSTCODE_KEY, EMAIL_KEY};
+    private final static String[] requiredFields = {NAME_KEY, SORTCODE_KEY, ACCOUNT_NUMBER_KEY, EMAIL_KEY};
 
     private final static Map<String, FieldSize> fieldSizes =
             ImmutableMap.<String, FieldSize>builder()

--- a/src/main/resources/migrations/00013_alter_table_payers_nullable_address.sql
+++ b/src/main/resources/migrations/00013_alter_table_payers_nullable_address.sql
@@ -1,0 +1,21 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-payers-address-line-1
+ALTER TABLE payers ALTER COLUMN address_line1 DROP NOT NULL;
+--rollback ALTER TABLE payers ALTER COLUMN address_line1 SET NOT NULL;
+
+--changeset uk.gov.pay:alter_table-payers-address_line2
+ALTER TABLE payers ALTER COLUMN address_line2 DROP NOT NULL;
+--rollback ALTER TABLE payers ALTER COLUMN address_line2 SET NOT NULL;
+
+--changeset uk.gov.pay:alter_table-payers-address_postcode
+ALTER TABLE payers ALTER COLUMN address_postcode DROP NOT NULL;
+--rollback ALTER TABLE payers ALTER COLUMN address_postcode SET NOT NULL;
+
+--changeset uk.gov.pay:alter_table-payers-address_city
+ALTER TABLE payers ALTER COLUMN address_city DROP NOT NULL;
+--rollback ALTER TABLE payers ALTER COLUMN address_city SET NOT NULL;
+
+--changeset uk.gov.pay:alter_table-payers-address_country
+ALTER TABLE payers ALTER COLUMN address_country DROP NOT NULL;
+--rollback ALTER TABLE payers ALTER COLUMN address_country SET NOT NULL;

--- a/src/test/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidatorTest.java
@@ -35,10 +35,6 @@ public class CreatePayerValidatorTest {
                 CreatePayerValidator.NAME_KEY + ", " +
                 CreatePayerValidator.SORTCODE_KEY + ", " +
                 CreatePayerValidator.ACCOUNT_NUMBER_KEY + ", " +
-                CreatePayerValidator.ADDRESS_COUNTRY_KEY + ", " +
-                CreatePayerValidator.ADDRESS_LINE1_KEY + ", " +
-                CreatePayerValidator.ADDRESS_CITY_KEY + ", " +
-                CreatePayerValidator.ADDRESS_POSTCODE_KEY + ", " +
                 CreatePayerValidator.EMAIL_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
@@ -228,18 +224,6 @@ public class CreatePayerValidatorTest {
     }
 
     @Test
-    public void shouldThrowMissingMandatoryFieldsExceptionIfAddressCountryFieldIsMissing() {
-        Map<String, String> request = generateValidRequest();
-        request.remove(CreatePayerValidator.ADDRESS_COUNTRY_KEY);
-        thrown.expect(MissingMandatoryFieldsException.class);
-        thrown.expectMessage("Field(s) missing: [" +
-                CreatePayerValidator.ADDRESS_COUNTRY_KEY +
-                "]");
-        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
-        createPayerValidator.validate(request);
-    }
-
-    @Test
     public void shouldThrowInvalidFieldsExceptionIfAddressCountryFieldIsEmptyString() {
         Map<String, String> request = generateValidRequest();
         request.put(CreatePayerValidator.ADDRESS_COUNTRY_KEY, "");
@@ -260,18 +244,6 @@ public class CreatePayerValidatorTest {
                 CreatePayerValidator.ADDRESS_COUNTRY_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
-        createPayerValidator.validate(request);
-    }
-
-    @Test
-    public void shouldThrowMissingMandatoryFieldsExceptionIfAddressLine1FieldIsMissing() {
-        Map<String, String> request = generateValidRequest();
-        request.remove(CreatePayerValidator.ADDRESS_LINE1_KEY);
-        thrown.expect(MissingMandatoryFieldsException.class);
-        thrown.expectMessage("Field(s) missing: [" +
-                CreatePayerValidator.ADDRESS_LINE1_KEY +
-                "]");
-        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
         createPayerValidator.validate(request);
     }
 
@@ -300,18 +272,6 @@ public class CreatePayerValidatorTest {
     }
 
     @Test
-    public void shouldThrowMissingMandatoryFieldsExceptionIfAddressCityFieldIsMissing() {
-        Map<String, String> request = generateValidRequest();
-        request.remove(CreatePayerValidator.ADDRESS_CITY_KEY);
-        thrown.expect(MissingMandatoryFieldsException.class);
-        thrown.expectMessage("Field(s) missing: [" +
-                CreatePayerValidator.ADDRESS_CITY_KEY +
-                "]");
-        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
-        createPayerValidator.validate(request);
-    }
-
-    @Test
     public void shouldThrowInvalidFieldsExceptionIfAddressCityFieldIsEmptyString() {
         Map<String, String> request = generateValidRequest();
         request.put(CreatePayerValidator.ADDRESS_CITY_KEY, "");
@@ -332,18 +292,6 @@ public class CreatePayerValidatorTest {
                 CreatePayerValidator.ADDRESS_CITY_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
-        createPayerValidator.validate(request);
-    }
-
-    @Test
-    public void shouldThrowMissingMandatoryFieldsExceptionIfAddressPostcodeFieldIsMissing() {
-        Map<String, String> request = generateValidRequest();
-        request.remove(CreatePayerValidator.ADDRESS_POSTCODE_KEY);
-        thrown.expect(MissingMandatoryFieldsException.class);
-        thrown.expectMessage("Field(s) missing: [" +
-                CreatePayerValidator.ADDRESS_POSTCODE_KEY +
-                "]");
-        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
         createPayerValidator.validate(request);
     }
 


### PR DESCRIPTION
## WHAT
- We will still optionally accept and store address if these fields appear in the request, but if they are not there they are not validated so they are nullable.

- If any adress fields ('adress_line_1', 'adress_line_2', 'postcode', 'country_code', 'city') appears in the payload is still being validated.
