### PR TITLE
PP-3361 Handle mandate cancelled event

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -1,11 +1,16 @@
 package uk.gov.pay.directdebit.mandate.dao;
 
+import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 import uk.gov.pay.directdebit.mandate.dao.mapper.MandateMapper;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+
+import java.util.Optional;
 
 @RegisterMapper(MandateMapper.class)
 public interface MandateDao {
@@ -13,4 +18,8 @@ public interface MandateDao {
     @SqlUpdate("INSERT INTO mandates(payer_id, external_id) VALUES (:payerId, :externalId)")
     @GetGeneratedKeys
     Long insert(@BindBean Mandate mandate);
+
+    @SqlQuery("SELECT * FROM mandates m JOIN payers p ON m.payer_id = p.id JOIN transactions t ON t.payment_request_id = p.payment_request_id WHERE t.id = :transactionId")
+    @SingleValueResult(Mandate.class)
+    Optional<Mandate> findByTransactionId(@Bind("transactionId") Long transactionId);
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/exception/MandateNotFoundException.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/exception/MandateNotFoundException.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.directdebit.mandate.exception;
+
+
+import uk.gov.pay.directdebit.common.exception.NotFoundException;
+
+import static java.lang.String.format;
+
+public class MandateNotFoundException extends NotFoundException {
+
+    public MandateNotFoundException(String transactionId) {
+        super(format("Couldn't find mandate for transaction with id: %s", transactionId));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/notifications/config/NotifyClientFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/config/NotifyClientFactory.java
@@ -22,11 +22,16 @@ public class NotifyClientFactory extends Configuration {
     private String mandateFailedTemplateId;
     @NotNull
     private String paymentConfirmedTemplateId;
+    @NotNull
+    private String mandateCancelledTemplateId;
 
     public String getMandateFailedTemplateId() {
         return mandateFailedTemplateId;
     }
 
+    public String getMandateCancelledTemplateId() {
+        return mandateCancelledTemplateId;
+    }
     public String getPaymentConfirmedTemplateId() {
         return paymentConfirmedTemplateId;
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/ChargeNotFoundException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/ChargeNotFoundException.java
@@ -6,7 +6,7 @@ import static java.lang.String.format;
 
 public class ChargeNotFoundException extends NotFoundException {
 
-    public ChargeNotFoundException(String paymentRequestExternalId) {
-        super(format("No charges found for payment request with id: %s", paymentRequestExternalId));
+    public ChargeNotFoundException(String key, String id) {
+        super(format("No charges found for %s: %s", key, id));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -10,6 +10,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_CANCELLED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID;
@@ -86,6 +87,10 @@ public class PaymentRequestEvent {
         return new PaymentRequestEvent(paymentRequestId, Type.MANDATE, MANDATE_FAILED);
     }
 
+    public static PaymentRequestEvent mandateCancelled(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, Type.MANDATE, MANDATE_CANCELLED);
+    }
+
     public static PaymentRequestEvent mandateActive(Long paymentRequestId) {
         return new PaymentRequestEvent(paymentRequestId, Type.MANDATE, MANDATE_ACTIVE);
     }
@@ -149,6 +154,7 @@ public class PaymentRequestEvent {
         PAYER_CREATED,
         DIRECT_DEBIT_DETAILS_CONFIRMED,
         MANDATE_FAILED,
+        MANDATE_CANCELLED,
         MANDATE_PENDING,
         MANDATE_ACTIVE,
         PAYMENT_CREATED,

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -18,6 +18,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_SUBMITTED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 
 public class PaymentRequestEvent {
@@ -67,6 +68,10 @@ public class PaymentRequestEvent {
 
     public static PaymentRequestEvent paymentCreated(Long paymentRequestId) {
         return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAYMENT_CREATED);
+    }
+
+    public static PaymentRequestEvent paymentSubmitted(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAYMENT_SUBMITTED);
     }
 
     public static PaymentRequestEvent paymentFailed(Long paymentRequestId) {
@@ -148,6 +153,7 @@ public class PaymentRequestEvent {
         MANDATE_ACTIVE,
         PAYMENT_CREATED,
         PAYMENT_PENDING,
+        PAYMENT_SUBMITTED,
         PAYMENT_FAILED,
         PAID_OUT,
         PAID;

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsConfirmed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.directDebitDetailsReceived;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandateActive;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandateCancelled;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandateFailed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.mandatePending;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paidOut;
@@ -76,6 +77,11 @@ public class PaymentRequestEventService {
 
     public PaymentRequestEvent registerMandateFailedEventFor(Transaction charge) {
         PaymentRequestEvent event = mandateFailed(charge.getPaymentRequestId());
+        return insertEventFor(charge, event);
+    }
+
+    public PaymentRequestEvent registerMandateCancelledEventFor(Transaction charge) {
+        PaymentRequestEvent event = mandateCancelled(charge.getPaymentRequestId());
         return insertEventFor(charge, event);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -20,6 +20,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payerCre
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentCreated;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentFailed;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentPending;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentSubmitted;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payoutPaid;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.tokenExchanged;
 
@@ -85,6 +86,11 @@ public class PaymentRequestEventService {
 
     public PaymentRequestEvent registerPaymentPendingEventFor(Transaction charge) {
         PaymentRequestEvent event = paymentPending(charge.getPaymentRequestId());
+        return insertEventFor(charge, event);
+    }
+
+    public PaymentRequestEvent registerPaymentSubmittedEventFor(Transaction charge) {
+        PaymentRequestEvent event = paymentSubmitted(charge.getPaymentRequestId());
         return insertEventFor(charge, event);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -131,6 +131,11 @@ public class TransactionService {
         return paymentRequestEventService.registerMandateFailedEventFor(transaction);
     }
 
+    public PaymentRequestEvent mandateCancelledFor(Transaction transaction) {
+        // todo userNotificationService.sendMandateCancelledEmailFor(transaction, payer);
+        return paymentRequestEventService.registerMandateCancelledEventFor(transaction);
+    }
+
     public PaymentRequestEvent paymentFailedFor(Transaction transaction) {
         Transaction newTransaction = updateStateFor(transaction, SupportedEvent.PAYMENT_FAILED);
         return paymentRequestEventService.registerPaymentFailedEventFor(newTransaction);
@@ -173,10 +178,8 @@ public class TransactionService {
         return transaction;
     }
 
-    public PaymentRequestEvent findPaymentSubmittedEventFor(Transaction transaction) {
-        return paymentRequestEventService.findBy(transaction.getPaymentRequestId(), CHARGE, PAYMENT_SUBMITTED)
-                .orElseThrow(() -> new InvalidStateException("Could not find payment submitted event for payment request with id: "
-                        + transaction.getPaymentRequestExternalId()));
+    public Optional<PaymentRequestEvent> findPaymentSubmittedEventFor(Transaction transaction) {
+        return paymentRequestEventService.findBy(transaction.getPaymentRequestId(), CHARGE, PAYMENT_SUBMITTED);
     }
 
     public Optional<PaymentRequestEvent> findMandatePendingEventFor(Transaction transaction) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -27,7 +27,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYER_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
-import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_SUBMITTED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.MANDATE;
@@ -145,6 +145,10 @@ public class TransactionService {
         return paymentRequestEventService.registerPaymentPendingEventFor(transaction);
     }
 
+    public PaymentRequestEvent paymentSubmittedFor(Transaction transaction) {
+        return paymentRequestEventService.registerPaymentSubmittedEventFor(transaction);
+    }
+
     public PaymentRequestEvent mandatePendingFor(Transaction transaction) {
         return paymentRequestEventService.registerMandatePendingEventFor(transaction);
     }
@@ -169,9 +173,9 @@ public class TransactionService {
         return transaction;
     }
 
-    public PaymentRequestEvent findPaymentPendingEventFor(Transaction transaction) {
-        return paymentRequestEventService.findBy(transaction.getPaymentRequestId(), CHARGE, PAYMENT_PENDING)
-                .orElseThrow(() -> new InvalidStateException("Could not find payment pending event for payment request with id: "
+    public PaymentRequestEvent findPaymentSubmittedEventFor(Transaction transaction) {
+        return paymentRequestEventService.findBy(transaction.getPaymentRequestId(), CHARGE, PAYMENT_SUBMITTED)
+                .orElseThrow(() -> new InvalidStateException("Could not find payment submitted event for payment request with id: "
                         + transaction.getPaymentRequestExternalId()));
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
@@ -24,8 +24,6 @@ public class WebhookGoCardlessService {
 
     @Inject
     public WebhookGoCardlessService(GoCardlessService goCardlessService,
-                                    TransactionService transactionService,
-                                    PayerService payerService,
                                     GoCardlessPaymentHandler goCardlessPaymentHandler,
                                     GoCardlessMandateHandler goCardlessMandateHandler) {
         this.goCardlessService = goCardlessService;

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.directdebit.webhook.gocardless.services.handlers;
 
+import com.gocardless.services.MandateService;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payers.services.PayerService;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
@@ -35,10 +37,11 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
                 GoCardlessMandateAction.SUBMITTED, this::findMandatePendingEventOrInsertOneIfItDoesNotExist,
                 GoCardlessMandateAction.ACTIVE, transactionService::mandateActiveFor,
                 GoCardlessMandateAction.CANCELLED, (Transaction transaction) -> {
+                    Payer payer = payerService.getPayerFor(transaction);
                     if (!transactionService.findPaymentSubmittedEventFor(transaction).isPresent()) {
                         transactionService.paymentFailedFor(transaction);
                     }
-                    return transactionService.mandateCancelledFor(transaction);
+                    return transactionService.mandateCancelledFor(transaction, payer);
                 },
                 GoCardlessMandateAction.FAILED, (Transaction transaction) -> {
                     Payer payer = payerService.getPayerFor(transaction);

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
+import uk.gov.pay.directdebit.payments.exception.InvalidStateException;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.PaymentRequestEvent;
 import uk.gov.pay.directdebit.payments.model.Transaction;
@@ -53,7 +54,9 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
         return ImmutableMap.of(
                 GoCardlessPaymentAction.CREATED, transactionService::paymentPendingFor,
                 GoCardlessPaymentAction.SUBMITTED, transactionService::paymentSubmittedFor,
-                GoCardlessPaymentAction.CONFIRMED, transactionService::findPaymentSubmittedEventFor,
+                GoCardlessPaymentAction.CONFIRMED, (Transaction transaction) ->
+                        transactionService.findPaymentSubmittedEventFor(transaction)
+                                .orElseThrow(() -> new InvalidStateException("Could not find payment submitted event for payment request with id: " + transaction.getPaymentRequestExternalId())),
                 GoCardlessPaymentAction.PAID_OUT, transactionService::paymentPaidOutFor,
                 GoCardlessPaymentAction.PAID, transactionService::payoutPaidFor
         );

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -52,8 +52,8 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
     protected Map<GoCardlessAction, Function<Transaction, PaymentRequestEvent>> getHandledActions() {
         return ImmutableMap.of(
                 GoCardlessPaymentAction.CREATED, transactionService::paymentPendingFor,
-                GoCardlessPaymentAction.SUBMITTED, transactionService::findPaymentPendingEventFor,
-                GoCardlessPaymentAction.CONFIRMED, transactionService::findPaymentPendingEventFor,
+                GoCardlessPaymentAction.SUBMITTED, transactionService::paymentSubmittedFor,
+                GoCardlessPaymentAction.CONFIRMED, transactionService::findPaymentSubmittedEventFor,
                 GoCardlessPaymentAction.PAID_OUT, transactionService::paymentPaidOutFor,
                 GoCardlessPaymentAction.PAID, transactionService::payoutPaidFor
         );

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -37,6 +37,7 @@ goCardless:
 notify:
   apiKey: ${GDS_DIRECTDEBIT_CONNECTOR_NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   mandateFailedTemplateId: ${NOTIFY_MANDATE_FAILED_EMAIL_TEMPLATE_ID}
+  mandateCancelledTemplateId: ${NOTIFY_MANDATE_CANCELLED_EMAIL_TEMPLATE_ID}
   paymentConfirmedTemplateId: ${NOTIFY_PAYMENT_CONFIRMATION_EMAIL_TEMPLATE_ID}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://api.notifications.service.gov.uk}
   emailNotifyEnabled: ${NOTIFY_EMAIL_ENABLED:-false}

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
@@ -19,6 +19,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_SUBMITTED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.MANDATE;
@@ -120,6 +121,16 @@ public class PaymentRequestEventTest {
         PaymentRequestEvent event = PaymentRequestEvent.paymentPending(paymentRequestId);
 
         assertThat(event.getEvent(), is(PAYMENT_PENDING));
+        assertThat(event.getEventType(), is(CHARGE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
+    }
+
+    @Test
+    public void paymentSubmitted_shouldReturnExpectedEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.paymentSubmitted(paymentRequestId);
+
+        assertThat(event.getEvent(), is(PAYMENT_SUBMITTED));
         assertThat(event.getEventType(), is(CHARGE));
         assertThat(event.getPaymentRequestId(), is(paymentRequestId));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
@@ -11,6 +11,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_CANCELLED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID;
@@ -171,6 +172,16 @@ public class PaymentRequestEventTest {
         PaymentRequestEvent event = PaymentRequestEvent.mandateFailed(paymentRequestId);
 
         assertThat(event.getEvent(), is(MANDATE_FAILED));
+        assertThat(event.getEventType(), is(MANDATE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
+    }
+
+    @Test
+    public void mandateCancelled_shouldReturnExpectedEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.mandateCancelled(paymentRequestId);
+
+        assertThat(event.getEvent(), is(MANDATE_CANCELLED));
         assertThat(event.getEventType(), is(MANDATE));
         assertThat(event.getPaymentRequestId(), is(paymentRequestId));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture.aPaymentRequestEventFixture;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_CANCELLED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID;
@@ -191,6 +192,18 @@ public class PaymentRequestEventServiceTest {
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(paymentRequestEvent.getEvent(), is(MANDATE_FAILED));
+        assertThat(paymentRequestEvent.getEventType(), is(MANDATE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void registerMandateCancelledEventFor_shouldCreateExpectedEvent() {
+        service.registerMandateCancelledEventFor(transactionFixture.toEntity());
+
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(MANDATE_CANCELLED));
         assertThat(paymentRequestEvent.getEventType(), is(MANDATE));
         assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
@@ -29,6 +29,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_SUBMITTED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.MANDATE;
 
@@ -106,6 +107,18 @@ public class PaymentRequestEventServiceTest {
         PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
         assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(paymentRequestEvent.getEvent(), is(PAYMENT_PENDING));
+        assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+
+    @Test
+    public void registerPaymentSubmittedEventFor_shouldCreateExpectedEvent() {
+        service.registerPaymentSubmittedEventFor(transactionFixture.toEntity());
+
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PAYMENT_SUBMITTED));
         assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
         assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -9,6 +9,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.mandate.dao.MandateDao;
+import uk.gov.pay.directdebit.mandate.exception.MandateNotFoundException;
+import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payers.model.Payer;
@@ -57,10 +61,15 @@ public class TransactionServiceTest {
     private TransactionDao mockedTransactionDao;
 
     @Mock
+    private MandateDao mockedMandateDao;
+
+    @Mock
     private UserNotificationService mockedUserNotificationService;
 
     private Payer payer = PayerFixture.aPayerFixture().toEntity();
-
+    private Mandate mandate = MandateFixture.aMandateFixture()
+            .withPayerId(payer.getId())
+            .toEntity();
     private TransactionService service;
     @Mock
     private PaymentRequestEventService mockedPaymentRequestEventService;
@@ -71,7 +80,7 @@ public class TransactionServiceTest {
 
     @Before
     public void setUp() {
-        service = new TransactionService(mockedTransactionDao, mockedPaymentRequestEventService, mockedUserNotificationService);
+        service = new TransactionService(mockedTransactionDao, mockedMandateDao, mockedPaymentRequestEventService, mockedUserNotificationService);
     }
 
     @Test
@@ -123,7 +132,7 @@ public class TransactionServiceTest {
     @Test
     public void findChargeForExternalIdAndGatewayAccountId_shouldThrow_ifNoTransactionExistsWithExternalId() {
         thrown.expect(ChargeNotFoundException.class);
-        thrown.expectMessage("No charges found for payment request with id: not-existing");
+        thrown.expectMessage("No charges found for payment request external id: not-existing");
         thrown.reportMissingExceptionWithMessage("ChargeNotFoundException expected");
         service.findChargeForExternalIdAndGatewayAccountId("not-existing", gatewayAccountFixture.getId());
     }
@@ -172,24 +181,35 @@ public class TransactionServiceTest {
 
     @Test
     public void shouldUpdateTransactionStateRegisterEventAndSendEmail_whenMandateFails() throws Exception {
-        TransactionFixture transactionFixture = TransactionFixture
+        Transaction transaction = TransactionFixture
                 .aTransactionFixture()
-                .withState(PENDING_DIRECT_DEBIT_PAYMENT);
-        Transaction transaction = transactionFixture.toEntity();
+                .withState(PENDING_DIRECT_DEBIT_PAYMENT).toEntity();
         service.mandateFailedFor(transaction, payer);
         verify(mockedPaymentRequestEventService).registerMandateFailedEventFor(transaction);
         verify(mockedUserNotificationService).sendMandateFailedEmailFor(transaction, payer);
     }
 
     @Test
-    public void shouldUpdateTransactionStateRegisterEventAndSendEmail_whenMandateIsCancelled() throws Exception {
-        TransactionFixture transactionFixture = TransactionFixture
+    public void shouldUpdateTransactionStateRegisterEventAndSendEmail_whenMandateIsCancelled() {
+        Transaction transaction = TransactionFixture
                 .aTransactionFixture()
-                .withState(PENDING_DIRECT_DEBIT_PAYMENT);
-        Transaction transaction = transactionFixture.toEntity();
-        service.mandateCancelledFor(transaction);
+                .withState(PENDING_DIRECT_DEBIT_PAYMENT).toEntity();
+        when(mockedMandateDao.findByTransactionId(transaction.getId())).thenReturn(Optional.of(mandate));
+        service.mandateCancelledFor(transaction, payer);
         verify(mockedPaymentRequestEventService).registerMandateCancelledEventFor(transaction);
-      // todo  verify(mockedUserNotificationService).sendMandateFailedEmailFor(transaction, payer);
+        verify(mockedUserNotificationService).sendMandateCancelledEmailFor(transaction, mandate, payer);
+    }
+
+    @Test
+    public void shouldThrow_whenCantFindMandateForTransaction() {
+        Transaction transaction = TransactionFixture
+                .aTransactionFixture()
+                .withState(PENDING_DIRECT_DEBIT_PAYMENT).toEntity();
+        when(mockedMandateDao.findByTransactionId(transaction.getId())).thenReturn(Optional.empty());
+        thrown.expect(MandateNotFoundException.class);
+        thrown.expectMessage("Couldn't find mandate for transaction with id: " + transaction.getId());
+        thrown.reportMissingExceptionWithMessage("MandateNotFoundException expected");
+        service.mandateCancelledFor(transaction, payer);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestEventFixture.aPaymentRequestEventFixture;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.CHARGE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.MANDATE_PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_SUBMITTED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_CONFIRMATION;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_DIRECT_DEBIT_DETAILS;
@@ -312,6 +313,24 @@ public class TransactionServiceTest {
         verify(mockedPaymentRequestEventService).registerMandateActiveEventFor(transaction);
         verifyZeroInteractions(mockedTransactionDao);
         assertThat(transaction.getState(), is(PENDING_DIRECT_DEBIT_PAYMENT));
+    }
+
+    @Test
+    public void findPaymentSubmittedEventFor_shouldFindEvent() {
+
+        Transaction transaction = TransactionFixture
+                .aTransactionFixture()
+                .withState(PENDING_DIRECT_DEBIT_PAYMENT)
+                .toEntity();
+
+        PaymentRequestEvent event = aPaymentRequestEventFixture().toEntity();
+
+        when(mockedPaymentRequestEventService.findBy(transaction.getPaymentRequestId(), Type.CHARGE, PAYMENT_SUBMITTED))
+                .thenReturn(Optional.of(event));
+
+        PaymentRequestEvent foundEvent = service.findPaymentSubmittedEventFor(transaction);
+
+        assertThat(foundEvent, is(event));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -182,6 +182,17 @@ public class TransactionServiceTest {
     }
 
     @Test
+    public void shouldUpdateTransactionStateRegisterEventAndSendEmail_whenMandateIsCancelled() throws Exception {
+        TransactionFixture transactionFixture = TransactionFixture
+                .aTransactionFixture()
+                .withState(PENDING_DIRECT_DEBIT_PAYMENT);
+        Transaction transaction = transactionFixture.toEntity();
+        service.mandateCancelledFor(transaction);
+        verify(mockedPaymentRequestEventService).registerMandateCancelledEventFor(transaction);
+      // todo  verify(mockedUserNotificationService).sendMandateFailedEmailFor(transaction, payer);
+    }
+
+    @Test
     public void findTransactionForToken_shouldUpdateTransactionStateAndRegisterEventWhenExchangingTokens() throws Exception {
         String token = "token";
         TransactionFixture transactionFixture = TransactionFixture
@@ -328,7 +339,7 @@ public class TransactionServiceTest {
         when(mockedPaymentRequestEventService.findBy(transaction.getPaymentRequestId(), Type.CHARGE, PAYMENT_SUBMITTED))
                 .thenReturn(Optional.of(event));
 
-        PaymentRequestEvent foundEvent = service.findPaymentSubmittedEventFor(transaction);
+        PaymentRequestEvent foundEvent = service.findPaymentSubmittedEventFor(transaction).get();
 
         assertThat(foundEvent, is(event));
     }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
@@ -186,14 +186,15 @@ public class GoCardlessMandateHandlerTest {
         GoCardlessEvent goCardlessEvent = spy(GoCardlessEventFixture.aGoCardlessEventFixture().withAction("cancelled").toEntity());
 
         when(mockedGoCardlessService.findMandateForEvent(goCardlessEvent)).thenReturn(goCardlessMandateFixture.toEntity());
+        when(mockedPayerService.getPayerFor(transaction)).thenReturn(payer);
         when(mockedTransactionService.findPaymentSubmittedEventFor(transaction)).thenReturn(Optional.empty());
-        when(mockedTransactionService.mandateCancelledFor(transaction)).thenReturn(paymentRequestEvent);
+        when(mockedTransactionService.mandateCancelledFor(transaction, payer)).thenReturn(paymentRequestEvent);
         when(mockedTransactionService.paymentFailedFor(transaction)).thenReturn(paymentRequestEvent);
 
         goCardlessMandateHandler.handle(goCardlessEvent);
 
         verify(mockedTransactionService).paymentFailedFor(transaction);
-        verify(mockedTransactionService).mandateCancelledFor(transaction);
+        verify(mockedTransactionService).mandateCancelledFor(transaction, payer);
         verify(goCardlessEvent).setPaymentRequestEventId(paymentRequestEvent.getId());
         verify(mockedGoCardlessService).storeEvent(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
@@ -204,13 +205,14 @@ public class GoCardlessMandateHandlerTest {
         GoCardlessEvent goCardlessEvent = spy(GoCardlessEventFixture.aGoCardlessEventFixture().withAction("cancelled").toEntity());
 
         when(mockedGoCardlessService.findMandateForEvent(goCardlessEvent)).thenReturn(goCardlessMandateFixture.toEntity());
+        when(mockedPayerService.getPayerFor(transaction)).thenReturn(payer);
         when(mockedTransactionService.findPaymentSubmittedEventFor(transaction)).thenReturn(Optional.of(paymentRequestEvent));
-        when(mockedTransactionService.mandateCancelledFor(transaction)).thenReturn(paymentRequestEvent);
+        when(mockedTransactionService.mandateCancelledFor(transaction, payer)).thenReturn(paymentRequestEvent);
 
         goCardlessMandateHandler.handle(goCardlessEvent);
 
         verify(mockedTransactionService, never()).paymentFailedFor(transaction);
-        verify(mockedTransactionService).mandateCancelledFor(transaction);
+        verify(mockedTransactionService).mandateCancelledFor(transaction, payer);
         verify(goCardlessEvent).setPaymentRequestEventId(paymentRequestEvent.getId());
         verify(mockedGoCardlessService).storeEvent(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
@@ -96,15 +96,15 @@ public class GoCardlessPaymentHandlerTest {
     }
 
     @Test
-    public void handle_onSubmittedPaymentGoCardlessEvent_shouldLinkTheEventToAnExistingPaymentPendingPayEvent() {
+    public void handle_onSubmittedPaymentGoCardlessEvent_shouldSetRegisterPaymentSubmittedEvent() {
         GoCardlessEvent goCardlessEvent = spy(GoCardlessEventFixture.aGoCardlessEventFixture().withAction("submitted").toEntity());
 
         when(mockedGoCardlessService.findPaymentForEvent(goCardlessEvent)).thenReturn(goCardlessPaymentFixture.toEntity());
-        when(mockedTransactionService.findPaymentPendingEventFor(transaction)).thenReturn(paymentRequestEvent);
+        when(mockedTransactionService.paymentSubmittedFor(transaction)).thenReturn(paymentRequestEvent);
 
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
-        verify(mockedTransactionService).findPaymentPendingEventFor(transaction);
+        verify(mockedTransactionService).paymentSubmittedFor(transaction);
         verify(goCardlessEvent).setPaymentRequestEventId(paymentRequestEvent.getId());
         verify(mockedGoCardlessService).storeEvent(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
@@ -112,11 +112,11 @@ public class GoCardlessPaymentHandlerTest {
     }
 
     @Test
-    public void handle_onConfirmedPaymentGoCardlessEvent_shouldLinkTheEventToAnExistingPaymentPendingPayEvent() {
+    public void handle_onConfirmedPaymentGoCardlessEvent_shouldLinkTheEventToAnExistingPaymentSubmittedPayEvent() {
         GoCardlessEvent goCardlessEvent = spy(GoCardlessEventFixture.aGoCardlessEventFixture().withAction("confirmed").toEntity());
 
         when(mockedGoCardlessService.findPaymentForEvent(goCardlessEvent)).thenReturn(goCardlessPaymentFixture.toEntity());
-        when(mockedTransactionService.findPaymentPendingEventFor(transaction)).thenReturn(paymentRequestEvent);
+        when(mockedTransactionService.findPaymentSubmittedEventFor(transaction)).thenReturn(paymentRequestEvent);
 
         goCardlessPaymentHandler.handle(goCardlessEvent);
 

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
@@ -20,6 +20,8 @@ import uk.gov.pay.directdebit.payments.services.GoCardlessService;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 import uk.gov.pay.directdebit.webhook.gocardless.services.handlers.GoCardlessPaymentHandler;
 
+import java.util.Optional;
+
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -116,7 +118,7 @@ public class GoCardlessPaymentHandlerTest {
         GoCardlessEvent goCardlessEvent = spy(GoCardlessEventFixture.aGoCardlessEventFixture().withAction("confirmed").toEntity());
 
         when(mockedGoCardlessService.findPaymentForEvent(goCardlessEvent)).thenReturn(goCardlessPaymentFixture.toEntity());
-        when(mockedTransactionService.findPaymentSubmittedEventFor(transaction)).thenReturn(paymentRequestEvent);
+        when(mockedTransactionService.findPaymentSubmittedEventFor(transaction)).thenReturn(Optional.of(paymentRequestEvent));
 
         goCardlessPaymentHandler.handle(goCardlessEvent);
 

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
@@ -39,10 +39,6 @@ public class WebhookGoCardlessServiceTest {
     @Mock
     private GoCardlessService mockedGoCardlessService;
     @Mock
-    private TransactionService mockedTransactionService;
-    @Mock
-    private PayerService mockedPayerService;
-    @Mock
     private GoCardlessPaymentHandler mockedGoCardlessPaymentHandler;
     @Mock
     private GoCardlessMandateHandler mockedGoCardlessMandateHandler;
@@ -51,7 +47,7 @@ public class WebhookGoCardlessServiceTest {
 
     @Before
     public void setUp() {
-        webhookGoCardlessService = new WebhookGoCardlessService(mockedGoCardlessService, mockedTransactionService, mockedPayerService, mockedGoCardlessPaymentHandler, mockedGoCardlessMandateHandler);
+        webhookGoCardlessService = new WebhookGoCardlessService(mockedGoCardlessService, mockedGoCardlessPaymentHandler, mockedGoCardlessMandateHandler);
     }
 
     @Test
@@ -71,7 +67,6 @@ public class WebhookGoCardlessServiceTest {
         List<GoCardlessEvent> events = Collections.singletonList(goCardlessEvent);
         webhookGoCardlessService.handleEvents(events);
         verify(mockedGoCardlessService).storeEvent(goCardlessEvent);
-        verifyZeroInteractions(mockedTransactionService);
     }
 
     @Test
@@ -81,7 +76,6 @@ public class WebhookGoCardlessServiceTest {
         List<GoCardlessEvent> events = Collections.singletonList(goCardlessEvent);
         webhookGoCardlessService.handleEvents(events);
         verify(mockedGoCardlessService).storeEvent(goCardlessEvent);
-        verifyZeroInteractions(mockedTransactionService);
     }
 
     @Test
@@ -91,7 +85,6 @@ public class WebhookGoCardlessServiceTest {
         List<GoCardlessEvent> events = Collections.singletonList(goCardlessEvent);
         webhookGoCardlessService.handleEvents(events);
         verify(mockedGoCardlessService).storeEvent(goCardlessEvent);
-        verifyZeroInteractions(mockedTransactionService);
     }
 
     @Test
@@ -106,7 +99,6 @@ public class WebhookGoCardlessServiceTest {
             fail("Expected GoCardlessPaymentNotFoundException.");
         } catch (GoCardlessPaymentNotFoundException expected) { }
         verify(mockedGoCardlessService).storeEvent(goCardlessEvent);
-        verifyZeroInteractions(mockedTransactionService);
     }
 
     @Test
@@ -121,7 +113,6 @@ public class WebhookGoCardlessServiceTest {
             fail("Expected GoCardlessMandateNotFoundException.");
         } catch (GoCardlessMandateNotFoundException expected) { }
         verify(mockedGoCardlessService).storeEvent(goCardlessEvent);
-        verifyZeroInteractions(mockedTransactionService);
     }
 
     @Test

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -37,6 +37,7 @@ executorService:
 
 notify:
   mandateFailedTemplateId: test-template-id
+  mandateCancelledTemplateId: test-template-id
   paymentConfirmedTemplateId: test-template-id
   apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain


### PR DESCRIPTION
## WHAT
- Registering a specific event when a payment is submitted by GC to the bank

- When we receive a mandate cancelled from GoCardless, we will act depending on two different scenarios:

    - The payment associated to the mandate is CREATED, this means it has not been submitted to the bank by GC. This also means they won't send us a webhook to tell us that the payment failed, so we have to update the charge status ourselves
    - The payment associated to the mandate is SUBMITTED. We don't update the charge status ourselves as we will receive a webhook from GC telling us what happened to it.
Right now we have no concept of a lifecycle for mandates, like we do for payments. I will raise another PR to add that graph. Once that is done, mandate cancelled will update the status of a mandate.
