### PR TITLE
PP-3238 Do not set payment reference in GoCardless

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
@@ -60,12 +60,10 @@ public class GoCardlessClientWrapper {
     }
 
     public GoCardlessPayment createPayment(String paymentRequestExternalId, GoCardlessMandate mandate, Transaction transaction) {
-        //todo check which reference we want to send
         Payment goCardlessPayment = goCardlessClient.payments()
                 .create()
                 .withAmount(Math.toIntExact(transaction.getAmount()))
                 .withCurrency(PaymentService.PaymentCreateRequest.Currency.GBP)
-                .withReference(transaction.getPaymentRequestDescription())
                 .withLinksMandate(mandate.getGoCardlessMandateId())
                 .withIdempotencyKey(paymentRequestExternalId)
                 .execute();

--- a/src/test/java/uk/gov/pay/directdebit/util/GoCardlessStubs.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/GoCardlessStubs.java
@@ -64,12 +64,10 @@ public class GoCardlessStubs {
 
     public static void stubCreatePayment(String paymentRequestExternalId, TransactionFixture transactionFixture) {
         String paymentRequestExpectedBody = load(GOCARDLESS_CREATE_PAYMENT_REQUEST)
-                .replace("{{amount}}", String.valueOf(transactionFixture.getAmount()))
-                .replace("{{reference}}", transactionFixture.getPaymentRequestDescription());
+                .replace("{{amount}}", String.valueOf(transactionFixture.getAmount()));
 
         String paymentResponseBody = load(GOCARDLESS_CREATE_PAYMENT_SUCCESS_RESPONSE)
-                .replace("{{amount}}", String.valueOf(transactionFixture.getAmount()))
-                .replace("{{reference}}", transactionFixture.getPaymentRequestDescription());
+                .replace("{{amount}}", String.valueOf(transactionFixture.getAmount()));
         stubCallsFor("/payments", 200, paymentRequestExternalId, paymentRequestExpectedBody, paymentResponseBody);
     }
     private static void stubCallsFor(String url, int statusCode, String idempotencyKey, String requestBody, String responseBody) {

--- a/src/test/resources/it/requests/gocardless/create-payment.json
+++ b/src/test/resources/it/requests/gocardless/create-payment.json
@@ -2,7 +2,6 @@
   "payments": {
     "amount": {{amount}},
     "currency": "GBP",
-    "reference": "{{reference}}",
     "links": {
       "mandate": "MD123"
     }

--- a/src/test/resources/it/responses/gocardless/create-payment-success.json
+++ b/src/test/resources/it/responses/gocardless/create-payment-success.json
@@ -7,7 +7,7 @@
     "description": null,
     "currency": "GBP",
     "status": "pending_submission",
-    "reference": "{{reference}}",
+    "reference": "reference",
     "amount_refunded": 0,
     "links": {
       "mandate": "MD123",


### PR DESCRIPTION
## WHAT
We don't need to send our payment reference to GoCardless right now. There are rules surrounding that (ie. max length) and we need to figure out the right way of dealing with that.
