### PR TITLE
PP-2810 Add charge date column to gocardless payments table

### DIFF
--- a/src/main/resources/migrations/00014_alter_table_gocardless_payments_charge_date.sql
+++ b/src/main/resources/migrations/00014_alter_table_gocardless_payments_charge_date.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-gocardless-payments-charge-date
+ALTER TABLE gocardless_payments ADD COLUMN charge_date DATE NOT NULL DEFAULT NOW();
+--rollback ALTER TABLE gocardless_payments DROP COLUMN charge_date;


### PR DESCRIPTION
## WHAT
This is sent to us from gocardless and it's going to be used in the body of the payment confirmation email we send to the user.