### PR TITLE
Pp 3666 remove openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,6 @@ EXPOSE 8081
 
 WORKDIR /app
 
-RUN apk add openssl && \
-    mkdir -p bin && \
-    apk del --purge openssl
-
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM govukpay/openjdk:8-jre-alpine
 
 
-RUN apk update
-RUN apk upgrade
+RUN apk --no-cache upgrade
 
-RUN apk add bash
+RUN apk add --no-cache bash
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-*/
 ENV PORT 8080


### PR DESCRIPTION
When chamber moved into the base image, we didn't fully clean up. Remove this stray code which adds and then removes openssl.

Also, use --no-cache more when running apk