### PR TITLE
PP-2810 Send email to user when a payment is confirmed

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/app/config/LinksConfig.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/LinksConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.app.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.dropwizard.Configuration;
 
 public class LinksConfig extends Configuration {
@@ -8,5 +9,10 @@ public class LinksConfig extends Configuration {
 
     public String getFrontendUrl() {
         return frontendUrl;
+    }
+
+    @JsonIgnore
+    public String getDirectDebitGuaranteeUrl() {
+        return getFrontendUrl() + "/direct-debit-guarantee";
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessPaymentMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessPaymentMapper.java
@@ -2,7 +2,6 @@ package uk.gov.pay.directdebit.mandate.dao.mapper;
 
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
 
 import java.sql.ResultSet;
@@ -12,12 +11,14 @@ public class GoCardlessPaymentMapper implements ResultSetMapper<GoCardlessPaymen
     private static final String ID_COLUMN = "id";
     private static final String TRANSACTION_ID_COLUMN = "transaction_id";
     private static final String PAYMENT_ID_COLUMN = "payment_id";
+    private static final String CHARGE_DATE_COLUMN = "charge_date";
 
     @Override
     public GoCardlessPayment map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException {
         return new GoCardlessPayment(
                 resultSet.getLong(ID_COLUMN),
                 resultSet.getLong(TRANSACTION_ID_COLUMN),
-                resultSet.getString(PAYMENT_ID_COLUMN));
+                resultSet.getString(PAYMENT_ID_COLUMN),
+                resultSet.getDate(CHARGE_DATE_COLUMN).toLocalDate());
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessPayment.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessPayment.java
@@ -1,19 +1,23 @@
 package uk.gov.pay.directdebit.mandate.model;
 
+import java.time.LocalDate;
+
 public class GoCardlessPayment {
 
     private Long id;
     private Long transactionId;
     private String paymentId;
+    private LocalDate chargeDate;
 
-    public GoCardlessPayment(Long id, Long transactionId, String paymentId) {
+    public GoCardlessPayment(Long id, Long transactionId, String paymentId, LocalDate chargeDate) {
         this.id = id;
         this.transactionId = transactionId;
         this.paymentId = paymentId;
+        this.chargeDate = chargeDate;
     }
 
-    public GoCardlessPayment(Long transactionId, String paymentId) {
-        this(null, transactionId, paymentId);
+    public GoCardlessPayment(Long transactionId, String paymentId, LocalDate chargeDate) {
+        this(null, transactionId, paymentId, chargeDate);
     }
 
     public Long getId() {
@@ -40,6 +44,14 @@ public class GoCardlessPayment {
         this.paymentId = paymentId;
     }
 
+    public LocalDate getChargeDate() {
+        return chargeDate;
+    }
+
+    public void setChargeDate(LocalDate chargeDate) {
+        this.chargeDate = chargeDate;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -49,7 +61,8 @@ public class GoCardlessPayment {
 
         if (id != null ? !id.equals(that.id) : that.id != null) return false;
         if (!transactionId.equals(that.transactionId)) return false;
-        return paymentId.equals(that.paymentId);
+        if (!paymentId.equals(that.paymentId)) return false;
+        return chargeDate.equals(that.chargeDate);
     }
 
     @Override
@@ -57,6 +70,7 @@ public class GoCardlessPayment {
         int result = id != null ? id.hashCode() : 0;
         result = 31 * result + transactionId.hashCode();
         result = 31 * result + paymentId.hashCode();
+        result = 31 * result + chargeDate.hashCode();
         return result;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/notifications/config/NotifyClientFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/config/NotifyClientFactory.java
@@ -2,7 +2,6 @@ package uk.gov.pay.directdebit.notifications.config;
 
 import io.dropwizard.Configuration;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.service.notify.NotificationClient;
 
@@ -21,9 +20,15 @@ public class NotifyClientFactory extends Configuration {
     private boolean emailNotifyEnabled;
     @NotNull
     private String mandateFailedTemplateId;
+    @NotNull
+    private String paymentConfirmedTemplateId;
 
     public String getMandateFailedTemplateId() {
         return mandateFailedTemplateId;
+    }
+
+    public String getPaymentConfirmedTemplateId() {
+        return paymentConfirmedTemplateId;
     }
 
     public String getApiKey() {

--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -126,7 +126,7 @@ public class UserNotificationService {
         HashMap<String, String> map = new HashMap<>();
         map.put(ORG_NAME_KEY, gatewayAccount.getServiceName());
         map.put(ORG_PHONE_KEY, PLACEHOLDER_PHONE_NUMBER);
-        map.put(DD_GUARANTEE_KEY, buildDirectDebitGuaranteeUrl());
+        map.put(DD_GUARANTEE_KEY, directDebitConfig.getLinks().getDirectDebitGuaranteeUrl());
 
         return map;
     }
@@ -143,13 +143,10 @@ public class UserNotificationService {
         map.put(SUN_KEY, PLACEHOLDER_SUN);
         map.put(MERCHANT_ADDRESS_KEY, PLACEHOLDER_MERCHANT_ADDRESS);
         map.put(MERCHANT_PHONE_NUMBER_KEY, PLACEHOLDER_PHONE_NUMBER);
-        map.put(DD_GUARANTEE_KEY, buildDirectDebitGuaranteeUrl());
+        map.put(DD_GUARANTEE_KEY, directDebitConfig.getLinks().getDirectDebitGuaranteeUrl());
         return map;
     }
 
-    private String buildDirectDebitGuaranteeUrl() {
-        return directDebitConfig.getLinks().getFrontendUrl() + "/direct-debit-guarantee";
-    }
     private String formatToPounds(long amountInPence) {
         return BigDecimal.valueOf(amountInPence, 2).toString();
     }

--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -35,6 +35,18 @@ public class UserNotificationService {
     private static final String PLACEHOLDER_SUN = "THE-CAKE-IS-A-LIE";
     private static final String PLACEHOLDER_MERCHANT_ADDRESS = "123 Rainbow Road, EC125Y, London";
 
+    private static final String DD_GUARANTEE_KEY = "dd guarantee link";
+    private static final String ORG_NAME_KEY = "org name";
+    private static final String SERVICE_NAME_KEY = "service name";
+    private static final String SUN_KEY = "SUN";
+    private static final String COLLECTION_DATE_KEY = "collection date";
+    private static final String AMOUNT_KEY = "amount";
+    private static final String PAYMENT_REFERENCE_KEY = "payment reference";
+    private static final String MERCHANT_ADDRESS_KEY = "merchant address";
+    private static final String ORG_PHONE_KEY = "org phone";
+    private static final String MERCHANT_PHONE_NUMBER_KEY = "merchant phone number";
+    private static final String BANK_ACCOUNT_LAST_DIGITS_KEY = "bank account last 2 digits";
+
     private boolean emailNotifyGloballyEnabled;
     private ExecutorService executorService;
     private final MetricRegistry metricRegistry;
@@ -112,9 +124,9 @@ public class UserNotificationService {
         GatewayAccount gatewayAccount = gatewayAccountService.getGatewayAccountFor(transaction);
 
         HashMap<String, String> map = new HashMap<>();
-        map.put("org name", gatewayAccount.getServiceName());
-        map.put("org phone", PLACEHOLDER_PHONE_NUMBER);
-        map.put("dd guarantee link", buildDirectDebitGuaranteeUrl());
+        map.put(ORG_NAME_KEY, gatewayAccount.getServiceName());
+        map.put(ORG_PHONE_KEY, PLACEHOLDER_PHONE_NUMBER);
+        map.put(DD_GUARANTEE_KEY, buildDirectDebitGuaranteeUrl());
 
         return map;
     }
@@ -123,15 +135,15 @@ public class UserNotificationService {
         GatewayAccount gatewayAccount = gatewayAccountService.getGatewayAccountFor(transaction);
 
         HashMap<String, String> map = new HashMap<>();
-        map.put("service name", gatewayAccount.getServiceName());
-        map.put("amount", formatToPounds(transaction.getAmount()));
-        map.put("payment reference", transaction.getPaymentRequestReference());
-        map.put("bank account last 2 digits", "******" + payer.getAccountNumberLastTwoDigits());
-        map.put("collection date", DATE_TIME_FORMATTER.format(earliestChargeDate));
-        map.put("SUN", PLACEHOLDER_SUN);
-        map.put("merchant address", PLACEHOLDER_MERCHANT_ADDRESS);
-        map.put("merchant phone number", PLACEHOLDER_PHONE_NUMBER);
-        map.put("dd guarantee link", buildDirectDebitGuaranteeUrl());
+        map.put(SERVICE_NAME_KEY, gatewayAccount.getServiceName());
+        map.put(AMOUNT_KEY, formatToPounds(transaction.getAmount()));
+        map.put(PAYMENT_REFERENCE_KEY, transaction.getPaymentRequestReference());
+        map.put(BANK_ACCOUNT_LAST_DIGITS_KEY, "******" + payer.getAccountNumberLastTwoDigits());
+        map.put(COLLECTION_DATE_KEY, DATE_TIME_FORMATTER.format(earliestChargeDate));
+        map.put(SUN_KEY, PLACEHOLDER_SUN);
+        map.put(MERCHANT_ADDRESS_KEY, PLACEHOLDER_MERCHANT_ADDRESS);
+        map.put(MERCHANT_PHONE_NUMBER_KEY, PLACEHOLDER_PHONE_NUMBER);
+        map.put(DD_GUARANTEE_KEY, buildDirectDebitGuaranteeUrl());
         return map;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -124,6 +124,7 @@ public class UserNotificationService {
         map.put("SUN", "THE-CAKE-IS-A-LIE");
         map.put("merchant address", "123 Rainbow Road, EC125Y, London");
         map.put("merchant phone number", "+44 000-CAKE-000");
+        map.put("dd guarantee link", directDebitConfig.getLinks().getFrontendUrl() + "/direct-debit-guarantee");
         return map;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -7,7 +7,6 @@ import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.gatewayaccounts.services.GatewayAccountService;
-import uk.gov.pay.directdebit.notifications.config.NotifyClientFactory;
 import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.service.notify.NotificationClient;
@@ -15,7 +14,11 @@ import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
 
 import javax.inject.Inject;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -24,7 +27,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.Runtime.getRuntime;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 
 public class UserNotificationService {
@@ -36,7 +38,7 @@ public class UserNotificationService {
     private final NotificationClient notificationClient;
     private final DirectDebitConfig directDebitConfig;
     private final GatewayAccountService gatewayAccountService;
-
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     @Inject
     public UserNotificationService(DirectDebitConfig directDebitConfig,
                                    NotificationClient notificationClient,
@@ -53,21 +55,23 @@ public class UserNotificationService {
         this.gatewayAccountService = gatewayAccountService;
     }
 
-    public Future<Optional<String>> sendMandateFailedEmail(Payer payer, Transaction transaction) {
+    public Future<Optional<String>> sendEmail(Map<String, String> personalisation,
+                                              String templateId,
+                                              String emailAddress,
+                                              String paymentRequestExternalId) {
         if (emailNotifyGloballyEnabled) {
-            String mandateFailedTemplateId = directDebitConfig.getNotifyConfig().getMandateFailedTemplateId();
             Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
             return executorService.submit(() -> {
                 try {
                     SendEmailResponse response = notificationClient
                             .sendEmail(
-                                    mandateFailedTemplateId,
-                                    payer.getEmail(),
-                                    buildMandateFailedPersonalisation(transaction),
+                                    templateId,
+                                    emailAddress,
+                                    personalisation,
                                     null);
                     return Optional.of(response.getNotificationId().toString());
                 } catch (NotificationClientException e) {
-                    LOGGER.error("Failed to send mandate failed email, payment request id: {}, error {}", transaction.getPaymentRequestExternalId(), e);
+                    LOGGER.error("Failed to send email, payment request id: {}, error {}", paymentRequestExternalId, e);
                     metricRegistry.counter("notify-operations.failures").inc();
                     return Optional.empty();
                 } finally {
@@ -77,6 +81,24 @@ public class UserNotificationService {
             });
         }
         return CompletableFuture.completedFuture(Optional.empty());
+    }
+
+    public Future<Optional<String>> sendMandateFailedEmailFor(Transaction transaction, Payer payer) {
+        String mandateFailedTemplateId = directDebitConfig.getNotifyConfig().getMandateFailedTemplateId();
+        LOGGER.info("Sending mandate failed email, payment request id: {}", transaction.getPaymentRequestExternalId());
+        return sendEmail(buildMandateFailedPersonalisation(transaction),
+                mandateFailedTemplateId,
+                payer.getEmail(),
+                transaction.getPaymentRequestExternalId());
+    }
+
+    public Future<Optional<String>> sendPaymentConfirmedEmailFor(Transaction transaction, Payer payer, LocalDate earliestChargeDate) {
+        String paymentConfirmedTemplateId = directDebitConfig.getNotifyConfig().getPaymentConfirmedTemplateId();
+        LOGGER.info("Sending payment confirmed email, payment request id: {}", transaction.getPaymentRequestExternalId());
+        return sendEmail(buildPaymentConfirmedPersonalisation(transaction, payer,earliestChargeDate),
+                paymentConfirmedTemplateId,
+                payer.getEmail(),
+                transaction.getPaymentRequestExternalId());
     }
 
     private HashMap<String, String> buildMandateFailedPersonalisation(Transaction transaction) {
@@ -89,4 +111,24 @@ public class UserNotificationService {
 
         return map;
     }
+
+    private HashMap<String, String> buildPaymentConfirmedPersonalisation(Transaction transaction, Payer payer, LocalDate earliestChargeDate) {
+        GatewayAccount gatewayAccount = gatewayAccountService.getGatewayAccountFor(transaction);
+
+        HashMap<String, String> map = new HashMap<>();
+        map.put("service name", gatewayAccount.getServiceName());
+        map.put("amount", formatToPounds(transaction.getAmount()));
+        map.put("payment reference", transaction.getPaymentRequestReference());
+        map.put("bank account last 2 digits", "******" + payer.getAccountNumberLastTwoDigits());
+        map.put("collection date", dateTimeFormatter.format(earliestChargeDate));
+        map.put("SUN", "THE-CAKE-IS-A-LIE");
+        map.put("merchant address", "123 Rainbow Road, EC125Y, London");
+        map.put("merchant phone number", "+44 000-CAKE-000");
+        return map;
+    }
+
+    private String formatToPounds(long amountInPence) {
+        return BigDecimal.valueOf(amountInPence, 2).toString();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
@@ -12,6 +12,8 @@ import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
 import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
+import java.time.LocalDate;
+
 //thin abstraction over the client provided in the SDK
 public class GoCardlessClientWrapper {
 
@@ -69,6 +71,7 @@ public class GoCardlessClientWrapper {
                 .execute();
         return new GoCardlessPayment(
                 transaction.getId(),
-                goCardlessPayment.getId());
+                goCardlessPayment.getId(),
+                LocalDate.parse(goCardlessPayment.getChargeDate()));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -16,6 +16,7 @@ public class TransactionMapper implements ResultSetMapper<Transaction> {
     private static final String STATE_COLUMN = "state";
     private static final String PAYMENT_REQUEST_ID_COLUMN = "payment_request_id";
     private static final String PAYMENT_REQUEST_EXTERNAL_ID_COLUMN = "external_id";
+    private static final String PAYMENT_REQUEST_REFERENCE_COLUMN = "reference";
     private static final String PAYMENT_REQUEST_RETURN_URL_COLUMN = "return_url";
     private static final String PAYMENT_REQUEST_GATEWAY_ACCOUNT_ID_COLUMN = "gateway_account_id";
     private static final String PAYMENT_REQUEST_DESCRIPTION_COLUMN = "description";
@@ -28,6 +29,7 @@ public class TransactionMapper implements ResultSetMapper<Transaction> {
                 resultSet.getLong(PAYMENT_REQUEST_ID_COLUMN),
                 resultSet.getString(PAYMENT_REQUEST_EXTERNAL_ID_COLUMN),
                 resultSet.getString(PAYMENT_REQUEST_DESCRIPTION_COLUMN),
+                resultSet.getString(PAYMENT_REQUEST_REFERENCE_COLUMN),
                 resultSet.getLong(PAYMENT_REQUEST_GATEWAY_ACCOUNT_ID_COLUMN),
                 PaymentProvider.fromString(resultSet.getString(GATEWAY_ACCOUNT_PAYMENT_PROVIDER_COLUMN)),
                 resultSet.getString(PAYMENT_REQUEST_RETURN_URL_COLUMN),

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -9,31 +9,34 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 public class Transaction {
 
     private Long id;
+    //todo refactor this to contain a PaymentRequest
     private String paymentRequestExternalId;
     private Long paymentRequestId;
     private String paymentRequestDescription;
     private String paymentRequestReturnUrl;
+    private String paymentRequestReference;
     private Long paymentRequestGatewayAccountId;
     private PaymentProvider paymentProvider;
     private Long amount;
     private Type type;
     private PaymentState state;
 
-    public Transaction(Long id, Long paymentRequestId, String paymentRequestExternalId, String paymentRequestDescription, Long paymentRequestGatewayAccountId, PaymentProvider paymentProvider, String paymentRequestReturnUrl, Long amount, Type type, PaymentState state) {
+    public Transaction(Long id, Long paymentRequestId, String paymentRequestExternalId, String paymentRequestDescription, String paymentRequestReference, Long paymentRequestGatewayAccountId, PaymentProvider paymentProvider, String paymentRequestReturnUrl, Long amount, Type type, PaymentState state) {
         this.id = id;
         this.paymentRequestExternalId = paymentRequestExternalId;
         this.paymentRequestId = paymentRequestId;
         this.paymentRequestGatewayAccountId = paymentRequestGatewayAccountId;
         this.paymentProvider = paymentProvider;
         this.paymentRequestDescription = paymentRequestDescription;
+        this.paymentRequestReference = paymentRequestReference;
         this.paymentRequestReturnUrl = paymentRequestReturnUrl;
         this.amount = amount;
         this.type = type;
         this.state = state;
     }
 
-    public Transaction(Long paymentRequestId, String paymentRequestExternalId, String paymentRequestDescription, Long paymentRequestGatewayAccountId, PaymentProvider paymentProvider, String paymentRequestReturnUrl, Long amount, Type type, PaymentState state) {
-        this(null, paymentRequestId, paymentRequestExternalId, paymentRequestDescription, paymentRequestGatewayAccountId, paymentProvider, paymentRequestReturnUrl, amount, type, state);
+    public Transaction(Long paymentRequestId, String paymentRequestExternalId, String paymentRequestDescription, String paymentRequestReference,  Long paymentRequestGatewayAccountId, PaymentProvider paymentProvider, String paymentRequestReturnUrl, Long amount, Type type, PaymentState state) {
+        this(null, paymentRequestId, paymentRequestExternalId, paymentRequestDescription, paymentRequestReference, paymentRequestGatewayAccountId, paymentProvider, paymentRequestReturnUrl, amount, type, state);
     }
 
     public Long getId() {
@@ -84,6 +87,15 @@ public class Transaction {
         this.paymentRequestDescription = paymentRequestDescription;
     }
 
+    public String getPaymentRequestReference() {
+        return paymentRequestReference;
+    }
+
+    public Transaction setPaymentRequestReference(String paymentRequestReference) {
+        this.paymentRequestReference = paymentRequestReference;
+        return this;
+    }
+
     public PaymentProvider getPaymentProvider() {
         return paymentProvider;
     }
@@ -129,6 +141,7 @@ public class Transaction {
         if (!paymentProvider.equals(that.paymentProvider)) return false;
         if (!paymentRequestId.equals(that.paymentRequestId)) return false;
         if (!paymentRequestReturnUrl.equals(that.paymentRequestReturnUrl)) return false;
+        if (!paymentRequestReference.equals(that.paymentRequestReference)) return false;
         if (!amount.equals(that.amount)) return false;
         if (type != that.type) return false;
         return state == that.state;
@@ -143,6 +156,7 @@ public class Transaction {
         result = 31 * result + paymentProvider.hashCode();
         result = 31 * result + paymentRequestDescription.hashCode();
         result = 31 * result + paymentRequestReturnUrl.hashCode();
+        result = 31 * result + paymentRequestReference.hashCode();
         result = 31 * result + amount.hashCode();
         result = 31 * result + type.hashCode();
         result = 31 * result + state.hashCode();

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 public class SandboxService implements DirectDebitPaymentProvider {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(SandboxService.class);
+    private static final LocalDate DAYS_UNTIL_COLLECTION = LocalDate.now().plusDays(4);
 
     private final PayerService payerService;
     private final PaymentConfirmService paymentConfirmService;
@@ -40,6 +41,6 @@ public class SandboxService implements DirectDebitPaymentProvider {
         LOGGER.info("Confirming payment for SANDBOX, payment with id: {}", paymentRequestExternalId);
         ConfirmationDetails confirmationDetails = paymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId);
         Payer payer = payerService.getPayerFor(confirmationDetails.getTransaction());
-        transactionService.paymentCreatedFor(confirmationDetails.getTransaction(), payer, LocalDate.now().plusDays(4));
+        transactionService.paymentCreatedFor(confirmationDetails.getTransaction(), payer, DAYS_UNTIL_COLLECTION);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
@@ -15,8 +15,7 @@ import java.util.Map;
 
 public class SandboxService implements DirectDebitPaymentProvider {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(SandboxService.class);
-    private static final LocalDate DAYS_UNTIL_COLLECTION = LocalDate.now().plusDays(4);
-
+    private static final int DAYS_TO_COLLECTION = 4;
     private final PayerService payerService;
     private final PaymentConfirmService paymentConfirmService;
     private final TransactionService transactionService;
@@ -41,6 +40,6 @@ public class SandboxService implements DirectDebitPaymentProvider {
         LOGGER.info("Confirming payment for SANDBOX, payment with id: {}", paymentRequestExternalId);
         ConfirmationDetails confirmationDetails = paymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId);
         Payer payer = payerService.getPayerFor(confirmationDetails.getTransaction());
-        transactionService.paymentCreatedFor(confirmationDetails.getTransaction(), payer, DAYS_UNTIL_COLLECTION);
+        transactionService.paymentCreatedFor(confirmationDetails.getTransaction(), payer, LocalDate.now().plusDays(DAYS_TO_COLLECTION));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
@@ -10,6 +10,7 @@ import uk.gov.pay.directdebit.payers.services.PayerService;
 import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProvider;
 
 import javax.inject.Inject;
+import java.time.LocalDate;
 import java.util.Map;
 
 public class SandboxService implements DirectDebitPaymentProvider {
@@ -38,6 +39,7 @@ public class SandboxService implements DirectDebitPaymentProvider {
     public void confirm(String paymentRequestExternalId, GatewayAccount gatewayAccount) {
         LOGGER.info("Confirming payment for SANDBOX, payment with id: {}", paymentRequestExternalId);
         ConfirmationDetails confirmationDetails = paymentConfirmService.confirm(gatewayAccount.getId(), paymentRequestExternalId);
-        transactionService.paymentCreatedFor(confirmationDetails.getTransaction());
+        Payer payer = payerService.getPayerFor(confirmationDetails.getTransaction());
+        transactionService.paymentCreatedFor(confirmationDetails.getTransaction(), payer, LocalDate.now().plusDays(4));
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -37,6 +37,7 @@ goCardless:
 notify:
   apiKey: ${GDS_DIRECTDEBIT_CONNECTOR_NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   mandateFailedTemplateId: ${NOTIFY_MANDATE_FAILED_EMAIL_TEMPLATE_ID}
+  paymentConfirmedTemplateId: ${NOTIFY_PAYMENT_CONFIRMATION_EMAIL_TEMPLATE_ID}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://api.notifications.service.gov.uk}
   emailNotifyEnabled: ${NOTIFY_EMAIL_ENABLED:-false}
 

--- a/src/test/java/uk/gov/pay/directdebit/app/config/LinksConfigTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/app/config/LinksConfigTest.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.directdebit.app.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LinksConfigTest {
+    @Spy
+    private LinksConfig linksConfig = new LinksConfig();
+
+    @Test
+    public void shouldBuildTheCorrectDDGuaranteeUrl() {
+        when(linksConfig.getFrontendUrl()).thenReturn("https://frontend.url");
+        assertThat(linksConfig.getDirectDebitGuaranteeUrl(), is("https://frontend.url/direct-debit-guarantee"));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessPaymentFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessPaymentFixture.java
@@ -6,11 +6,15 @@ import uk.gov.pay.directdebit.common.fixtures.DbFixture;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
 
+import java.sql.Date;
+import java.time.LocalDate;
+
 public class GoCardlessPaymentFixture implements DbFixture<GoCardlessPaymentFixture, GoCardlessPayment> {
 
     private Long id = RandomUtils.nextLong(1, 99999);
     private Long transactionId = RandomUtils.nextLong(1, 99999);
     private String paymentId = RandomIdGenerator.newId();
+    private LocalDate chargeDate = LocalDate.now().plusDays(5);
 
     private GoCardlessPaymentFixture() {
 
@@ -47,6 +51,15 @@ public class GoCardlessPaymentFixture implements DbFixture<GoCardlessPaymentFixt
         return this;
     }
 
+    public LocalDate getChargeDate() {
+        return chargeDate;
+    }
+
+    public GoCardlessPaymentFixture setChargeDate(LocalDate chargeDate) {
+        this.chargeDate = chargeDate;
+        return this;
+    }
+
     @Override
     public GoCardlessPaymentFixture insert(DBI jdbi) {
         jdbi.withHandle(h ->
@@ -55,12 +68,14 @@ public class GoCardlessPaymentFixture implements DbFixture<GoCardlessPaymentFixt
                                 "    gocardless_payments(\n" +
                                 "        id,\n" +
                                 "        transaction_id,\n" +
-                                "        payment_id\n" +
+                                "        payment_id,\n" +
+                                "        charge_date\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, ?)\n",
+                                "   VALUES(?, ?, ?, ?)\n",
                         id,
                         transactionId,
-                        paymentId
+                        paymentId,
+                        Date.valueOf(chargeDate)
                 )
         );
         return this;
@@ -68,6 +83,6 @@ public class GoCardlessPaymentFixture implements DbFixture<GoCardlessPaymentFixt
 
     @Override
     public GoCardlessPayment toEntity() {
-        return new GoCardlessPayment(id, transactionId, paymentId);
+        return new GoCardlessPayment(id, transactionId, paymentId, chargeDate);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -80,7 +80,7 @@ public class UserNotificationServiceTest {
         when(mockNotifyClientFactory.getPaymentConfirmedTemplateId()).thenReturn(PAYMENT_CONFIRMATION_TEMPLATE);
         when(mockExecutorConfiguration.getThreadsPerCpu()).thenReturn(2);
         when(mockGatewayAccountService.getGatewayAccountFor(transaction)).thenReturn(gatewayAccount);
-        when(mockLinksConfig.getFrontendUrl()).thenReturn("https://frontend.url.test");
+        when(mockLinksConfig.getDirectDebitGuaranteeUrl()).thenReturn("https://frontend.url.test/direct-debit-guarantee");
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -126,6 +126,7 @@ public class UserNotificationServiceTest {
         emailPersonalisation.put("SUN", "THE-CAKE-IS-A-LIE");
         emailPersonalisation.put("merchant address", "123 Rainbow Road, EC125Y, London");
         emailPersonalisation.put("merchant phone number", "+44 000-CAKE-000");
+        emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
 
         verify(mockNotifyClient).sendEmail(
                 PAYMENT_CONFIRMATION_TEMPLATE,

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -145,8 +145,8 @@ public class UserNotificationServiceTest {
         when(mockNotifyClientFactory.isEmailNotifyEnabled()).thenReturn(false);
         userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
 
-        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
-        idF.get(1000, TimeUnit.SECONDS);
+        Future<Optional<String>> maybeNotificationId = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
+        maybeNotificationId.get(1000, TimeUnit.SECONDS);
 
         verifyZeroInteractions(mockNotifyClient);
     }

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -14,31 +14,29 @@ import uk.gov.pay.directdebit.app.config.LinksConfig;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.gatewayaccounts.services.GatewayAccountService;
 import uk.gov.pay.directdebit.notifications.config.NotifyClientFactory;
-import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payers.model.Payer;
-import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
-import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.UUID.randomUUID;
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserNotificationServiceTest {
@@ -65,16 +63,21 @@ public class UserNotificationServiceTest {
     private UserNotificationService userNotificationService;
 
     private static final String EMAIL = "ksdfhkjsdh@sdjkfh.test";
-    private Payer payer = PayerFixture.aPayerFixture().withEmail(EMAIL).toEntity();
-    private Transaction transaction = TransactionFixture.aTransactionFixture().toEntity();
-    private GatewayAccount gatewayAccount = GatewayAccountFixture.aGatewayAccountFixture().toEntity();
+    private static final String MANDATE_FAILED_TEMPLATE = "mandate-failed-template";
+    private static final String PAYMENT_CONFIRMATION_TEMPLATE = "payment-confirmation-template";
+    private Payer payer = aPayerFixture().withEmail(EMAIL).toEntity();
+    private Transaction transaction = aTransactionFixture()
+            .withAmount(12345L)
+            .toEntity();
+    private GatewayAccount gatewayAccount = aGatewayAccountFixture().toEntity();
 
     @Before
     public void setUp() {
         when(mockDirectDebitConfig.getNotifyConfig()).thenReturn(mockNotifyClientFactory);
         when(mockDirectDebitConfig.getExecutorServiceConfig()).thenReturn(mockExecutorConfiguration);
         when(mockDirectDebitConfig.getLinks()).thenReturn(mockLinksConfig);
-        when(mockNotifyClientFactory.getMandateFailedTemplateId()).thenReturn("some-template");
+        when(mockNotifyClientFactory.getMandateFailedTemplateId()).thenReturn(MANDATE_FAILED_TEMPLATE);
+        when(mockNotifyClientFactory.getPaymentConfirmedTemplateId()).thenReturn(PAYMENT_CONFIRMATION_TEMPLATE);
         when(mockExecutorConfiguration.getThreadsPerCpu()).thenReturn(2);
         when(mockGatewayAccountService.getGatewayAccountFor(transaction)).thenReturn(gatewayAccount);
         when(mockLinksConfig.getFrontendUrl()).thenReturn("https://frontend.url.test");
@@ -85,24 +88,50 @@ public class UserNotificationServiceTest {
     }
 
     @Test
-    public void shouldSendEmailIfEmailNotifyIsEnabled() throws Exception {
+    public void shouldSendMandateFailedEmailIfEmailNotifyIsEnabled() throws Exception {
         when(mockNotifyClientFactory.isEmailNotifyEnabled()).thenReturn(true);
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
 
         userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
-        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmail(payer, transaction);
+        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
         idF.get(1000, TimeUnit.SECONDS);
 
-        HashMap<String, String> map = new HashMap<>();
-        map.put("org name", gatewayAccount.getServiceName());
-        map.put("org phone", "000-CAKE-000");
-        map.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
+        HashMap<String, String> emailPersonalisation = new HashMap<>();
+        emailPersonalisation.put("org name", gatewayAccount.getServiceName());
+        emailPersonalisation.put("org phone", "000-CAKE-000");
+        emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
         verify(mockNotifyClient).sendEmail(
-                mockNotifyClientFactory.getMandateFailedTemplateId(),
+                MANDATE_FAILED_TEMPLATE,
                 EMAIL,
-                map,
+                emailPersonalisation,
                 null
         );
+    }
+
+    @Test
+    public void shouldSendPaymentConfirmedEmailIfEmailNotifyIsEnabled() throws Exception {
+        when(mockNotifyClientFactory.isEmailNotifyEnabled()).thenReturn(true);
+        when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
+
+        userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
+        Future<Optional<String>> idF = userNotificationService.sendPaymentConfirmedEmailFor(transaction, payer, LocalDate.parse("2018-05-21"));
+        idF.get(1000, TimeUnit.SECONDS);
+
+        HashMap<String, String> emailPersonalisation = new HashMap<>();
+        emailPersonalisation.put("service name", gatewayAccount.getServiceName());
+        emailPersonalisation.put("amount", "123.45");
+        emailPersonalisation.put("payment reference", transaction.getPaymentRequestReference());
+        emailPersonalisation.put("collection date", "21/05/2018");
+        emailPersonalisation.put("bank account last 2 digits", "******" + payer.getAccountNumberLastTwoDigits());
+        emailPersonalisation.put("SUN", "THE-CAKE-IS-A-LIE");
+        emailPersonalisation.put("merchant address", "123 Rainbow Road, EC125Y, London");
+        emailPersonalisation.put("merchant phone number", "+44 000-CAKE-000");
+
+        verify(mockNotifyClient).sendEmail(
+                PAYMENT_CONFIRMATION_TEMPLATE,
+                EMAIL,
+                emailPersonalisation,
+                null);
     }
 
     @Test
@@ -110,7 +139,7 @@ public class UserNotificationServiceTest {
         when(mockNotifyClientFactory.isEmailNotifyEnabled()).thenReturn(false);
         userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
 
-        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmail(payer, transaction);
+        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
         idF.get(1000, TimeUnit.SECONDS);
 
         verifyZeroInteractions(mockNotifyClient);
@@ -123,7 +152,7 @@ public class UserNotificationServiceTest {
 
         userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
 
-        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmail(payer, transaction);
+        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
         idF.get(1000, TimeUnit.SECONDS);
         verify(mockMetricRegistry).histogram("notify-operations.response_time");
         verify(mockHistogram).update(anyLong());
@@ -137,7 +166,7 @@ public class UserNotificationServiceTest {
 
         userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
 
-        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmail(payer, transaction);
+        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
         idF.get(1000, TimeUnit.SECONDS);
         verify(mockMetricRegistry).histogram("notify-operations.response_time");
         verify(mockHistogram).update(anyLong());

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -90,16 +90,19 @@ public class UserNotificationServiceTest {
     @Test
     public void shouldSendMandateFailedEmailIfEmailNotifyIsEnabled() throws Exception {
         when(mockNotifyClientFactory.isEmailNotifyEnabled()).thenReturn(true);
-        when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
 
         userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
-        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
-        idF.get(1000, TimeUnit.SECONDS);
 
         HashMap<String, String> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put("org name", gatewayAccount.getServiceName());
-        emailPersonalisation.put("org phone", "000-CAKE-000");
+        emailPersonalisation.put("org phone", "+44 000-CAKE-000");
         emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
+
+        when(mockNotifyClient.sendEmail(MANDATE_FAILED_TEMPLATE, EMAIL, emailPersonalisation, null)).thenReturn(mockNotificationCreatedResponse);
+
+        Future<Optional<String>> maybeNotificationId = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
+        maybeNotificationId.get(1000, TimeUnit.SECONDS);
+
         verify(mockNotifyClient).sendEmail(
                 MANDATE_FAILED_TEMPLATE,
                 EMAIL,
@@ -111,11 +114,8 @@ public class UserNotificationServiceTest {
     @Test
     public void shouldSendPaymentConfirmedEmailIfEmailNotifyIsEnabled() throws Exception {
         when(mockNotifyClientFactory.isEmailNotifyEnabled()).thenReturn(true);
-        when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
 
         userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
-        Future<Optional<String>> idF = userNotificationService.sendPaymentConfirmedEmailFor(transaction, payer, LocalDate.parse("2018-05-21"));
-        idF.get(1000, TimeUnit.SECONDS);
 
         HashMap<String, String> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put("service name", gatewayAccount.getServiceName());
@@ -127,6 +127,11 @@ public class UserNotificationServiceTest {
         emailPersonalisation.put("merchant address", "123 Rainbow Road, EC125Y, London");
         emailPersonalisation.put("merchant phone number", "+44 000-CAKE-000");
         emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
+
+        when(mockNotifyClient.sendEmail(PAYMENT_CONFIRMATION_TEMPLATE, EMAIL, emailPersonalisation, null)).thenReturn(mockNotificationCreatedResponse);
+
+        Future<Optional<String>> maybeNotificationId = userNotificationService.sendPaymentConfirmedEmailFor(transaction, payer, LocalDate.parse("2018-05-21"));
+        maybeNotificationId.get(1000, TimeUnit.SECONDS);
 
         verify(mockNotifyClient).sendEmail(
                 PAYMENT_CONFIRMATION_TEMPLATE,
@@ -153,8 +158,8 @@ public class UserNotificationServiceTest {
 
         userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
 
-        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
-        idF.get(1000, TimeUnit.SECONDS);
+        Future<Optional<String>> maybeNotificationId = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
+        maybeNotificationId.get(1000, TimeUnit.SECONDS);
         verify(mockMetricRegistry).histogram("notify-operations.response_time");
         verify(mockHistogram).update(anyLong());
         verifyNoMoreInteractions(mockCounter);
@@ -167,8 +172,8 @@ public class UserNotificationServiceTest {
 
         userNotificationService = new UserNotificationService(mockDirectDebitConfig, mockNotifyClient, mockMetricRegistry, mockGatewayAccountService);
 
-        Future<Optional<String>> idF = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
-        idF.get(1000, TimeUnit.SECONDS);
+        Future<Optional<String>> maybeNotificationId = userNotificationService.sendMandateFailedEmailFor(transaction, payer);
+        maybeNotificationId.get(1000, TimeUnit.SECONDS);
         verify(mockMetricRegistry).histogram("notify-operations.response_time");
         verify(mockHistogram).update(anyLong());
         verify(mockCounter).inc();

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
@@ -14,6 +14,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private Long paymentRequestId = RandomUtils.nextLong(1, 99999);
     private String paymentRequestExternalId = RandomIdGenerator.newId();
     private String paymentRequestDescription = RandomStringUtils.randomAlphabetic(20);
+    private String paymentRequestReference = RandomStringUtils.randomAlphabetic(20);
     private Long paymentRequestGatewayAccountId = RandomUtils.nextLong(1, 99999);
     private String paymentRequestReturnUrl = "http://www." + RandomStringUtils.randomAlphabetic(10) + ".test";
     private PaymentProvider paymentProvider = PaymentProvider.SANDBOX;
@@ -40,6 +41,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
 
     public TransactionFixture withPaymentRequestDescription(String paymentRequestDescription) {
         this.paymentRequestDescription = paymentRequestDescription;
+        return this;
+    }
+    public TransactionFixture withPaymentRequestReference(String paymentRequestReference) {
+        this.paymentRequestReference = paymentRequestReference;
         return this;
     }
     public TransactionFixture withPaymentRequestGatewayAccountId(Long paymentRequestGatewayAccountId) {
@@ -100,6 +105,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return state;
     }
 
+    public String getPaymentRequestReference() {
+        return paymentRequestReference;
+    }
+
     public String getPaymentRequestReturnUrl() {
         return paymentRequestReturnUrl;
     }
@@ -137,7 +146,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
 
     @Override
     public Transaction toEntity() {
-        return new Transaction(id, paymentRequestId, paymentRequestExternalId, paymentRequestDescription, paymentRequestGatewayAccountId, paymentProvider, paymentRequestReturnUrl, amount, type, state);
+        return new Transaction(id, paymentRequestId, paymentRequestExternalId, paymentRequestDescription, paymentRequestReference, paymentRequestGatewayAccountId, paymentProvider, paymentRequestReturnUrl, amount, type, state);
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -166,12 +166,13 @@ public class GoCardlessServiceTest {
         when(mockedPaymentConfirmService.confirm(gatewayAccount.getId(), PAYMENT_REQUEST_EXTERNAL_ID)).thenReturn(confirmationDetails);
         when(mockedGoCardlessClientWrapper.createMandate(PAYMENT_REQUEST_EXTERNAL_ID, mandate, goCardlessCustomer)).thenReturn(goCardlessMandate);
         when(mockedGoCardlessClientWrapper.createPayment(PAYMENT_REQUEST_EXTERNAL_ID, goCardlessMandate, transaction)).thenReturn(goCardlessPayment);
+        when(mockedPayerService.getPayerFor(transaction)).thenReturn(payer);
         service.confirm(PAYMENT_REQUEST_EXTERNAL_ID, gatewayAccount);
         verify(mockedGoCardlessMandateDao).insert(goCardlessMandate);
         verify(mockedGoCardlessPaymentDao).insert(goCardlessPayment);
         verify(mockedGoCardlessClientWrapper).createMandate(PAYMENT_REQUEST_EXTERNAL_ID, mandate, goCardlessCustomer);
         verify(mockedGoCardlessClientWrapper).createPayment(PAYMENT_REQUEST_EXTERNAL_ID, goCardlessMandate, transaction);
-        verify(mockedTransactionService).paymentCreatedFor(transaction);
+        verify(mockedTransactionService).paymentCreatedFor(transaction, payer, goCardlessPayment.getChargeDate());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -214,9 +214,6 @@ public class TransactionServiceTest {
                 .aTransactionFixture()
                 .withState(PROCESSING_DIRECT_DEBIT_PAYMENT)
                 .toEntity();
-        when(mockedTransactionDao.findById(transaction.getId()))
-                .thenReturn(Optional.of(transaction));
-
         service.paymentCreatedFor(transaction, payer, LocalDate.now());
 
         verify(mockedTransactionDao).updateState(transaction.getId(), PENDING_DIRECT_DEBIT_PAYMENT);

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -21,6 +21,7 @@ import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -88,6 +89,7 @@ public class TransactionServiceTest {
         assertThat(transaction.getPaymentRequestReturnUrl(), is(paymentRequestFixture.getReturnUrl()));
         assertThat(transaction.getPaymentRequestGatewayAccountId(), is(paymentRequestFixture.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(paymentRequestFixture.getDescription()));
+        assertThat(transaction.getPaymentRequestReference(), is(paymentRequestFixture.getReference()));
         assertThat(transaction.getAmount(), is(paymentRequestFixture.getAmount()));
         assertThat(transaction.getType(), is(Transaction.Type.CHARGE));
         assertThat(transaction.getState(), is(NEW));
@@ -111,6 +113,7 @@ public class TransactionServiceTest {
         assertThat(foundTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(foundTransaction.getPaymentRequestGatewayAccountId(), is(transactionFixture.getPaymentRequestGatewayAccountId()));
         assertThat(foundTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(foundTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(foundTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(foundTransaction.getType(), is(transactionFixture.getType()));
         assertThat(foundTransaction.getState(), is(transactionFixture.getState()));
@@ -136,6 +139,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getPaymentRequestGatewayAccountId(), is(transactionFixture.getPaymentRequestGatewayAccountId()));
         assertThat(newTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(newTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
         assertThat(newTransaction.getState(), is(AWAITING_CONFIRMATION));
@@ -156,6 +160,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getPaymentRequestGatewayAccountId(), is(transactionFixture.getPaymentRequestGatewayAccountId()));
         assertThat(newTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(newTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
         assertThat(newTransaction.getState(), is(PROCESSING_DIRECT_DEBIT_DETAILS));
@@ -170,7 +175,7 @@ public class TransactionServiceTest {
         Transaction transaction = transactionFixture.toEntity();
         service.mandateFailedFor(transaction, payer);
         verify(mockedPaymentRequestEventService).registerMandateFailedEventFor(transaction);
-        verify(mockedUserNotificationService).sendMandateFailedEmail(payer, transaction);
+        verify(mockedUserNotificationService).sendMandateFailedEmailFor(transaction, payer);
     }
 
     @Test
@@ -188,6 +193,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getPaymentRequestGatewayAccountId(), is(transactionFixture.getPaymentRequestGatewayAccountId()));
         assertThat(newTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(newTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
         assertThat(newTransaction.getState(), is(AWAITING_DIRECT_DEBIT_DETAILS));
@@ -211,7 +217,7 @@ public class TransactionServiceTest {
         when(mockedTransactionDao.findById(transaction.getId()))
                 .thenReturn(Optional.of(transaction));
 
-        service.paymentCreatedFor(transaction);
+        service.paymentCreatedFor(transaction, payer, LocalDate.now());
 
         verify(mockedTransactionDao).updateState(transaction.getId(), PENDING_DIRECT_DEBIT_PAYMENT);
         verify(mockedPaymentRequestEventService).registerPaymentCreatedEventFor(transaction);

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -37,6 +37,7 @@ executorService:
 
 notify:
   mandateFailedTemplateId: test-template-id
+  paymentConfirmedTemplateId: test-template-id
   apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false


### PR DESCRIPTION
## WHAT
- When a user confirms a payment, we send out an email to their address. This emails contains a few details about the payment they are about to set up. A few of them are pretty self-explanatory, like `service name`, `amount`, `payment reference`, `last two digits of the bank account`
- `colelction date` is a bit more interesting. GoCardless sends back to us the earliest charge date (or the one you set up yourself, in case of scheduled / ad hoc payments), so we are using that to give an indication to the user as to when the payment will be taken
- `SUN` is not filled in right now, as we still have to decide which one will be used
- `merchant details` are not filled in either. This is because merchant details are at a service level and this is becoming increasingly not compatible with our needs. There are plans to refactor this bit, so we are postponing filling merchant details in the email until we have more clarity on this.