### PR TITLE
Fix exception message (String.format uses %s not {} as placeholder)

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -168,8 +168,8 @@ public class TransactionService {
 
     public PaymentRequestEvent findPaymentPendingEventFor(Transaction transaction) {
         return paymentRequestEventService.findBy(transaction.getPaymentRequestId(), CHARGE, PAYMENT_PENDING)
-                .orElseThrow(() -> new InvalidStateException(format("Could not find payment pending event for payment request with id: {}",
-                        transaction.getPaymentRequestExternalId())));
+                .orElseThrow(() -> new InvalidStateException("Could not find payment pending event for payment request with id: "
+                        + transaction.getPaymentRequestExternalId()));
     }
 
     public Optional<PaymentRequestEvent> findMandatePendingEventFor(Transaction transaction) {


### PR DESCRIPTION
Change:

```java
new InvalidStateException(format("Could not find payment pending event for payment request with id: {}", transaction.getPaymentRequestExternalId()))
```

… to:

```java
new InvalidStateException("Could not find payment pending event for payment request with id: " + transaction.getPaymentRequestExternalId()))
```

… which will actually output the ID, not a literal `{}`.
