### PR TITLE
PP-3238 Handle Mandate 'active' event

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -9,6 +9,7 @@ import java.time.ZonedDateTime;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_ACTIVE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
@@ -69,6 +70,10 @@ public class PaymentRequestEvent {
         return new PaymentRequestEvent(paymentRequestId, Type.MANDATE, MANDATE_PENDING);
     }
 
+    public static PaymentRequestEvent mandateActive(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, Type.MANDATE, MANDATE_ACTIVE);
+    }
+
     public static PaymentRequestEvent paidOut(Long paymentRequestId) {
         return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAID_OUT);
     }
@@ -124,6 +129,7 @@ public class PaymentRequestEvent {
         PAYER_CREATED,
         DIRECT_DEBIT_DETAILS_CONFIRMED,
         MANDATE_PENDING,
+        MANDATE_ACTIVE,
         PAYMENT_CREATED,
         PAYMENT_PENDING,
         PAID_OUT;

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsConfirmed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsReceived;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandateActive;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandatePending;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paidOut;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payerCreated;
@@ -85,6 +86,11 @@ public class PaymentRequestEventService {
 
     public PaymentRequestEvent registerMandatePendingEventFor(Transaction transaction) {
         PaymentRequestEvent event = mandatePending(transaction.getPaymentRequestId());
+        return insertEventFor(transaction, event);
+    }
+
+    public PaymentRequestEvent registerMandateActiveEventFor(Transaction transaction) {
+        PaymentRequestEvent event = mandateActive(transaction.getPaymentRequestId());
         return insertEventFor(transaction, event);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -131,6 +131,10 @@ public class TransactionService {
         return paymentRequestEventService.registerMandatePendingEventFor(transaction);
     }
 
+    public PaymentRequestEvent mandateActiveFor(Transaction transaction) {
+        return paymentRequestEventService.registerMandateActiveEventFor(transaction);
+    }
+
     private Transaction updateStateFor(Transaction transaction, SupportedEvent event) {
         PaymentState newState = getStates().getNextStateForEvent(transaction.getState(),
                 event);

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
@@ -29,7 +29,13 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
     }
 
     public enum GoCardlessMandateAction implements GoCardlessAction {
-        CREATED, SUBMITTED, ACTIVE;
+        CREATED, SUBMITTED,
+        ACTIVE {
+            @Override
+            public PaymentRequestEvent process(TransactionService transactionService, Transaction transaction) {
+                return transactionService.mandateActiveFor(transaction);
+            }
+        };
 
         @Override
         public PaymentRequestEvent process(TransactionService transactionService, Transaction transaction) {

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_ACTIVE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
@@ -130,6 +131,16 @@ public class PaymentRequestEventTest {
         PaymentRequestEvent event = PaymentRequestEvent.mandatePending(paymentRequestId);
 
         assertThat(event.getEvent(), is(MANDATE_PENDING));
+        assertThat(event.getEventType(), is(MANDATE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
+    }
+
+    @Test
+    public void mandateActive_shouldReturnExpectedEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.mandateActive(paymentRequestId);
+
+        assertThat(event.getEvent(), is(MANDATE_ACTIVE));
         assertThat(event.getEventType(), is(MANDATE));
         assertThat(event.getPaymentRequestId(), is(paymentRequestId));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture.aPaymentRequestEventFixture;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_ACTIVE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
@@ -109,6 +110,18 @@ public class PaymentRequestEventServiceTest {
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(paymentRequestEvent.getEvent(), is(MANDATE_PENDING));
+        assertThat(paymentRequestEvent.getEventType(), is(MANDATE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void registerMandateActiveEventFor_shouldCreateExpectedEvent() {
+        service.registerMandateActiveEventFor(transactionFixture.toEntity());
+        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(MANDATE_ACTIVE));
         assertThat(paymentRequestEvent.getEventType(), is(MANDATE));
         assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -182,7 +182,7 @@ public class TransactionServiceTest {
     }
 
     @Test
-    public void paymentCreatedFor_shouldUpdateTransaction_andRegisterAPaymentCreatedEvent() {
+    public void paymentCreatedFor_shouldUpdateTransactionAsPending_andRegisterAPaymentCreatedEvent() {
         Transaction transaction = TransactionFixture
                 .aTransactionFixture()
                 .withState(PROCESSING_DIRECT_DEBIT_PAYMENT)
@@ -198,7 +198,7 @@ public class TransactionServiceTest {
     }
 
     @Test
-    public void paymentPendingFor_shouldRegisterAPaymentPendingEvent_butTheTransactionRemainsAsPaymentCreated() {
+    public void paymentPendingFor_shouldRegisterAPaymentPendingEvent() {
 
         Transaction transaction = TransactionFixture
                 .aTransactionFixture()
@@ -213,7 +213,7 @@ public class TransactionServiceTest {
     }
 
     @Test
-    public void paymentPaidOutFor_shouldRegisterAPaymentPendingEvent_andRegisterAPaidOutEvent() {
+    public void paymentPaidOutFor_shouldSetPaymentAsSucceeded_andRegisterAPaidOutEvent() {
 
         Transaction transaction = TransactionFixture
                 .aTransactionFixture()
@@ -228,7 +228,7 @@ public class TransactionServiceTest {
     }
 
     @Test
-    public void mandatePendingFor_shouldRegisterAPaymentPendingEvent_butTheTransactionRemainsAsPaymentCreated() {
+    public void mandatePendingFor_shouldRegisterAMandatePendingEvent() {
 
         Transaction transaction = TransactionFixture
                 .aTransactionFixture()
@@ -238,6 +238,21 @@ public class TransactionServiceTest {
         service.mandatePendingFor(transaction);
 
         verify(mockedPaymentRequestEventService).registerMandatePendingEventFor(transaction);
+        verifyZeroInteractions(mockedTransactionDao);
+        assertThat(transaction.getState(), is(PENDING_DIRECT_DEBIT_PAYMENT));
+    }
+
+    @Test
+    public void mandateActiveFor_shouldRegisterAMandateActiveEvent() {
+
+        Transaction transaction = TransactionFixture
+                .aTransactionFixture()
+                .withState(PENDING_DIRECT_DEBIT_PAYMENT)
+                .toEntity();
+
+        service.mandateActiveFor(transaction);
+
+        verify(mockedPaymentRequestEventService).registerMandateActiveEventFor(transaction);
         verifyZeroInteractions(mockedTransactionDao);
         assertThat(transaction.getState(), is(PENDING_DIRECT_DEBIT_PAYMENT));
     }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
@@ -85,47 +85,6 @@ public class GoCardlessMandateHandlerTest {
     }
 
     @Test
-    public void handle_onActiveMandateGoCardlessEvent_shouldSetAPayEventAsMandateActive_whenDoesNotPreviouslyExist() {
-        GoCardlessEvent goCardlessEvent = GoCardlessEventFixture.aGoCardlessEventFixture().withAction("active").toEntity();
-        PaymentRequestEvent paymentRequestEvent = PaymentRequestEventFixture.aPaymentRequestEventFixture().toEntity();
-        Transaction transaction = TransactionFixture.aTransactionFixture().toEntity();
-
-        when(mockedGoCardlessService.findMandateForEvent(goCardlessEvent)).thenReturn(goCardlessMandateFixture.toEntity());
-        when(mockedTransactionService.findTransactionForMandateId(goCardlessMandateFixture.getMandateId())).thenReturn(transaction);
-
-        when(mockedTransactionService.findMandatePendingEventFor(transaction)).thenReturn(Optional.empty());
-        when(mockedTransactionService.mandatePendingFor(transaction)).thenReturn(paymentRequestEvent);
-
-        goCardlessMandateHandler.handle(goCardlessEvent);
-
-
-        ArgumentCaptor<GoCardlessEvent> geCaptor = forClass(GoCardlessEvent.class);
-        verify(mockedGoCardlessService).storeEvent(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        Assert.assertThat(storedGoCardlessEvent.getPaymentRequestEventId(), is(paymentRequestEvent.getId()));
-    }
-
-    @Test
-    public void handle_onActiveMandateGoCardlessEvent_shouldNotRegisterAnEventAsMandatePending_whenAPreviousMandatePendingEventExists() {
-        GoCardlessEvent goCardlessEvent = GoCardlessEventFixture.aGoCardlessEventFixture().withAction("active").toEntity();
-        PaymentRequestEvent paymentRequestEvent = PaymentRequestEventFixture.aPaymentRequestEventFixture().toEntity();
-        Transaction transaction = TransactionFixture.aTransactionFixture().toEntity();
-
-        when(mockedGoCardlessService.findMandateForEvent(goCardlessEvent)).thenReturn(goCardlessMandateFixture.toEntity());
-        when(mockedTransactionService.findTransactionForMandateId(goCardlessMandateFixture.getMandateId())).thenReturn(transaction);
-
-        when(mockedTransactionService.findMandatePendingEventFor(transaction)).thenReturn(Optional.of(paymentRequestEvent));
-
-        goCardlessMandateHandler.handle(goCardlessEvent);
-
-        verify(mockedTransactionService, never()).mandatePendingFor(transaction);
-        ArgumentCaptor<GoCardlessEvent> geCaptor = forClass(GoCardlessEvent.class);
-        verify(mockedGoCardlessService).storeEvent(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        Assert.assertThat(storedGoCardlessEvent.getPaymentRequestEventId(), is(paymentRequestEvent.getId()));
-    }
-
-    @Test
     public void handle_onSubmittedMandateGoCardlessEvent_shouldSetAPayEventAsMandatePending_whenDoesNotPreviouslyExist() {
         GoCardlessEvent goCardlessEvent = GoCardlessEventFixture.aGoCardlessEventFixture().withAction("submitted").toEntity();
         PaymentRequestEvent paymentRequestEvent = PaymentRequestEventFixture.aPaymentRequestEventFixture().toEntity();
@@ -160,6 +119,25 @@ public class GoCardlessMandateHandlerTest {
         goCardlessMandateHandler.handle(goCardlessEvent);
 
         verify(mockedTransactionService, never()).mandatePendingFor(transaction);
+        ArgumentCaptor<GoCardlessEvent> geCaptor = forClass(GoCardlessEvent.class);
+        verify(mockedGoCardlessService).storeEvent(geCaptor.capture());
+        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
+        Assert.assertThat(storedGoCardlessEvent.getPaymentRequestEventId(), is(paymentRequestEvent.getId()));
+    }
+
+    @Test
+    public void handle_onActiveMandateGoCardlessEvent_shouldSetAPayEventAsMandateActive() {
+        GoCardlessEvent goCardlessEvent = GoCardlessEventFixture.aGoCardlessEventFixture().withAction("active").toEntity();
+        PaymentRequestEvent paymentRequestEvent = PaymentRequestEventFixture.aPaymentRequestEventFixture().toEntity();
+        Transaction transaction = TransactionFixture.aTransactionFixture().toEntity();
+
+        when(mockedGoCardlessService.findMandateForEvent(goCardlessEvent)).thenReturn(goCardlessMandateFixture.toEntity());
+        when(mockedTransactionService.findTransactionForMandateId(goCardlessMandateFixture.getMandateId())).thenReturn(transaction);
+        when(mockedTransactionService.mandateActiveFor(transaction)).thenReturn(paymentRequestEvent);
+
+        goCardlessMandateHandler.handle(goCardlessEvent);
+
+
         ArgumentCaptor<GoCardlessEvent> geCaptor = forClass(GoCardlessEvent.class);
         verify(mockedGoCardlessService).storeEvent(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();


### PR DESCRIPTION
## WHAT
- Create a payment request event as mandate 'active' when Gocardless Webhook event type mandate is action 'active'