### PR TITLE
PP-3238 Handle payout paid event

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessResourceType.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessResourceType.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 
 public enum GoCardlessResourceType {
-    PAYMENTS, MANDATES, UNHANDLED;
+    PAYMENTS, MANDATES, PAYOUTS, UNHANDLED;
     private static final Logger LOGGER = PayLoggerFactory.getLogger(GoCardlessResourceType.class);
 
     public static GoCardlessResourceType fromString(String type) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -9,9 +9,10 @@ import java.time.ZonedDateTime;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
-import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
@@ -88,6 +89,10 @@ public class PaymentRequestEvent {
         return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAID_OUT);
     }
 
+    public static PaymentRequestEvent payoutPaid(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAID);
+    }
+
     public Long getId() {
         return id;
     }
@@ -144,7 +149,8 @@ public class PaymentRequestEvent {
         PAYMENT_CREATED,
         PAYMENT_PENDING,
         PAYMENT_FAILED,
-        PAID_OUT;
+        PAID_OUT,
+        PAID;
 
         public static SupportedEvent fromString(String event) throws UnsupportedPaymentRequestEventException {
             try {

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -12,14 +12,15 @@ import java.util.Optional;
 
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsConfirmed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsReceived;
-import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandateFailed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandateActive;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandateFailed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandatePending;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paidOut;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payerCreated;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentCreated;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentFailed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentPending;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payoutPaid;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.tokenExchanged;
 
 public class PaymentRequestEventService {
@@ -62,6 +63,11 @@ public class PaymentRequestEventService {
         insertEventFor(charge, event);
     }
 
+    public void registerTokenExchangedEventFor(Transaction charge) {
+        PaymentRequestEvent event = tokenExchanged(charge.getPaymentRequestId());
+        insertEventFor(charge, event);
+    }
+
     public PaymentRequestEvent registerPaymentCreatedEventFor(Transaction charge) {
         PaymentRequestEvent event = paymentCreated(charge.getPaymentRequestId());
         return insertEventFor(charge, event);
@@ -87,13 +93,9 @@ public class PaymentRequestEventService {
         return insertEventFor(charge, event);
     }
 
-    public void registerTokenExchangedEventFor(Transaction charge) {
-        PaymentRequestEvent event = tokenExchanged(charge.getPaymentRequestId());
-        insertEventFor(charge, event);
-    }
-
-    public Optional<PaymentRequestEvent> findBy(Long paymentRequestId, PaymentRequestEvent.Type type, PaymentRequestEvent.SupportedEvent event) {
-        return paymentRequestEventDao.findByPaymentRequestIdAndEvent(paymentRequestId, type, event);
+    public PaymentRequestEvent registerPayoutPaidEventFor(Transaction charge) {
+        PaymentRequestEvent event = payoutPaid(charge.getPaymentRequestId());
+        return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerMandatePendingEventFor(Transaction transaction) {
@@ -104,5 +106,9 @@ public class PaymentRequestEventService {
     public PaymentRequestEvent registerMandateActiveEventFor(Transaction transaction) {
         PaymentRequestEvent event = mandateActive(transaction.getPaymentRequestId());
         return insertEventFor(transaction, event);
+    }
+
+    public Optional<PaymentRequestEvent> findBy(Long paymentRequestId, PaymentRequestEvent.Type type, PaymentRequestEvent.SupportedEvent event) {
+        return paymentRequestEventDao.findByPaymentRequestIdAndEvent(paymentRequestId, type, event);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -123,15 +123,6 @@ public class TransactionService {
         return paymentRequestEventService.registerPaymentCreatedEventFor(updatedTransaction);
     }
 
-    public PaymentRequestEvent mandateFailedFor(Transaction transaction, Payer payer) {
-        userNotificationService.sendMandateFailedEmail(payer, transaction);
-        return paymentRequestEventService.registerMandateFailedEventFor(transaction);
-    }
-
-    public PaymentRequestEvent paymentPendingFor(Transaction transaction) {
-        return paymentRequestEventService.registerPaymentPendingEventFor(transaction);
-    }
-
     public PaymentRequestEvent paymentFailedFor(Transaction transaction) {
         Transaction newTransaction = updateStateFor(transaction, SupportedEvent.PAYMENT_FAILED);
         return paymentRequestEventService.registerPaymentFailedEventFor(newTransaction);
@@ -142,12 +133,25 @@ public class TransactionService {
         return paymentRequestEventService.registerPaymentPaidOutEventFor(updatedTransaction);
     }
 
+    public PaymentRequestEvent mandateFailedFor(Transaction transaction, Payer payer) {
+        userNotificationService.sendMandateFailedEmail(payer, transaction);
+        return paymentRequestEventService.registerMandateFailedEventFor(transaction);
+    }
+
+    public PaymentRequestEvent paymentPendingFor(Transaction transaction) {
+        return paymentRequestEventService.registerPaymentPendingEventFor(transaction);
+    }
+
     public PaymentRequestEvent mandatePendingFor(Transaction transaction) {
         return paymentRequestEventService.registerMandatePendingEventFor(transaction);
     }
 
     public PaymentRequestEvent mandateActiveFor(Transaction transaction) {
         return paymentRequestEventService.registerMandateActiveEventFor(transaction);
+    }
+
+    public PaymentRequestEvent payoutPaidFor(Transaction transaction) {
+        return paymentRequestEventService.registerPayoutPaidEventFor(transaction);
     }
 
     private Transaction updateStateFor(Transaction transaction, SupportedEvent event) {

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
@@ -44,6 +44,7 @@ public class WebhookGoCardlessService {
     private GoCardlessActionHandler getHandlerFor(GoCardlessResourceType goCardlessResourceType) {
         switch (goCardlessResourceType) {
             case PAYMENTS:
+            case PAYOUTS:
                 return goCardlessPaymentHandler;
             case MANDATES:
                 return goCardlessMandateHandler;

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -23,7 +23,7 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
     }
 
     public enum GoCardlessPaymentAction implements GoCardlessAction {
-        CREATED, SUBMITTED, CONFIRMED, PAID_OUT;
+        CREATED, SUBMITTED, CONFIRMED, PAID_OUT, PAID;
 
         public static GoCardlessPaymentAction fromString(String type) {
             for (GoCardlessPaymentAction typeEnum : values()) {
@@ -52,8 +52,8 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
                 GoCardlessPaymentAction.CREATED, transactionService::paymentPendingFor,
                 GoCardlessPaymentAction.SUBMITTED, transactionService::findPaymentPendingEventFor,
                 GoCardlessPaymentAction.CONFIRMED, transactionService::findPaymentPendingEventFor,
-                GoCardlessPaymentAction.PAID_OUT, transactionService::paymentPaidOutFor
+                GoCardlessPaymentAction.PAID_OUT, transactionService::paymentPaidOutFor,
+                GoCardlessPaymentAction.PAID, transactionService::payoutPaidFor
         );
     }
-
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
@@ -11,10 +11,13 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
@@ -52,7 +55,6 @@ public class PaymentRequestEventTest {
 
     @Test
     public void directDebitDetailsConfirmed_shouldReturnExpectedEvent() {
-
         long paymentRequestId = 1L;
         PaymentRequestEvent event = PaymentRequestEvent.directDebitDetailsConfirmed(paymentRequestId);
 
@@ -63,7 +65,6 @@ public class PaymentRequestEventTest {
 
     @Test
     public void payerCreated_shouldReturnExpectedEvent() {
-
         long paymentRequestId = 1L;
         PaymentRequestEvent event = PaymentRequestEvent.payerCreated(paymentRequestId);
 
@@ -85,7 +86,6 @@ public class PaymentRequestEventTest {
 
     @Test
     public void tokenExchanged_shouldReturnExpectedEvent() {
-
         long paymentRequestId = 1L;
         PaymentRequestEvent event = PaymentRequestEvent.tokenExchanged(paymentRequestId);
 
@@ -96,7 +96,6 @@ public class PaymentRequestEventTest {
 
     @Test
     public void chargeCreated_shouldReturnExpectedEvent() {
-
         long paymentRequestId = 1L;
         PaymentRequestEvent event = PaymentRequestEvent.chargeCreated(paymentRequestId);
 
@@ -126,12 +125,22 @@ public class PaymentRequestEventTest {
     }
 
     @Test
-    public void mandatePending_shouldReturnExpectedEvent() {
+    public void paymentFailed_shouldReturnExpectedEvent() {
         long paymentRequestId = 1L;
-        PaymentRequestEvent event = PaymentRequestEvent.mandatePending(paymentRequestId);
+        PaymentRequestEvent event = PaymentRequestEvent.paymentFailed(paymentRequestId);
 
-        assertThat(event.getEvent(), is(MANDATE_PENDING));
-        assertThat(event.getEventType(), is(MANDATE));
+        assertThat(event.getEvent(), is(PAYMENT_FAILED));
+        assertThat(event.getEventType(), is(CHARGE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
+    }
+
+    @Test
+    public void payoutPaid_shouldReturnExpectedEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.payoutPaid(paymentRequestId);
+
+        assertThat(event.getEvent(), is(PAID));
+        assertThat(event.getEventType(), is(CHARGE));
         assertThat(event.getPaymentRequestId(), is(paymentRequestId));
     }
 
@@ -141,6 +150,16 @@ public class PaymentRequestEventTest {
         PaymentRequestEvent event = PaymentRequestEvent.mandateActive(paymentRequestId);
 
         assertThat(event.getEvent(), is(MANDATE_ACTIVE));
+        assertThat(event.getEventType(), is(MANDATE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
+    }
+
+    @Test
+    public void mandateFailed_shouldReturnExpectedEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.mandateFailed(paymentRequestId);
+
+        assertThat(event.getEvent(), is(MANDATE_FAILED));
         assertThat(event.getEventType(), is(MANDATE));
         assertThat(event.getPaymentRequestId(), is(paymentRequestId));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.payments.dao.PaymentRequestEventDao;
@@ -22,7 +23,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture.aPaymentRequestEventFixture;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.MANDATE;
@@ -32,6 +37,9 @@ public class PaymentRequestEventServiceTest {
 
     @Mock
     private PaymentRequestEventDao mockedPaymentRequestEventDao;
+
+    @Captor
+    ArgumentCaptor<PaymentRequestEvent> prCaptor;
 
     private PaymentRequestEventService service;
 
@@ -45,7 +53,7 @@ public class PaymentRequestEventServiceTest {
     @Test
     public void registerTokenExchangedEventFor_shouldInsertAnEventWhenTokenIsExchanged() {
         service.registerTokenExchangedEventFor(transactionFixture.toEntity());
-        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
@@ -57,7 +65,7 @@ public class PaymentRequestEventServiceTest {
     @Test
     public void registerDirectDebitReceivedEventFor_shouldInsertAnEventWhenDDDetailsAreReceived() {
         service.registerDirectDebitReceivedEventFor(transactionFixture.toEntity());
-        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
@@ -69,7 +77,7 @@ public class PaymentRequestEventServiceTest {
     @Test
     public void registerPayerCreatedEventFor_shouldInsertAnEventWhenPayerIsCreated() {
         service.registerPayerCreatedEventFor(transactionFixture.toEntity());
-        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
@@ -81,7 +89,7 @@ public class PaymentRequestEventServiceTest {
     @Test
     public void registerPaymentCreatedEventFor_shouldCreateExpectedEvent() {
         service.registerPaymentCreatedEventFor(transactionFixture.toEntity());
-        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
@@ -93,7 +101,7 @@ public class PaymentRequestEventServiceTest {
     @Test
     public void registerPaymentPendingEventFor_shouldCreateExpectedEvent() {
         service.registerPaymentPendingEventFor(transactionFixture.toEntity());
-        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
@@ -103,9 +111,45 @@ public class PaymentRequestEventServiceTest {
     }
 
     @Test
+    public void registerPaymentPaidOutEventFor_shouldCreateExpectedEvent() {
+        service.registerPaymentPaidOutEventFor(transactionFixture.toEntity());
+
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PAID_OUT));
+        assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void registerPaymentFailedEventFor_shouldCreateExpectedEvent() {
+        service.registerPaymentFailedEventFor(transactionFixture.toEntity());
+
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PAYMENT_FAILED));
+        assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void registerPayoutPaidEventFor_shouldCreateExpectedEvent() {
+        service.registerPayoutPaidEventFor(transactionFixture.toEntity());
+
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PAID));
+        assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
     public void registerMandatePendingEventFor_shouldCreateExpectedEvent() {
         service.registerMandatePendingEventFor(transactionFixture.toEntity());
-        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
@@ -117,11 +161,23 @@ public class PaymentRequestEventServiceTest {
     @Test
     public void registerMandateActiveEventFor_shouldCreateExpectedEvent() {
         service.registerMandateActiveEventFor(transactionFixture.toEntity());
-        ArgumentCaptor<PaymentRequestEvent> prCaptor = forClass(PaymentRequestEvent.class);
+
         verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(paymentRequestEvent.getEvent(), is(MANDATE_ACTIVE));
+        assertThat(paymentRequestEvent.getEventType(), is(MANDATE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void registerMandateFailedEventFor_shouldCreateExpectedEvent() {
+        service.registerMandateFailedEventFor(transactionFixture.toEntity());
+
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(MANDATE_FAILED));
         assertThat(paymentRequestEvent.getEventType(), is(MANDATE));
         assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }


### PR DESCRIPTION
## WHAT
 - Paid is the only possible action for payout - so we are handling that in our payment handler
   instead of creating a new handler just for that one action
 - Assumption is that the payment has already been set to `PAID_OUT` (meaning the money has left the user's bank account) before receiving a payout `PAID` event (meaning the money has left gocardless' bank account in favour of the service's).
   If this assumptions proves to be incorrect, we might need to revisit our handler
 - Added some tests for unrelated events which were missing


## HOW 
_Steps to test or reproduce:_
