### PR TITLE
Use undeprecated methods instead of deprecated ones in tests

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -29,9 +29,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.UUID.randomUUID;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;

--- a/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentRequestResponseTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentRequestResponseTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertFalse;
 
 
 public class PaymentRequestResponseTest {


### PR DESCRIPTION
Removes a few warnings when you do a build