### PR TITLE
PP-3265 Jenkins jobs converted to use selenium style smoke tests for all

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,36 @@ pipeline {
         branch 'master'
       }
       steps {
-        deployEcs("directdebit-connector", "test", null, true, true, "uk.gov.pay.endtoend.categories.SmokeDirectDebitPayments", false)
+        deployEcs("directdebit-connector", "test", null, false, false)
+      }
+    }
+    stage('Smoke Tests') {
+      when {
+        branch 'master'
+      }
+      steps {
+        runDirectDebitSmokeTest()
+      }
+    }
+    stage('Complete') {
+      failFast true
+      parallel {
+        stage('Tag Build') {
+          when {
+            branch 'master'
+          }
+          steps {
+            tagDeployment("direct-debit-connector")
+          }
+        }
+        stage('Trigger Deploy Notification') {
+          when {
+            branch 'master'
+          }
+          steps {
+            triggerGraphiteDeployEvent("direct-debit-connector")
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Use new separate split out jobs for deployment, smoke tests, tagging and
deployment event notification
Updated deployEcs arguments not to run tests and tag

solo @belindac