### PR TITLE
PP-3646 Add simple search for payments by gateway account external id

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
@@ -12,6 +12,7 @@ import uk.gov.pay.directdebit.common.dao.DateArgumentFactory;
 import uk.gov.pay.directdebit.payments.dao.mapper.PaymentRequestMapper;
 import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 
+import java.util.List;
 import java.util.Optional;
 
 @RegisterMapper(PaymentRequestMapper.class)
@@ -28,4 +29,7 @@ public interface PaymentRequestDao {
     @GetGeneratedKeys
     @RegisterArgumentFactory(DateArgumentFactory.class)
     Long insert(@BindBean PaymentRequest paymentRequest);
+
+    @SqlQuery("SELECT * FROM payment_requests p JOIN gateway_accounts g ON p.gateway_account_id = g.id WHERE g.external_id = :accountExternalId ORDER BY p.id DESC LIMIT :pageSize")
+    List<PaymentRequest> findByAccountExternalId(@Bind("accountExternalId") String accountExternalId, @Bind("pageSize") Integer pageSize);
 }


### PR DESCRIPTION
- Implement a simple search in PaymentsRequestsDAO to fetch a list by gateway account's external id. The search returns a list, ordered DESC and limited by pageSize.
