### PR TITLE
PP-3828 Make sure we store events even when the handlers throw an exception

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.payments.services.GoCardlessService;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 import uk.gov.pay.directdebit.webhook.gocardless.services.GoCardlessAction;
 
+import javax.inject.Inject;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -21,6 +22,7 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(GoCardlessMandateHandler.class);
     private final PayerService payerService;
 
+    @Inject
     public GoCardlessMandateHandler(TransactionService transactionService, GoCardlessService goCardlessService, PayerService payerService) {
         super(transactionService, goCardlessService);
         this.payerService = payerService;

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -11,6 +11,7 @@ import uk.gov.pay.directdebit.payments.services.GoCardlessService;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 import uk.gov.pay.directdebit.webhook.gocardless.services.GoCardlessAction;
 
+import javax.inject.Inject;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -18,6 +19,7 @@ import java.util.function.Function;
 public class GoCardlessPaymentHandler extends GoCardlessHandler {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(GoCardlessPaymentHandler.class);
 
+    @Inject
     public GoCardlessPaymentHandler(TransactionService transactionService, GoCardlessService goCardlessService) {
         super(transactionService, goCardlessService);
     }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.payments.model.GoCardlessResourceType;
 import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.GoCardlessService;
@@ -72,6 +73,22 @@ public class GoCardlessPaymentHandlerTest {
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
         verify(mockedTransactionService).paymentPendingFor(transaction);
+        verify(goCardlessEvent).setPaymentRequestEventId(paymentRequestEvent.getId());
+        verify(mockedGoCardlessService).storeEvent(geCaptor.capture());
+        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
+        Assert.assertThat(storedGoCardlessEvent.getPaymentRequestEventId(), is(paymentRequestEvent.getId()));
+    }
+
+    @Test
+    public void handle_onPayoutPaidGoCardlessEvent_shouldSetRegisterPayoutPaidEvent() {
+        GoCardlessEvent goCardlessEvent = spy(GoCardlessEventFixture.aGoCardlessEventFixture().withAction("paid").withResourceType(GoCardlessResourceType.PAYOUTS).toEntity());
+
+        when(mockedGoCardlessService.findPaymentForEvent(goCardlessEvent)).thenReturn(goCardlessPaymentFixture.toEntity());
+        when(mockedTransactionService.payoutPaidFor(transaction)).thenReturn(paymentRequestEvent);
+
+        goCardlessPaymentHandler.handle(goCardlessEvent);
+
+        verify(mockedTransactionService).payoutPaidFor(transaction);
         verify(goCardlessEvent).setPaymentRequestEventId(paymentRequestEvent.getId());
         verify(mockedGoCardlessService).storeEvent(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();


### PR DESCRIPTION
- When mandate/payment handlers for webhooks throw an exception, the exception mapper
  of Dropwizard kicks in and the execution is interrupted. As we were storing events after handling them, we were missing quite a few of them.
- We are now storing events immediately after parsing the webhook, so that whatever happens
  in the handler, we are already covered

## HOW 
Create one or more webhooks in stubs and send them to dd connector. DD connector logs will show an error. Nevertheless, we should see in the database all the events.