### PR TITLE
PP-3258 Fix dead links

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentState.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentState.java
@@ -12,14 +12,26 @@ public enum ExternalPaymentState {
     EXTERNAL_SUCCESS("success", true),
     EXTERNAL_FAILED("failed", true),
     EXTERNAL_CANCELLED("cancelled", true),
-    EXTERNAL_EXPIRED("expired", true);
+    EXTERNAL_EXPIRED("expired", true),
+    EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE("cancelled", true, "P0060", "User not eligible for Direct Debit");
 
     private final String value;
     private final boolean finished;
+    private final String code;
+    private final String message;
 
     ExternalPaymentState(String value, boolean finished) {
         this.value = value;
         this.finished = finished;
+        this.code = null;
+        this.message = null;
+    }
+
+    ExternalPaymentState(String value, boolean finished, String code, String message) {
+        this.value = value;
+        this.finished = finished;
+        this.code = code;
+        this.message = message;
     }
 
     @JsonProperty("status")
@@ -29,6 +41,14 @@ public enum ExternalPaymentState {
 
     public boolean isFinished() {
         return finished;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
     }
 }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEvent.java
@@ -19,6 +19,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CANCELLED_BY_USER;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_FAILED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_SUBMITTED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
@@ -108,6 +109,10 @@ public class PaymentRequestEvent {
         return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAID);
     }
 
+    public static PaymentRequestEvent paymentMethodChanged(Long paymentRequestId) {
+        return new PaymentRequestEvent(paymentRequestId, Type.CHARGE, PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE);
+    }
+
     public Long getId() {
         return id;
     }
@@ -164,6 +169,7 @@ public class PaymentRequestEvent {
         MANDATE_CANCELLED,
         PAYMENT_CREATED,
         PAYMENT_CANCELLED_BY_USER,
+        PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE,
         PAYMENT_PENDING,
         PAYMENT_SUBMITTED,
         PAYMENT_FAILED,

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentState.java
@@ -2,6 +2,7 @@ package uk.gov.pay.directdebit.payments.model;
 
 import uk.gov.pay.directdebit.payments.api.ExternalPaymentState;
 
+import static uk.gov.pay.directdebit.payments.api.ExternalPaymentState.EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE;
 import static uk.gov.pay.directdebit.payments.api.ExternalPaymentState.EXTERNAL_FAILED;
 import static uk.gov.pay.directdebit.payments.api.ExternalPaymentState.EXTERNAL_PENDING;
 import static uk.gov.pay.directdebit.payments.api.ExternalPaymentState.EXTERNAL_STARTED;
@@ -20,6 +21,7 @@ public enum PaymentState {
     PENDING_DIRECT_DEBIT_PAYMENT(EXTERNAL_PENDING),
     FAILED(EXTERNAL_FAILED),
     CANCELLED(EXTERNAL_FAILED),
+    USER_CANCEL_NOT_ELIGIBLE(EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE),
 
     SUCCESS(EXTERNAL_SUCCESS);
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
@@ -14,15 +14,17 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CREATED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_CONFIRMATION;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.AWAITING_DIRECT_DEBIT_DETAILS;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.CANCELLED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.NEW;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.PENDING_DIRECT_DEBIT_PAYMENT;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.PROCESSING_DIRECT_DEBIT_DETAILS;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.PROCESSING_DIRECT_DEBIT_PAYMENT;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.SUCCESS;
-import static uk.gov.pay.directdebit.payments.model.PaymentState.CANCELLED;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.USER_CANCEL_NOT_ELIGIBLE;
 
 public class PaymentStatesGraph {
 
@@ -51,6 +53,7 @@ public class PaymentStatesGraph {
 
         graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, PROCESSING_DIRECT_DEBIT_DETAILS, DIRECT_DEBIT_DETAILS_RECEIVED);
         graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, CANCELLED, PAYMENT_CANCELLED_BY_USER);
+        graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, USER_CANCEL_NOT_ELIGIBLE, PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE);
 
         graph.putEdgeValue(PROCESSING_DIRECT_DEBIT_DETAILS, AWAITING_CONFIRMATION, PAYER_CREATED);
         graph.putEdgeValue(PROCESSING_DIRECT_DEBIT_DETAILS, CANCELLED, PAYMENT_CANCELLED_BY_USER);

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
@@ -63,4 +63,13 @@ public class PaymentRequestResource {
         paymentRequestService.cancelTransaction(accountExternalId, paymentRequestExternalId);
         return Response.noContent().build();
     }
+
+    @POST
+    @Path("/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/change-payment-method")
+    @Produces(APPLICATION_JSON)
+    public Response userChangePaymentMethod(@PathParam("accountId") String accountExternalId, @PathParam("paymentRequestExternalId") String paymentRequestExternalId) {
+        LOGGER.info("User wants to change payment method for - {}", paymentRequestExternalId);
+        paymentRequestService.changePaymentMethod(accountExternalId, paymentRequestExternalId);
+        return Response.noContent().build();
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -21,6 +21,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payerCre
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentCancelled;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentCreated;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentFailed;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentMethodChanged;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentPending;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.paymentSubmitted;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.payoutPaid;
@@ -128,5 +129,10 @@ public class PaymentRequestEventService {
 
     public Optional<PaymentRequestEvent> findBy(Long paymentRequestId, PaymentRequestEvent.Type type, PaymentRequestEvent.SupportedEvent event) {
         return paymentRequestEventDao.findByPaymentRequestIdAndEvent(paymentRequestId, type, event);
+    }
+
+    public PaymentRequestEvent registerPaymentMethodChangedEventFor(Transaction transaction) {
+        PaymentRequestEvent event = paymentMethodChanged(transaction.getPaymentRequestId());
+        return insertEventFor(transaction, event);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
@@ -109,4 +109,9 @@ public class PaymentRequestService {
                 .orElseThrow(() -> new PaymentRequestNotFoundException(paymentExternalId, accountExternalId));
     }
 
+    public void changePaymentMethod(String accountExternalId, String paymentRequestExternalId) {
+        Transaction transaction = transactionService.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequestExternalId, accountExternalId);
+        transactionService.paymentMethodChangedFor(transaction);
+    }
+
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -170,4 +170,9 @@ public class TransactionService {
     public Optional<PaymentRequestEvent> findMandatePendingEventFor(Transaction transaction) {
         return paymentRequestEventService.findBy(transaction.getPaymentRequestId(), MANDATE, MANDATE_PENDING);
     }
+
+    public PaymentRequestEvent paymentMethodChangedFor(Transaction transaction) {
+        Transaction newTransaction = updateStateFor(transaction, SupportedEvent.PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE);
+        return paymentRequestEventService.registerPaymentMethodChangedEventFor(newTransaction);
+    }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentRequestEventTest.java
@@ -23,6 +23,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_SUBMITTED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.TOKEN_EXCHANGED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.MANDATE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.PAYER;
@@ -204,6 +205,16 @@ public class PaymentRequestEventTest {
 
         assertThat(event.getEvent(), is(MANDATE_CANCELLED));
         assertThat(event.getEventType(), is(MANDATE));
+        assertThat(event.getPaymentRequestId(), is(paymentRequestId));
+    }
+
+    @Test
+    public void paymentMethodChanged_shouldReturnExpectedEvent() {
+        long paymentRequestId = 1L;
+        PaymentRequestEvent event = PaymentRequestEvent.paymentMethodChanged(paymentRequestId);
+
+        assertThat(event.getEvent(), is(PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE));
+        assertThat(event.getEventType(), is(CHARGE));
         assertThat(event.getPaymentRequestId(), is(paymentRequestId));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventServiceTest.java
@@ -31,6 +31,7 @@ import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Supporte
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_PENDING;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_SUBMITTED;
+import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.SupportedEvent.PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.CHARGE;
 import static uk.gov.pay.directdebit.payments.model.PaymentRequestEvent.Type.MANDATE;
 
@@ -230,5 +231,17 @@ public class PaymentRequestEventServiceTest {
         Optional<PaymentRequestEvent> event = service.findBy(paymentRequestId, CHARGE, PAYMENT_PENDING);
 
         assertThat(event.get(), is(expectedEvent));
+    }
+
+    @Test
+    public void registerPaymentMethodChangedEventFor_shouldCreateExpectedEvent() {
+        service.registerPaymentMethodChangedEventFor(transactionFixture.toEntity());
+
+        verify(mockedPaymentRequestEventDao).insert(prCaptor.capture());
+        PaymentRequestEvent paymentRequestEvent = prCaptor.getValue();
+        assertThat(paymentRequestEvent.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequestEvent.getEvent(), is(PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE));
+        assertThat(paymentRequestEvent.getEventType(), is(CHARGE));
+        assertThat(paymentRequestEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
@@ -240,4 +240,14 @@ public class PaymentRequestServiceTest {
         thrown.reportMissingExceptionWithMessage("PaymentNotFoundException expected");
         service.getPaymentWithExternalId(gatewayAccountFixture.getExternalId(), externalPaymentId, uriInfo);
     }
+
+    @Test
+    public void shouldDelegateToTheTransactionServiceToChangeAPaymentMethod() {
+        Transaction transaction = transactionFixture.toEntity();
+        when(mockTransactionService.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequest.getExternalId(), gatewayAccountFixture.getExternalId()))
+                .thenReturn(transaction);
+
+        service.changePaymentMethod(gatewayAccountFixture.getExternalId(), paymentRequest.getExternalId());
+        verify(mockTransactionService).paymentMethodChangedFor(transaction);
+    }
 }


### PR DESCRIPTION
- Added a new endpoint
`"/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/change-payment-method"`
that will cancel the current payment and will update the state to
`USER_CANCEL_NOT_ELIGIBLE`
- Added the new state to the graph and marked it as transitionable only
from `AWAITING_DIRECT_DEBIT_DETAILS` and will mark externally as
`CANCELLED`
- Externally this state will map to P0060 - User not eligible for Direct
Debit
- This change should handle requests from `direct-debit-frontend` when a
user chooses to cancel a payment by choosing a different payment method
