### PR TITLE
PP-3361 Add state and reference columns to mandate table

### DIFF
--- a/src/main/resources/migrations/00015_alter_table_mandates_reference_state.sql
+++ b/src/main/resources/migrations/00015_alter_table_mandates_reference_state.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-mandates-reference
+ALTER TABLE mandates ADD COLUMN reference VARCHAR(18);
+--rollback ALTER TABLE mandates DROP COLUMN reference;
+
+--changeset uk.gov.pay:alter_table-mandates-state
+ALTER TABLE mandates ADD COLUMN state VARCHAR(255);
+--rollback ALTER TABLE mandates DROP COLUMN state;


### PR DESCRIPTION
## WHAT
 - State will be used to keep track of the state of a mandate
 - Reference is what will be displayed in the body of the email
   we send to the users. It has to follow certain rules so we can't simply
   use the external id we generate. See https://support.gocardless.com/hc/en-gb/articles/115004246645-Custom-mandate-references-guidance

