### PR TITLE
PP-3238 Add happy path events handling

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.directdebit.mandate.services;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.exception.PayerConflictException;
 import uk.gov.pay.directdebit.mandate.model.ConfirmationDetails;
@@ -12,9 +14,10 @@ import uk.gov.pay.directdebit.payments.services.TransactionService;
 import javax.inject.Inject;
 
 public class PaymentConfirmService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PaymentConfirmService.class);
+    private final TransactionService transactionService;
     private final MandateDao mandateDao;
     private final PayerDao payerDao;
-    private final TransactionService transactionService;
 
     @Inject
     public PaymentConfirmService(TransactionService transactionService, PayerDao payerDao, MandateDao mandateDao) {
@@ -25,6 +28,7 @@ public class PaymentConfirmService {
 
     /**
      * Creates a mandate and updates the transaction to a pending (Sandbox)
+     *
      * @param paymentExternalId
      */
     public ConfirmationDetails confirm(Long accountId, String paymentExternalId) {
@@ -32,7 +36,7 @@ public class PaymentConfirmService {
         Mandate createdMandate = payerDao.findByPaymentRequestId(transaction.getPaymentRequestId())
                 .map(this::createMandateFor)
                 .orElseThrow(() -> new PayerConflictException(String.format("Expected payment request %s to be already associated with a payer", paymentExternalId)));
-        transactionService.mandateCreatedFor(transaction);
+        LOGGER.info("Mandate created for payment request {}", transaction.getPaymentRequestId());
         return new ConfirmationDetails(transaction, createdMandate);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDao.java
@@ -1,13 +1,18 @@
 package uk.gov.pay.directdebit.payments.dao;
 
+import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterArgumentFactory;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 import uk.gov.pay.directdebit.common.dao.DateArgumentFactory;
 import uk.gov.pay.directdebit.payments.dao.mapper.PaymentRequestEventMapper;
 import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
+
+import java.util.Optional;
 
 @RegisterMapper(PaymentRequestEventMapper.class)
 public interface PaymentRequestEventDao {
@@ -16,4 +21,8 @@ public interface PaymentRequestEventDao {
     @GetGeneratedKeys
     @RegisterArgumentFactory(DateArgumentFactory.class)
     Long insert(@BindBean PaymentRequestEvent paymentRequestevent);
+
+    @SqlQuery("SELECT * FROM payment_request_events e WHERE e.payment_request_id = :paymentRequestId and e.event_type = :eventType and e.event = :event")
+    @SingleValueResult(PaymentRequestEvent.class)
+    Optional<PaymentRequestEvent> findByPaymentRequestIdAndEvent(@Bind("paymentRequestId") Long paymentRequestId, @Bind("eventType") String eventType, @Bind("event") String event);
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDao.java
@@ -14,6 +14,8 @@ import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
 
 import java.util.Optional;
 
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.*;
+
 @RegisterMapper(PaymentRequestEventMapper.class)
 public interface PaymentRequestEventDao {
 
@@ -24,5 +26,5 @@ public interface PaymentRequestEventDao {
 
     @SqlQuery("SELECT * FROM payment_request_events e WHERE e.payment_request_id = :paymentRequestId and e.event_type = :eventType and e.event = :event")
     @SingleValueResult(PaymentRequestEvent.class)
-    Optional<PaymentRequestEvent> findByPaymentRequestIdAndEvent(@Bind("paymentRequestId") Long paymentRequestId, @Bind("eventType") String eventType, @Bind("event") String event);
+    Optional<PaymentRequestEvent> findByPaymentRequestIdAndEvent(@Bind("paymentRequestId") Long paymentRequestId, @Bind("eventType") Type eventType, @Bind("event") SupportedEvent event);
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -9,9 +9,10 @@ import java.time.ZonedDateTime;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
-import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 
 public class PaymentRequestEvent {
@@ -55,8 +56,12 @@ public class PaymentRequestEvent {
         return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, DIRECT_DEBIT_DETAILS_CONFIRMED);
     }
 
-    public static PaymentRequestEvent mandateCreated(Long paymentRequestId) {
-        return new PaymentRequestEvent(paymentRequestId, Type.MANDATE, MANDATE_CREATED);
+    public static PaymentRequestEvent paymentPending(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAYMENT_PENDING);
+    }
+
+    public static PaymentRequestEvent paymentCreated(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAYMENT_CREATED);
     }
 
     public static PaymentRequestEvent paidOut(Long paymentRequestId) {
@@ -113,7 +118,8 @@ public class PaymentRequestEvent {
         DIRECT_DEBIT_DETAILS_RECEIVED,
         PAYER_CREATED,
         DIRECT_DEBIT_DETAILS_CONFIRMED,
-        MANDATE_CREATED,
+        PAYMENT_CREATED,
+        PAYMENT_PENDING,
         PAID_OUT;
 
         public static SupportedEvent fromString(String event) throws UnsupportedPaymentRequestEventException {

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -9,6 +9,7 @@ import java.time.ZonedDateTime;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
@@ -62,6 +63,10 @@ public class PaymentRequestEvent {
 
     public static PaymentRequestEvent paymentCreated(Long paymentRequestId) {
         return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAYMENT_CREATED);
+    }
+
+    public static PaymentRequestEvent mandatePending(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, Type.MANDATE, MANDATE_PENDING);
     }
 
     public static PaymentRequestEvent paidOut(Long paymentRequestId) {
@@ -118,6 +123,7 @@ public class PaymentRequestEvent {
         DIRECT_DEBIT_DETAILS_RECEIVED,
         PAYER_CREATED,
         DIRECT_DEBIT_DETAILS_CONFIRMED,
+        MANDATE_PENDING,
         PAYMENT_CREATED,
         PAYMENT_PENDING,
         PAID_OUT;

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
@@ -8,9 +8,9 @@ import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
-import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_CONFIRMATION;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_DIRECT_DEBIT_DETAILS;
@@ -20,23 +20,23 @@ import static uk.gov.pay.directdebit.payments.model.PaymentState.PROCESSING_DIRE
 import static uk.gov.pay.directdebit.payments.model.PaymentState.PENDING_DIRECT_DEBIT_PAYMENT;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.SUCCESS;
 
-public class SandboxPaymentStatesGraph {
+public class PaymentStatesGraph {
 
     private final ImmutableValueGraph<PaymentState, SupportedEvent> graphStates;
 
-    private SandboxPaymentStatesGraph() {
-        this.graphStates = buildSandboxStatesGraph();
+    private PaymentStatesGraph() {
+        this.graphStates = buildStatesGraph();
     }
 
     public static PaymentState initialState() {
         return NEW;
     }
 
-    public static SandboxPaymentStatesGraph getStates() {
-        return new SandboxPaymentStatesGraph();
+    public static PaymentStatesGraph getStates() {
+        return new PaymentStatesGraph();
     }
 
-    private ImmutableValueGraph<PaymentState, PaymentRequestEvent.SupportedEvent> buildSandboxStatesGraph() {
+    private ImmutableValueGraph<PaymentState, PaymentRequestEvent.SupportedEvent> buildStatesGraph() {
         MutableValueGraph<PaymentState, SupportedEvent> graph = ValueGraphBuilder
                 .directed()
                 .build();
@@ -47,7 +47,7 @@ public class SandboxPaymentStatesGraph {
         graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, PROCESSING_DIRECT_DEBIT_DETAILS, DIRECT_DEBIT_DETAILS_RECEIVED);
         graph.putEdgeValue(PROCESSING_DIRECT_DEBIT_DETAILS, AWAITING_CONFIRMATION, PAYER_CREATED);
         graph.putEdgeValue(AWAITING_CONFIRMATION, PROCESSING_DIRECT_DEBIT_PAYMENT, DIRECT_DEBIT_DETAILS_CONFIRMED);
-        graph.putEdgeValue(PROCESSING_DIRECT_DEBIT_PAYMENT, PENDING_DIRECT_DEBIT_PAYMENT, MANDATE_CREATED);
+        graph.putEdgeValue(PROCESSING_DIRECT_DEBIT_PAYMENT, PENDING_DIRECT_DEBIT_PAYMENT, PAYMENT_CREATED);
         graph.putEdgeValue(PENDING_DIRECT_DEBIT_PAYMENT, SUCCESS, PAID_OUT);
 
         return ImmutableValueGraph.copyOf(graph);

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
@@ -34,6 +34,7 @@ public class GoCardlessService implements DirectDebitPaymentProvider {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(GoCardlessService.class);
 
     private final PayerService payerService;
+    private final TransactionService transactionService;
     private final PaymentConfirmService paymentConfirmService;
     private final GoCardlessClientWrapper goCardlessClientWrapper;
     private final GoCardlessCustomerDao goCardlessCustomerDao;
@@ -43,13 +44,14 @@ public class GoCardlessService implements DirectDebitPaymentProvider {
 
     @Inject
     public GoCardlessService(PayerService payerService,
-                             PaymentConfirmService paymentConfirmService,
+                             TransactionService transactionService, PaymentConfirmService paymentConfirmService,
                              GoCardlessClientWrapper goCardlessClientWrapper,
                              GoCardlessCustomerDao goCardlessCustomerDao,
                              GoCardlessPaymentDao goCardlessPaymentDao,
                              GoCardlessMandateDao goCardlessMandateDao,
                              GoCardlessEventDao goCardlessEventDao) {
         this.payerService = payerService;
+        this.transactionService = transactionService;
         this.paymentConfirmService = paymentConfirmService;
         this.goCardlessClientWrapper = goCardlessClientWrapper;
         this.goCardlessCustomerDao = goCardlessCustomerDao;
@@ -71,6 +73,7 @@ public class GoCardlessService implements DirectDebitPaymentProvider {
         ConfirmationDetails confirmationDetails = paymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId);
         GoCardlessMandate goCardlessMandate = createMandate(paymentRequestExternalId, confirmationDetails.getMandate());
         createPayment(paymentRequestExternalId, confirmationDetails.getTransaction(), goCardlessMandate);
+        transactionService.paymentCreatedFor(confirmationDetails.getTransaction());
     }
 
     private GoCardlessCustomer createCustomer(String paymentRequestExternalId, Payer payer) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -9,11 +9,14 @@ import uk.gov.pay.directdebit.payments.model.Transaction;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsConfirmed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsReceived;
-import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandateCreated;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paidOut;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payerCreated;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentCreated;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentPending;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.tokenExchanged;
 
 public class PaymentRequestEventService {
@@ -56,13 +59,17 @@ public class PaymentRequestEventService {
         insertEventFor(charge, event);
     }
 
-    public PaymentRequestEvent registerMandateCreatedEventFor(Transaction charge) {
-        PaymentRequestEvent event = mandateCreated(charge.getPaymentRequestId());
-        insertEventFor(charge, event);
-        return event;
+    public PaymentRequestEvent registerPaymentCreatedEventFor(Transaction charge) {
+        PaymentRequestEvent event = paymentCreated(charge.getPaymentRequestId());
+        return insertEventFor(charge, event);
     }
 
-    public PaymentRequestEvent registerPaidOutEventFor(Transaction charge) {
+    public PaymentRequestEvent registerPaymentPendingEventFor(Transaction charge) {
+        PaymentRequestEvent event = paymentPending(charge.getPaymentRequestId());
+        return insertEventFor(charge, event);
+    }
+
+    public PaymentRequestEvent registerPaymentPaidOutEventFor(Transaction charge) {
         PaymentRequestEvent event = paidOut(charge.getPaymentRequestId());
         return insertEventFor(charge, event);
     }
@@ -70,5 +77,9 @@ public class PaymentRequestEventService {
     public void registerTokenExchangedEventFor(Transaction charge) {
         PaymentRequestEvent event = tokenExchanged(charge.getPaymentRequestId());
         insertEventFor(charge, event);
+    }
+
+    public Optional<PaymentRequestEvent> findBy(Long paymentRequestId, PaymentRequestEvent.Type type, PaymentRequestEvent.SupportedEvent event) {
+        return paymentRequestEventDao.findByPaymentRequestIdAndEvent(paymentRequestId, type.toString(), event.toString());
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -8,11 +8,11 @@ import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
 import javax.inject.Inject;
-
 import java.util.Optional;
 
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsConfirmed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsReceived;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandatePending;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paidOut;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payerCreated;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentCreated;
@@ -80,6 +80,11 @@ public class PaymentRequestEventService {
     }
 
     public Optional<PaymentRequestEvent> findBy(Long paymentRequestId, PaymentRequestEvent.Type type, PaymentRequestEvent.SupportedEvent event) {
-        return paymentRequestEventDao.findByPaymentRequestIdAndEvent(paymentRequestId, type.toString(), event.toString());
+        return paymentRequestEventDao.findByPaymentRequestIdAndEvent(paymentRequestId, type, event);
+    }
+
+    public PaymentRequestEvent registerMandatePendingEventFor(Transaction transaction) {
+        PaymentRequestEvent event = mandatePending(transaction.getPaymentRequestId());
+        return insertEventFor(transaction, event);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.payments.services;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.model.ConfirmationDetails;
 import uk.gov.pay.directdebit.mandate.services.PaymentConfirmService;
 import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payers.services.PayerService;
@@ -16,12 +17,15 @@ public class SandboxService implements DirectDebitPaymentProvider {
 
     private final PayerService payerService;
     private final PaymentConfirmService paymentConfirmService;
+    private final TransactionService transactionService;
 
     @Inject
     public SandboxService(PayerService payerService,
-                          PaymentConfirmService paymentConfirmService) {
+                          PaymentConfirmService paymentConfirmService,
+                          TransactionService transactionService) {
         this.payerService = payerService;
         this.paymentConfirmService = paymentConfirmService;
+        this.transactionService = transactionService;
     }
 
     @Override
@@ -33,6 +37,7 @@ public class SandboxService implements DirectDebitPaymentProvider {
     @Override
     public void confirm(String paymentRequestExternalId, GatewayAccount gatewayAccount) {
         LOGGER.info("Confirming payment for SANDBOX, payment with id: {}", paymentRequestExternalId);
-        paymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId);
+        ConfirmationDetails confirmationDetails = paymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId);
+        transactionService.paymentCreatedFor(confirmationDetails.getTransaction());
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessAction.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessAction.java
@@ -6,5 +6,5 @@ import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 
 public interface GoCardlessAction {
-    PaymentRequestEvent changeTransactionState(TransactionService transactionService, Transaction transaction);
+    PaymentRequestEvent process(TransactionService transactionService, Transaction transaction);
 }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
@@ -14,14 +14,18 @@ import javax.inject.Inject;
 import java.util.List;
 
 public class WebhookGoCardlessService {
+
     private static final Logger LOGGER = PayLoggerFactory.getLogger(WebhookGoCardlessService.class);
-    private final TransactionService transactionService;
+
     private final GoCardlessService goCardlessService;
+    private final GoCardlessPaymentHandler goCardlessPaymentHandler;
+    private final GoCardlessMandateHandler goCardlessMandateHandler;
 
     @Inject
     public WebhookGoCardlessService(GoCardlessService goCardlessService, TransactionService transactionService) {
         this.goCardlessService = goCardlessService;
-        this.transactionService = transactionService;
+        goCardlessPaymentHandler = new GoCardlessPaymentHandler(transactionService, goCardlessService);
+        goCardlessMandateHandler = new GoCardlessMandateHandler(transactionService, goCardlessService);
     }
 
     public void handleEvents(List<GoCardlessEvent> events) {
@@ -39,9 +43,9 @@ public class WebhookGoCardlessService {
     private GoCardlessActionHandler getHandlerFor(GoCardlessResourceType goCardlessResourceType) {
         switch (goCardlessResourceType) {
             case PAYMENTS:
-                return new GoCardlessPaymentHandler(transactionService, goCardlessService);
+                return goCardlessPaymentHandler;
             case MANDATES:
-                return new GoCardlessMandateHandler(transactionService, goCardlessService);
+                return goCardlessMandateHandler;
             default:
                 return goCardlessService::storeEvent;
         }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessHandler.java
@@ -10,15 +10,16 @@ import uk.gov.pay.directdebit.payments.services.TransactionService;
 import uk.gov.pay.directdebit.webhook.gocardless.services.GoCardlessAction;
 
 public abstract class GoCardlessHandler implements GoCardlessActionHandler {
+
     private static final Logger LOGGER = PayLoggerFactory.getLogger(GoCardlessHandler.class);
+
     protected TransactionService transactionService;
     GoCardlessService goCardlessService;
 
     protected abstract GoCardlessAction parseAction(String action);
     protected abstract Transaction getTransactionForEvent(GoCardlessEvent event);
 
-
-    public GoCardlessHandler(TransactionService transactionService, GoCardlessService goCardlessService) {
+    GoCardlessHandler(TransactionService transactionService, GoCardlessService goCardlessService) {
         this.transactionService = transactionService;
         this.goCardlessService = goCardlessService;
     }
@@ -27,9 +28,9 @@ public abstract class GoCardlessHandler implements GoCardlessActionHandler {
         GoCardlessAction goCardlessAction = parseAction(event.getAction());
         if (goCardlessAction != null) {
             Transaction transaction = getTransactionForEvent(event);
-            PaymentRequestEvent paymentRequestEvent = goCardlessAction.changeTransactionState(transactionService, transaction);
+            PaymentRequestEvent paymentRequestEvent = goCardlessAction.process(transactionService, transaction);
             event.setPaymentRequestEventId(paymentRequestEvent.getId());
-            LOGGER.info("handled gocardless event with id: {}, resource type: {}", event.getEventId(), event.getResourceType().toString());
+            LOGGER.info("Handled GoCardless event with id: {}, resource type: {}", event.getEventId(), event.getResourceType().toString());
         }
         goCardlessService.storeEvent(event);
     }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
@@ -27,7 +27,7 @@ public class WebhookSandboxResource {
     @POST
     public Response handleWebhook() {
         List<Transaction> pendingTransactions = transactionService.findAllByPaymentStateAndProvider(PaymentState.PENDING_DIRECT_DEBIT_PAYMENT, PaymentProvider.SANDBOX);
-        pendingTransactions.forEach(transactionService::paidOutFor);
+        pendingTransactions.forEach(transactionService::paymentPaidOutFor);
 
         return Response.status(OK).build();
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmPaymentResourceIT.java
@@ -49,7 +49,7 @@ public class ConfirmPaymentResourceIT {
             .withPaymentRequestDescription(paymentRequestFixture.getDescription())
             .withState(AWAITING_CONFIRMATION);
     @Test
-    public void confirm_shouldCreateAMandateAndUpdateCharge() throws Exception {
+    public void confirm_shouldCreateAMandateAndUpdateCharge() {
         gatewayAccountFixture.insert(testContext.getJdbi());
         paymentRequestFixture.insert(testContext.getJdbi());
         transactionFixture.insert(testContext.getJdbi());
@@ -68,7 +68,7 @@ public class ConfirmPaymentResourceIT {
     }
 
     @Test
-    public void confirm_shouldCreateAMandateAndUpdateCharge_ForGoCardless() throws Exception {
+    public void confirm_shouldCreateAMandateAndUpdateCharge_ForGoCardless() {
         paymentRequestFixture.insert(testContext.getJdbi());
         PayerFixture payerFixture = PayerFixture.aPayerFixture()
                 .withPaymentRequestId(paymentRequestFixture.getId())
@@ -97,7 +97,7 @@ public class ConfirmPaymentResourceIT {
     }
 
     @Test
-    public void confirm_shouldFailWhenPayerDoesNotExist() throws Exception {
+    public void confirm_shouldFailWhenPayerDoesNotExist() {
         gatewayAccountFixture.insert(testContext.getJdbi());
         paymentRequestFixture.insert(testContext.getJdbi());
         transactionFixture.insert(testContext.getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmServiceTest.java
@@ -73,7 +73,6 @@ public class PaymentConfirmServiceTest {
         assertThat(mandate.getExternalId(), is(notNullValue()));
         assertThat(mandate.getPayerId(), is(payerId));
 
-        verify(mockTransactionService).mandateCreatedFor(transaction);
         assertThat(confirmationDetails.getMandate(), is(mandate));
         assertThat(confirmationDetails.getTransaction(), is(transaction));
     }
@@ -97,7 +96,6 @@ public class PaymentConfirmServiceTest {
             fail("Expected PayerConflictException to be thrown");
         } catch (PayerConflictException e) {
             verify(mockMandateDao, never()).insert(any(Mandate.class));
-            verify(mockTransactionService, never()).mandateCreatedFor(any(Transaction.class));
         }
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.payments.dao;
 
-import liquibase.exception.LiquibaseException;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -15,14 +14,18 @@ import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
 
-import java.io.IOException;
 import java.sql.Timestamp;
-import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture.aPaymentRequestEventFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.aPaymentRequestFixture;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payerCreated;
 import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.isDate;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -39,7 +42,7 @@ public class PaymentRequestEventDaoIT {
     private TestContext testContext;
 
     @Before
-    public void setup() throws IOException, LiquibaseException {
+    public void setup() {
         paymentRequestEventDao = testContext.getJdbi().onDemand(PaymentRequestEventDao.class);
         this.testPaymentRequest = aPaymentRequestFixture()
                 .withGatewayAccountId(RandomUtils.nextLong(1, 99999))
@@ -49,7 +52,7 @@ public class PaymentRequestEventDaoIT {
     @Test
     public void shouldInsertAnEvent() {
         Long paymentRequestId = testPaymentRequest.getId();
-        PaymentRequestEvent paymentRequestEvent = PaymentRequestEvent.payerCreated(paymentRequestId);
+        PaymentRequestEvent paymentRequestEvent = payerCreated(paymentRequestId);
         Long id = paymentRequestEventDao.insert(paymentRequestEvent);
         Map<String, Object> foundPaymentRequestEvent = testContext.getDatabaseTestHelper().getPaymentRequestEventById(id);
         assertThat(foundPaymentRequestEvent.get("id"), is(id));
@@ -59,4 +62,17 @@ public class PaymentRequestEventDaoIT {
         assertThat((Timestamp) foundPaymentRequestEvent.get("event_date"), isDate(paymentRequestEvent.getEventDate()));
     }
 
+    @Test
+    public void shouldFindByPaymentRequestIdAndEvent() {
+
+        aPaymentRequestEventFixture()
+                .withPaymentRequestId(testPaymentRequest.getId())
+                .withEventType(CHARGE)
+                .withEvent(PAYMENT_PENDING)
+                .insert(testContext.getJdbi());
+
+        Optional<PaymentRequestEvent> event = paymentRequestEventDao.findByPaymentRequestIdAndEvent(testPaymentRequest.getId(), "CHARGE", "PAYMENT_PENDING");
+
+        assertThat(event.isPresent(), is(true));
+    }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestEventDaoIT.java
@@ -71,7 +71,7 @@ public class PaymentRequestEventDaoIT {
                 .withEvent(PAYMENT_PENDING)
                 .insert(testContext.getJdbi());
 
-        Optional<PaymentRequestEvent> event = paymentRequestEventDao.findByPaymentRequestIdAndEvent(testPaymentRequest.getId(), "CHARGE", "PAYMENT_PENDING");
+        Optional<PaymentRequestEvent> event = paymentRequestEventDao.findByPaymentRequestIdAndEvent(testPaymentRequest.getId(), CHARGE, PAYMENT_PENDING);
 
         assertThat(event.isPresent(), is(true));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/ConfirmationDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/ConfirmationDetailsFixture.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.directdebit.payments.fixtures;
+
+import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.mandate.model.ConfirmationDetails;
+
+public class ConfirmationDetailsFixture {
+
+    private TransactionFixture transactionFixture;
+    private MandateFixture mandateFixture;
+
+    private ConfirmationDetailsFixture() { }
+
+    public static ConfirmationDetailsFixture confirmationDetails() {
+        return new ConfirmationDetailsFixture();
+    }
+
+    public ConfirmationDetailsFixture withTransaction(TransactionFixture transaction) {
+        this.transactionFixture = transaction;
+        return this;
+    }
+
+    public ConfirmationDetailsFixture withMandate(MandateFixture mandateFixture) {
+        this.mandateFixture = mandateFixture;
+        return this;
+    }
+
+    public ConfirmationDetails build() {
+        return new ConfirmationDetails(transactionFixture.toEntity(), mandateFixture.toEntity());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
@@ -10,12 +10,10 @@ import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
-import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
-import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.MANDATE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.PAYER;
 
 public class PaymentRequestEventTest {
@@ -44,17 +42,6 @@ public class PaymentRequestEventTest {
 
         assertThat(event.getEvent(), is(PAID_OUT));
         assertThat(event.getEventType(), is(CHARGE));
-        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
-    }
-
-    @Test
-    public void mandateCreated_shouldReturnExpectedEvent() {
-
-        long paymentRequestId = 1L;
-        PaymentRequestEvent event = PaymentRequestEvent.mandateCreated(paymentRequestId);
-
-        assertThat(event.getEvent(), is(MANDATE_CREATED));
-        assertThat(event.getEventType(), is(MANDATE));
         assertThat(event.getPaymentRequestId(), is(paymentRequestId));
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
@@ -10,10 +10,14 @@ import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.MANDATE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.PAYER;
 
 public class PaymentRequestEventTest {
@@ -97,6 +101,36 @@ public class PaymentRequestEventTest {
 
         assertThat(event.getEvent(), is(CHARGE_CREATED));
         assertThat(event.getEventType(), is(CHARGE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
+    }
+
+    @Test
+    public void paymentCreated_shouldReturnExpectedEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.paymentCreated(paymentRequestId);
+
+        assertThat(event.getEvent(), is(PAYMENT_CREATED));
+        assertThat(event.getEventType(), is(CHARGE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
+    }
+
+    @Test
+    public void paymentPending_shouldReturnExpectedEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.paymentPending(paymentRequestId);
+
+        assertThat(event.getEvent(), is(PAYMENT_PENDING));
+        assertThat(event.getEventType(), is(CHARGE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
+    }
+
+    @Test
+    public void mandatePending_shouldReturnExpectedEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.mandatePending(paymentRequestId);
+
+        assertThat(event.getEvent(), is(MANDATE_PENDING));
+        assertThat(event.getEventType(), is(MANDATE));
         assertThat(event.getPaymentRequestId(), is(paymentRequestId));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraphTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraphTest.java
@@ -12,25 +12,25 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.NEW;
 
-public class SandboxPaymentStatesGraphTest {
+public class PaymentStatesGraphTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-    private SandboxPaymentStatesGraph sandboxPaymentStatesGraph;
+    private PaymentStatesGraph paymentStatesGraph;
 
     @Before
     public void setup() {
-        sandboxPaymentStatesGraph = SandboxPaymentStatesGraph.getStates();
+        paymentStatesGraph = PaymentStatesGraph.getStates();
     }
 
     @Test
     public void initialState_shouldReturnInitialState() {
-        assertThat(SandboxPaymentStatesGraph.initialState(), is(NEW));
+        assertThat(PaymentStatesGraph.initialState(), is(NEW));
     }
 
     @Test
     public void getNextStateForEvent_shouldGiveTheNextStateIfEventIsValid() {
-        assertThat(sandboxPaymentStatesGraph.getNextStateForEvent(NEW, TOKEN_EXCHANGED), is(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS));
+        assertThat(paymentStatesGraph.getNextStateForEvent(NEW, TOKEN_EXCHANGED), is(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS));
     }
 
     @Test
@@ -38,17 +38,17 @@ public class SandboxPaymentStatesGraphTest {
         thrown.expect(InvalidStateTransitionException.class);
         thrown.expectMessage("Transition CHARGE_CREATED from state NEW is not valid");
         thrown.reportMissingExceptionWithMessage("InvalidStateTransitionException expected");
-        sandboxPaymentStatesGraph.getNextStateForEvent(NEW, CHARGE_CREATED);
+        paymentStatesGraph.getNextStateForEvent(NEW, CHARGE_CREATED);
     }
 
     @Test
     public void isValidTransition_shouldReturnTrueFromWhenTransitionIsExpected() {
-        assertThat(sandboxPaymentStatesGraph.isValidTransition(PaymentState.NEW, PaymentState.AWAITING_DIRECT_DEBIT_DETAILS, TOKEN_EXCHANGED), is(true));
+        assertThat(paymentStatesGraph.isValidTransition(PaymentState.NEW, PaymentState.AWAITING_DIRECT_DEBIT_DETAILS, TOKEN_EXCHANGED), is(true));
     }
 
     @Test
     public void isValidTransition_shouldReturnFalseWhenTransitionIsInvalid() {
-        assertThat(sandboxPaymentStatesGraph.isValidTransition(PaymentState.NEW, PaymentState.AWAITING_DIRECT_DEBIT_DETAILS, CHARGE_CREATED), is(false));
+        assertThat(paymentStatesGraph.isValidTransition(PaymentState.NEW, PaymentState.AWAITING_DIRECT_DEBIT_DETAILS, CHARGE_CREATED), is(false));
     }
 }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
@@ -8,16 +8,22 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.payments.dao.PaymentRequestEventDao;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture.*;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PaymentRequestEventServiceTest {
@@ -29,36 +35,36 @@ public class PaymentRequestEventServiceTest {
 
     private TransactionFixture transactionFixture = TransactionFixture.aTransactionFixture();
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         service = new PaymentRequestEventService(mockedPaymentRequestEventDao);
     }
 
     @Test
-    public void shouldInsertAnEventWhenTokenIsExchanged() {
+    public void registerTokenExchangedEventFor_shouldInsertAnEventWhenTokenIsExchanged() {
         service.registerTokenExchangedEventFor(transactionFixture.toEntity());
         ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(paymentRequestEvent.getEvent(), is(PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED));
-        assertThat(paymentRequestEvent.getEventType(), is(PaymentRequestEvent.Type.CHARGE));
+        assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
         assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }
 
     @Test
-    public void shouldInsertAnEventWhenDDDetailsAreReceived() {
+    public void registerDirectDebitReceivedEventFor_shouldInsertAnEventWhenDDDetailsAreReceived() {
         service.registerDirectDebitReceivedEventFor(transactionFixture.toEntity());
         ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(paymentRequestEvent.getEvent(), is(PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED));
-        assertThat(paymentRequestEvent.getEventType(), is(PaymentRequestEvent.Type.CHARGE));
+        assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
         assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }
 
     @Test
-    public void shouldInsertAnEventWhenPayerIsCreated() {
+    public void registerPayerCreatedEventFor_shouldInsertAnEventWhenPayerIsCreated() {
         service.registerPayerCreatedEventFor(transactionFixture.toEntity());
         ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
@@ -68,4 +74,69 @@ public class PaymentRequestEventServiceTest {
         assertThat(paymentRequestEvent.getEventType(), is(PaymentRequestEvent.Type.PAYER));
         assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }
+
+    @Test
+    public void registerPaymentCreatedEventFor_shouldCreateExpectedEvent() {
+        service.registerPaymentCreatedEventFor(transactionFixture.toEntity());
+        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED));
+        assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void registerPaymentPendingEventFor_shouldCreateExpectedEvent() {
+        service.registerPaymentPendingEventFor(transactionFixture.toEntity());
+        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PAYMENT_PENDING));
+        assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void findBy_shouldFindEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent expectedEvent = aPaymentRequestEventFixture().toEntity();
+        when(mockedPaymentRequestEventDao.findByPaymentRequestIdAndEvent(paymentRequestId, "CHARGE", "PAYMENT_PENDING"))
+                .thenReturn(Optional.of(expectedEvent));
+
+        Optional<PaymentRequestEvent> event = service.findBy(paymentRequestId, CHARGE, PAYMENT_PENDING);
+
+        assertThat(event.get(), is(expectedEvent));
+    }
 }
+
+
+/*
+
+   public PaymentRequestEvent registerPaymentCreatedEventFor(Transaction charge) {
+        PaymentRequestEvent event = paymentCreated(charge.getPaymentRequestId());
+        return insertEventFor(charge, event);
+    }
+
+    public PaymentRequestEvent registerPaymentPendingEventFor(Transaction charge) {
+        PaymentRequestEvent event = paymentPending(charge.getPaymentRequestId());
+        return insertEventFor(charge, event);
+    }
+
+    public PaymentRequestEvent registerPaymentPaidOutEventFor(Transaction charge) {
+        PaymentRequestEvent event = paidOut(charge.getPaymentRequestId());
+        return insertEventFor(charge, event);
+    }
+
+    public void registerTokenExchangedEventFor(Transaction charge) {
+        PaymentRequestEvent event = tokenExchanged(charge.getPaymentRequestId());
+        insertEventFor(charge, event);
+    }
+
+    public Optional<PaymentRequestEvent> findBy(Long paymentRequestId, PaymentRequestEvent.Type type, PaymentRequestEvent.SupportedEvent event) {
+        return paymentRequestEventDao.findByPaymentRequestIdAndEvent(paymentRequestId, type.toString(), event.toString());
+    }
+
+*/

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
@@ -7,21 +7,28 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.model.ConfirmationDetails;
 import uk.gov.pay.directdebit.mandate.services.PaymentConfirmService;
 import uk.gov.pay.directdebit.payers.services.PayerService;
 
 import java.util.Map;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.ConfirmationDetailsFixture.confirmationDetails;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SandboxServiceTest {
 
     @Mock
-    PayerService mockedPayerService;
+    private PayerService mockedPayerService;
     @Mock
-    PaymentConfirmService mockedPaymentConfirmService;
+    private PaymentConfirmService mockedPaymentConfirmService;
+    @Mock
+    private TransactionService mockedTransactionService;
 
     private SandboxService service;
     private String paymentRequestExternalId = "sdkfhsdkjfhjdks";
@@ -29,13 +36,29 @@ public class SandboxServiceTest {
     private GatewayAccount gatewayAccount = aGatewayAccountFixture().toEntity();
     @Before
     public void setUp() {
-        service = new SandboxService(mockedPayerService, mockedPaymentConfirmService);
+        service = new SandboxService(mockedPayerService, mockedPaymentConfirmService, mockedTransactionService);
     }
 
     @Test
-    public void shouldCreatePayerWhenReceivingPayerRequest() {
+    public void createPayer_shouldCreatePayerWhenReceivingPayerRequest() {
         Map<String, String> createPayerRequest = ImmutableMap.of();
         service.createPayer(paymentRequestExternalId, gatewayAccount, createPayerRequest);
         verify(mockedPayerService).create(paymentRequestExternalId, gatewayAccount.getId(), createPayerRequest);
+    }
+
+    @Test
+    public void confirm_shouldRegisterAPaymentCreatedEventWhenSuccessfullyConfirmed() {
+
+        ConfirmationDetails confirmationDetails = confirmationDetails()
+                .withTransaction(aTransactionFixture())
+                .withMandate(aMandateFixture())
+                .build();
+
+        when(mockedPaymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId))
+                .thenReturn(confirmationDetails);
+
+        service.confirm(paymentRequestExternalId, gatewayAccount);
+
+        verify(mockedTransactionService).paymentCreatedFor(confirmationDetails.getTransaction());
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
@@ -29,12 +29,15 @@ import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTrans
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
 public class WebhookGoCardlessResourceIT {
 
+    private final static String REQUEST_PATH = "/v1/webhooks/gocardless";
+    private final static String WEBHOOK = "{\"events\":[{\"id\":\"EV0000ED6V59V1\",\"created_at\":\"2015-04-17T15:24:26.817Z\",\"resource_type\":\"payments\",\"action\":\"status_unhandled_in_our_side\",\"links\":{\"payment\":\"PM00008Q30R2BR\"},\"details\":{\"origin\":\"gocardless\",\"cause\":\"payment_submitted\",\"description\":\"The payment has now been submitted to the banks, and cannot be cancelled. [SANDBOX TRANSITION]\"},\"metadata\":{}},{\"id\":\"EV0000ED6WBEQ0\",\"created_at\":\"2015-04-17T15:24:26.848Z\",\"resource_type\":\"payments\",\"action\":\"paid_out\",\"links\":{\"payment\":\"PM00008Q30R2BR\"},\"details\":{\"origin\":\"gocardless\",\"cause\":\"paid_out\",\"description\":\"Enough time has passed since the payment was submitted for the banks to return an error, so this payment is now confirmed. [SANDBOX TRANSITION]\"},\"metadata\":{}}]}";
+    private final static String WEBHOOK_SIGNATURE = "0daa8acb3ea7e5f42bab6ddb0daabeae985cb793b07850e1387be209c1d40001";
 
     @DropwizardTestContext
     private TestContext testContext;
 
     @Test
-    public void handleWebhook_shouldInsertGoCardlessEventsUpdateChargeAndReturn200() throws Exception {
+    public void handleWebhook_shouldInsertGoCardlessEventsUpdateChargeAndReturn200() {
         GatewayAccountFixture testGatewayAccount = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
         PaymentRequestFixture paymentRequestFixture = aPaymentRequestFixture()
                 .withGatewayAccountId(testGatewayAccount.getId())
@@ -62,7 +65,7 @@ public class WebhookGoCardlessResourceIT {
         Map<String, Object> firstEvent = events.get(0);
         assertThat(firstEvent.get("event_id"), is("EV0000ED6V59V1"));
         assertThat(firstEvent.get("resource_type"), is("PAYMENTS"));
-        assertThat(firstEvent.get("action"), is("submitted"));
+        assertThat(firstEvent.get("action"), is("status_unhandled_in_our_side"));
 
         Map<String, Object> secondEvent = events.get(1);
         assertThat(secondEvent.get("event_id"), is("EV0000ED6WBEQ0"));
@@ -72,10 +75,4 @@ public class WebhookGoCardlessResourceIT {
         Map<String, Object> transaction = testContext.getDatabaseTestHelper().getTransactionById(transactionFixture.getId());
         MatcherAssert.assertThat(transaction.get("state"), is("SUCCESS"));
     }
-    private final static String REQUEST_PATH = "/v1/webhooks/gocardless";
-
-    private final static String WEBHOOK = "{\"events\":[{\"id\":\"EV0000ED6V59V1\",\"created_at\":\"2015-04-17T15:24:26.817Z\",\"resource_type\":\"payments\",\"action\":\"submitted\",\"links\":{\"payment\":\"PM00008Q30R2BR\"},\"details\":{\"origin\":\"gocardless\",\"cause\":\"payment_submitted\",\"description\":\"The payment has now been submitted to the banks, and cannot be cancelled. [SANDBOX TRANSITION]\"},\"metadata\":{}},{\"id\":\"EV0000ED6WBEQ0\",\"created_at\":\"2015-04-17T15:24:26.848Z\",\"resource_type\":\"payments\",\"action\":\"paid_out\",\"links\":{\"payment\":\"PM00008Q30R2BR\"},\"details\":{\"origin\":\"gocardless\",\"cause\":\"paid_out\",\"description\":\"Enough time has passed since the payment was submitted for the banks to return an error, so this payment is now confirmed. [SANDBOX TRANSITION]\"},\"metadata\":{}}]}";
-
-    private final String WEBHOOK_SIGNATURE = "0d7cd9d11ad20814124f35dfa3aa9e24fbbbcfaf16b1cd09f04ebe0ca0a47c40";
-
 }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.directdebit.payments.services.TransactionService;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -32,15 +33,13 @@ import static uk.gov.pay.directdebit.payments.model.GoCardlessResourceType.UNHAN
 
 public class WebhookGoCardlessServiceTest {
     @Mock
-    GoCardlessService mockedGoCardlessService;
-
+    private GoCardlessService mockedGoCardlessService;
     @Mock
-    TransactionService mockedTransactionService;
-
-    WebhookGoCardlessService webhookGoCardlessService;
-    GoCardlessPayment goCardlessPayment = aGoCardlessPaymentFixture().toEntity();
-    Transaction transaction = aTransactionFixture().toEntity();
-    GoCardlessMandate goCardlessMandate = aGoCardlessMandateFixture().toEntity();
+    private TransactionService mockedTransactionService;
+    private WebhookGoCardlessService webhookGoCardlessService;
+    private GoCardlessPayment goCardlessPayment = aGoCardlessPaymentFixture().toEntity();
+    private Transaction transaction = aTransactionFixture().toEntity();
+    private GoCardlessMandate goCardlessMandate = aGoCardlessMandateFixture().toEntity();
 
     @Before
     public void setUp() {
@@ -109,11 +108,11 @@ public class WebhookGoCardlessServiceTest {
         PaymentRequestEvent paymentRequestEvent = PaymentRequestEvent.paymentCreated(transaction.getPaymentRequestId());
         when(mockedGoCardlessService.findMandateForEvent(goCardlessEvent)).thenReturn(goCardlessMandate);
         when(mockedTransactionService.findTransactionForMandateId(goCardlessMandate.getMandateId())).thenReturn(transaction);
-        when(mockedTransactionService.findPaymentPendingEventFor(transaction)).thenReturn(paymentRequestEvent);
+        when(mockedTransactionService.findMandatePendingEventFor(transaction)).thenReturn(Optional.of(paymentRequestEvent));
 
         List<GoCardlessEvent> events = Collections.singletonList(goCardlessEvent);
         webhookGoCardlessService.handleEvents(events);
         verify(mockedGoCardlessService).storeEvent(goCardlessEvent);
-        verify(mockedTransactionService).findPaymentPendingEventFor(transaction);
+        verify(mockedTransactionService).findMandatePendingEventFor(transaction);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
@@ -94,26 +94,26 @@ public class WebhookGoCardlessServiceTest {
         PaymentRequestEvent paymentRequestEvent = PaymentRequestEvent.paidOut(transaction.getPaymentRequestId());
         when(mockedGoCardlessService.findPaymentForEvent(goCardlessEvent)).thenReturn(goCardlessPayment);
         when(mockedTransactionService.findTransactionFor(goCardlessPayment.getTransactionId())).thenReturn(transaction);
-        when(mockedTransactionService.paidOutFor(transaction)).thenReturn(paymentRequestEvent);
+        when(mockedTransactionService.paymentPaidOutFor(transaction)).thenReturn(paymentRequestEvent);
 
         List<GoCardlessEvent> events = Collections.singletonList(goCardlessEvent);
         webhookGoCardlessService.handleEvents(events);
         verify(mockedGoCardlessService).storeEvent(goCardlessEvent);
-        verify(mockedTransactionService).paidOutFor(transaction);
+        verify(mockedTransactionService).paymentPaidOutFor(transaction);
     }
 
     @Test
     public void shouldStoreAndHandleMandateEventsWithAValidAction() {
         GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture().withResourceType(MANDATES).withAction("created").toEntity();
 
-        PaymentRequestEvent paymentRequestEvent = PaymentRequestEvent.mandateCreated(transaction.getPaymentRequestId());
+        PaymentRequestEvent paymentRequestEvent = PaymentRequestEvent.paymentCreated(transaction.getPaymentRequestId());
         when(mockedGoCardlessService.findMandateForEvent(goCardlessEvent)).thenReturn(goCardlessMandate);
         when(mockedTransactionService.findTransactionForMandateId(goCardlessMandate.getMandateId())).thenReturn(transaction);
-        when(mockedTransactionService.mandateCreatedFor(transaction)).thenReturn(paymentRequestEvent);
+        when(mockedTransactionService.findPaymentPendingEventFor(transaction)).thenReturn(paymentRequestEvent);
 
         List<GoCardlessEvent> events = Collections.singletonList(goCardlessEvent);
         webhookGoCardlessService.handleEvents(events);
         verify(mockedGoCardlessService).storeEvent(goCardlessEvent);
-        verify(mockedTransactionService).mandateCreatedFor(transaction);
+        verify(mockedTransactionService).findPaymentPendingEventFor(transaction);
     }
 }


### PR DESCRIPTION
## WHAT
Handle events:
- Mandates: 'created', 'submitted','active'
- Payments: 'created', 'submitted', 'confirmed', 'paid_out'
- Transitions are pending, this is because we need to think if for one off we should add mandate transitions at all or just store the events and only _listen_ to payment ones.
