### PR TITLE
PP-3545 Transaction constructor refactoring

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -83,6 +83,6 @@ public class MandateService {
     }
 
     public Optional<PaymentRequestEvent> findMandatePendingEventFor(Transaction transaction) {
-        return paymentRequestEventService.findBy(transaction.getPaymentRequestId(), MANDATE, MANDATE_PENDING);
+        return paymentRequestEventService.findBy(transaction.getPaymentRequest().getId(), MANDATE, MANDATE_PENDING);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
@@ -33,10 +33,11 @@ public class PaymentConfirmService {
      */
     public ConfirmationDetails confirm(String accountExternalId, String paymentExternalId) {
         Transaction transaction = transactionService.confirmedDirectDebitDetailsFor(accountExternalId, paymentExternalId);
-        Mandate createdMandate = payerDao.findByPaymentRequestId(transaction.getPaymentRequest().getId())
+        Long paymentRequestId = transaction.getPaymentRequest().getId();
+        Mandate createdMandate = payerDao.findByPaymentRequestId(paymentRequestId)
                 .map(this::createMandateFor)
                 .orElseThrow(() -> new PayerConflictException(String.format("Expected payment request %s to be already associated with a payer", paymentExternalId)));
-        LOGGER.info("Mandate created for payment request {}", transaction.getPaymentRequest().getId());
+        LOGGER.info("Mandate created for payment request {}", paymentRequestId);
         return new ConfirmationDetails(transaction, createdMandate);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/PaymentConfirmService.java
@@ -33,10 +33,10 @@ public class PaymentConfirmService {
      */
     public ConfirmationDetails confirm(String accountExternalId, String paymentExternalId) {
         Transaction transaction = transactionService.confirmedDirectDebitDetailsFor(accountExternalId, paymentExternalId);
-        Mandate createdMandate = payerDao.findByPaymentRequestId(transaction.getPaymentRequestId())
+        Mandate createdMandate = payerDao.findByPaymentRequestId(transaction.getPaymentRequest().getId())
                 .map(this::createMandateFor)
                 .orElseThrow(() -> new PayerConflictException(String.format("Expected payment request %s to be already associated with a payer", paymentExternalId)));
-        LOGGER.info("Mandate created for payment request {}", transaction.getPaymentRequestId());
+        LOGGER.info("Mandate created for payment request {}", transaction.getPaymentRequest().getId());
         return new ConfirmationDetails(transaction, createdMandate);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -152,7 +152,7 @@ public class UserNotificationService {
         HashMap<String, String> map = new HashMap<>();
         map.put(SERVICE_NAME_KEY, gatewayAccount.getServiceName());
         map.put(AMOUNT_KEY, formatToPounds(transaction.getAmount()));
-        map.put(PAYMENT_REFERENCE_KEY, transaction.getPaymentRequestReference());
+        map.put(PAYMENT_REFERENCE_KEY, transaction.getPaymentRequest().getReference());
         map.put(BANK_ACCOUNT_LAST_DIGITS_KEY, "******" + payer.getAccountNumberLastTwoDigits());
         map.put(COLLECTION_DATE_KEY, DATE_TIME_FORMATTER.format(earliestChargeDate));
         map.put(SUN_KEY, PLACEHOLDER_SUN);

--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -104,20 +104,20 @@ public class UserNotificationService {
         return sendEmail(buildMandateProblemPersonalisation(transaction, mandate),
                 templateId,
                 payer.getEmail(),
-                transaction.getPaymentRequestExternalId());
+                transaction.getPaymentRequest().getExternalId());
     }
 
     public Future<Optional<String>> sendMandateFailedEmailFor(Transaction transaction, Mandate mandate, Payer payer) {
         String mandateFailedTemplateId = directDebitConfig.getNotifyConfig().getMandateFailedTemplateId();
         LOGGER.info("Sending mandate failed email, payment request id: {}, gateway account id: {}",
-                transaction.getPaymentRequestExternalId(),
+                transaction.getPaymentRequest().getExternalId(),
                 transaction.getGatewayAccountExternalId());
         return sendMandateProblemEmailFor(mandateFailedTemplateId, transaction, mandate, payer);
     }
     public Future<Optional<String>> sendMandateCancelledEmailFor(Transaction transaction, Mandate mandate, Payer payer) {
         String mandateCancelledTemplateId = directDebitConfig.getNotifyConfig().getMandateCancelledTemplateId();
         LOGGER.info("Sending mandate cancelled email, payment request id: {}, gateway account id: {}",
-                transaction.getPaymentRequestExternalId(),
+                transaction.getPaymentRequest().getExternalId(),
                 transaction.getGatewayAccountExternalId());
         return sendMandateProblemEmailFor(mandateCancelledTemplateId, transaction, mandate, payer);
     }
@@ -125,12 +125,12 @@ public class UserNotificationService {
     public Future<Optional<String>> sendPaymentConfirmedEmailFor(Transaction transaction, Payer payer, LocalDate earliestChargeDate) {
         String paymentConfirmedTemplateId = directDebitConfig.getNotifyConfig().getPaymentConfirmedTemplateId();
         LOGGER.info("Sending payment confirmed email, payment request id: {}, gateway account id: {}",
-                transaction.getPaymentRequestExternalId(),
+                transaction.getPaymentRequest().getExternalId(),
                 transaction.getGatewayAccountExternalId());
         return sendEmail(buildPaymentConfirmedPersonalisation(transaction, payer,earliestChargeDate),
                 paymentConfirmedTemplateId,
                 payer.getEmail(),
-                transaction.getPaymentRequestExternalId());
+                transaction.getPaymentRequest().getExternalId());
     }
 
     private HashMap<String, String> buildMandateProblemPersonalisation(Transaction transaction, Mandate mandate) {

--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -56,6 +56,7 @@ public class UserNotificationService {
     private final DirectDebitConfig directDebitConfig;
     private final GatewayAccountService gatewayAccountService;
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
     @Inject
     public UserNotificationService(DirectDebitConfig directDebitConfig,
                                    NotificationClient notificationClient,
@@ -114,6 +115,7 @@ public class UserNotificationService {
                 transaction.getGatewayAccountExternalId());
         return sendMandateProblemEmailFor(mandateFailedTemplateId, transaction, mandate, payer);
     }
+
     public Future<Optional<String>> sendMandateCancelledEmailFor(Transaction transaction, Mandate mandate, Payer payer) {
         String mandateCancelledTemplateId = directDebitConfig.getNotifyConfig().getMandateCancelledTemplateId();
         LOGGER.info("Sending mandate cancelled email, payment request id: {}, gateway account id: {}",
@@ -124,13 +126,14 @@ public class UserNotificationService {
 
     public Future<Optional<String>> sendPaymentConfirmedEmailFor(Transaction transaction, Payer payer, LocalDate earliestChargeDate) {
         String paymentConfirmedTemplateId = directDebitConfig.getNotifyConfig().getPaymentConfirmedTemplateId();
+        String paymentRequestExternalId = transaction.getPaymentRequest().getExternalId();
         LOGGER.info("Sending payment confirmed email, payment request id: {}, gateway account id: {}",
-                transaction.getPaymentRequest().getExternalId(),
+                paymentRequestExternalId,
                 transaction.getGatewayAccountExternalId());
-        return sendEmail(buildPaymentConfirmedPersonalisation(transaction, payer,earliestChargeDate),
+        return sendEmail(buildPaymentConfirmedPersonalisation(transaction, payer, earliestChargeDate),
                 paymentConfirmedTemplateId,
                 payer.getEmail(),
-                transaction.getPaymentRequest().getExternalId());
+                paymentRequestExternalId);
     }
 
     private HashMap<String, String> buildMandateProblemPersonalisation(Transaction transaction, Mandate mandate) {

--- a/src/main/java/uk/gov/pay/directdebit/payers/api/PayerParser.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/PayerParser.java
@@ -16,7 +16,7 @@ public class PayerParser {
         String accountNumber = createPayerMap.get("account_number");
         String sortCode = createPayerMap.get("sort_code");
         return new Payer(
-                transaction.getPaymentRequestId(),
+                transaction.getPaymentRequest().getId(),
                 createPayerMap.get("account_holder_name"),
                 createPayerMap.get("email"),
                 encrypt(sortCode),

--- a/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
@@ -29,7 +29,7 @@ public class PayerService {
     }
     public Payer getPayerFor(Transaction transaction) {
         return payerDao
-                .findByPaymentRequestId(transaction.getPaymentRequestId())
+                .findByPaymentRequestId(transaction.getPaymentRequest().getId())
                 .orElseThrow(() -> new PayerNotFoundException(transaction.getPaymentRequestExternalId()));
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
@@ -30,7 +30,7 @@ public class PayerService {
     public Payer getPayerFor(Transaction transaction) {
         return payerDao
                 .findByPaymentRequestId(transaction.getPaymentRequest().getId())
-                .orElseThrow(() -> new PayerNotFoundException(transaction.getPaymentRequestExternalId()));
+                .orElseThrow(() -> new PayerNotFoundException(transaction.getPaymentRequest().getExternalId()));
     }
 
     public Payer create(String paymentRequestExternalId, String accountExternalId, Map<String, String> createPayerRequest) {

--- a/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
@@ -6,6 +6,7 @@ import uk.gov.pay.directdebit.mandate.exception.PayerNotFoundException;
 import uk.gov.pay.directdebit.payers.api.PayerParser;
 import uk.gov.pay.directdebit.payers.dao.PayerDao;
 import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 
@@ -27,10 +28,12 @@ public class PayerService {
         this.transactionService = transactionService;
         this.payerParser = payerParser;
     }
+
     public Payer getPayerFor(Transaction transaction) {
+        PaymentRequest paymentRequest = transaction.getPaymentRequest();
         return payerDao
-                .findByPaymentRequestId(transaction.getPaymentRequest().getId())
-                .orElseThrow(() -> new PayerNotFoundException(transaction.getPaymentRequest().getExternalId()));
+                .findByPaymentRequestId(paymentRequest.getId())
+                .orElseThrow(() -> new PayerNotFoundException(paymentRequest.getExternalId()));
     }
 
     public Payer create(String paymentRequestExternalId, String accountExternalId, Map<String, String> createPayerRequest) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
@@ -179,7 +179,7 @@ public interface TransactionDao {
     @SqlUpdate("UPDATE transactions t SET state = :state WHERE t.id = :id")
     int updateState(@Bind("id") Long id, @Bind("state") PaymentState paymentState);
 
-    @SqlUpdate("INSERT INTO transactions(payment_request_id, amount, type, state) VALUES (:paymentRequestId, :amount, :type, :state)")
+    @SqlUpdate("INSERT INTO transactions(payment_request_id, amount, type, state) VALUES (:paymentRequest.id, :amount, :type, :state)")
     @GetGeneratedKeys
     Long insert(@BindBean Transaction transaction);
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -23,6 +23,7 @@ public class TransactionMapper implements RowMapper<Transaction> {
     private static final String PAYMENT_REQUEST_REFERENCE_COLUMN = "payment_request_reference";
     private static final String PAYMENT_REQUEST_RETURN_URL_COLUMN = "payment_request_return_url";
     private static final String PAYMENT_REQUEST_DESCRIPTION_COLUMN = "payment_request_description";
+    private static final String PAYMENT_REQUEST_AMOUNT_COLUMN = "payment_request_amount";
     private static final String GATEWAY_ACCOUNT_ID_COLUMN = "gateway_account_id";
     private static final String GATEWAY_ACCOUNT_EXTERNAL_ID_COLUMN = "gateway_account_external_id";
     private static final String GATEWAY_ACCOUNT_PAYMENT_PROVIDER_COLUMN = "gateway_account_payment_provider";
@@ -31,7 +32,7 @@ public class TransactionMapper implements RowMapper<Transaction> {
     public Transaction map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
         PaymentRequest paymentRequest = new PaymentRequest(
                 resultSet.getLong(PAYMENT_REQUEST_ID_COLUMN),
-                resultSet.getLong(TRANSACTION_AMOUNT_COLUMN),
+                resultSet.getLong(PAYMENT_REQUEST_AMOUNT_COLUMN),
                 resultSet.getString(PAYMENT_REQUEST_RETURN_URL_COLUMN),
                 resultSet.getLong(GATEWAY_ACCOUNT_ID_COLUMN),
                 resultSet.getString(PAYMENT_REQUEST_DESCRIPTION_COLUMN),

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -3,11 +3,14 @@ package uk.gov.pay.directdebit.payments.dao.mapper;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 public class TransactionMapper implements RowMapper<Transaction> {
 
@@ -26,16 +29,24 @@ public class TransactionMapper implements RowMapper<Transaction> {
 
     @Override
     public Transaction map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
-        return new Transaction(
-                resultSet.getLong(TRANSACTION_ID_COLUMN),
+        PaymentRequest paymentRequest = new PaymentRequest(
                 resultSet.getLong(PAYMENT_REQUEST_ID_COLUMN),
-                resultSet.getString(PAYMENT_REQUEST_EXTERNAL_ID_COLUMN),
+                resultSet.getLong(TRANSACTION_AMOUNT_COLUMN),
+                resultSet.getString(PAYMENT_REQUEST_RETURN_URL_COLUMN),
+                resultSet.getLong(GATEWAY_ACCOUNT_ID_COLUMN),
                 resultSet.getString(PAYMENT_REQUEST_DESCRIPTION_COLUMN),
                 resultSet.getString(PAYMENT_REQUEST_REFERENCE_COLUMN),
+                resultSet.getString(PAYMENT_REQUEST_EXTERNAL_ID_COLUMN),
+                ZonedDateTime.now(ZoneOffset.UTC)
+        );
+
+
+        return new Transaction(
+                resultSet.getLong(TRANSACTION_ID_COLUMN),
+                paymentRequest,
                 resultSet.getLong(GATEWAY_ACCOUNT_ID_COLUMN),
                 resultSet.getString(GATEWAY_ACCOUNT_EXTERNAL_ID_COLUMN),
                 PaymentProvider.fromString(resultSet.getString(GATEWAY_ACCOUNT_PAYMENT_PROVIDER_COLUMN)),
-                resultSet.getString(PAYMENT_REQUEST_RETURN_URL_COLUMN),
                 resultSet.getLong(TRANSACTION_AMOUNT_COLUMN),
                 Transaction.Type.valueOf(resultSet.getString(TRANSACTION_TYPE_COLUMN)),
                 PaymentState.valueOf(resultSet.getString(TRANSACTION_STATE_COLUMN)));

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.payments.model;
 
-
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 
 import java.time.ZoneOffset;
@@ -9,15 +8,29 @@ import java.time.ZonedDateTime;
 public class PaymentRequest {
 
     private Long id;
+
     private String externalId;
+
     private Long amount;
+
     private String returnUrl;
+
     private Long gatewayAccountId;
+
     private String description;
+
     private String reference;
+
     private ZonedDateTime createdDate;
 
-    public PaymentRequest(Long id, Long amount, String returnUrl, Long gatewayAccountId, String description, String reference, String externalId, ZonedDateTime createdDate) {
+    public PaymentRequest(Long id,
+                          Long amount,
+                          String returnUrl,
+                          Long gatewayAccountId,
+                          String description,
+                          String reference,
+                          String externalId,
+                          ZonedDateTime createdDate) {
         this.id = id;
         this.amount = amount;
         this.returnUrl = returnUrl;
@@ -28,8 +41,21 @@ public class PaymentRequest {
         this.externalId = externalId;
     }
 
-    public PaymentRequest(Long amount, String returnUrl, Long gatewayAccountId, String description, String reference) {
-        this(null, amount, returnUrl, gatewayAccountId, description, reference, RandomIdGenerator.newId(), ZonedDateTime.now(ZoneOffset.UTC));
+    public PaymentRequest(Long amount,
+                          String returnUrl,
+                          Long gatewayAccountId,
+                          String description,
+                          String reference) {
+        this(
+                null,
+                amount,
+                returnUrl,
+                gatewayAccountId,
+                description,
+                reference,
+                RandomIdGenerator.newId(),
+                ZonedDateTime.now(ZoneOffset.UTC)
+        );
     }
 
     public String getExternalId() {

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.payments.model;
 
+
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 
 import java.time.ZoneOffset;
@@ -8,29 +9,15 @@ import java.time.ZonedDateTime;
 public class PaymentRequest {
 
     private Long id;
-
     private String externalId;
-
     private Long amount;
-
     private String returnUrl;
-
     private Long gatewayAccountId;
-
     private String description;
-
     private String reference;
-
     private ZonedDateTime createdDate;
 
-    public PaymentRequest(Long id,
-                          Long amount,
-                          String returnUrl,
-                          Long gatewayAccountId,
-                          String description,
-                          String reference,
-                          String externalId,
-                          ZonedDateTime createdDate) {
+    public PaymentRequest(Long id, Long amount, String returnUrl, Long gatewayAccountId, String description, String reference, String externalId, ZonedDateTime createdDate) {
         this.id = id;
         this.amount = amount;
         this.returnUrl = returnUrl;
@@ -41,21 +28,8 @@ public class PaymentRequest {
         this.externalId = externalId;
     }
 
-    public PaymentRequest(Long amount,
-                          String returnUrl,
-                          Long gatewayAccountId,
-                          String description,
-                          String reference) {
-        this(
-                null,
-                amount,
-                returnUrl,
-                gatewayAccountId,
-                description,
-                reference,
-                RandomIdGenerator.newId(),
-                ZonedDateTime.now(ZoneOffset.UTC)
-        );
+    public PaymentRequest(Long amount, String returnUrl, Long gatewayAccountId, String description, String reference) {
+        this(null, amount, returnUrl, gatewayAccountId, description, reference, RandomIdGenerator.newId(), ZonedDateTime.now(ZoneOffset.UTC));
     }
 
     public String getExternalId() {

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -75,10 +75,6 @@ public class Transaction {
         return gatewayAccountExternalId;
     }
 
-    public String getPaymentRequestDescription() {
-        return this.paymentRequest.getDescription();
-    }
-
     public String getPaymentRequestReference() {
         return this.paymentRequest.getReference();
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -75,10 +75,6 @@ public class Transaction {
         return gatewayAccountExternalId;
     }
 
-    public String getPaymentRequestReference() {
-        return this.paymentRequest.getReference();
-    }
-
     public PaymentProvider getPaymentProvider() {
         return paymentProvider;
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -2,15 +2,13 @@ package uk.gov.pay.directdebit.payments.model;
 
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
 public class Transaction {
 
     private Long id;
-    //todo refactor this to contain a PaymentRequest
-    private String paymentRequestExternalId;
-    private Long paymentRequestId;
-    private String paymentRequestDescription;
-    private String paymentRequestReturnUrl;
-    private String paymentRequestReference;
+    private PaymentRequest paymentRequest;
     private Long gatewayAccountId;
     private String gatewayAccountExternalId;
     private PaymentProvider paymentProvider;
@@ -31,14 +29,19 @@ public class Transaction {
                        Type type,
                        PaymentState state) {
         this.id = id;
-        this.paymentRequestExternalId = paymentRequestExternalId;
-        this.paymentRequestId = paymentRequestId;
+        this.paymentRequest = new PaymentRequest(
+                paymentRequestId,
+                amount,
+                paymentRequestReturnUrl,
+                gatewayAccountId,
+                paymentRequestDescription,
+                paymentRequestReference,
+                paymentRequestExternalId,
+                ZonedDateTime.now(ZoneOffset.UTC)
+        );
         this.gatewayAccountId = gatewayAccountId;
         this.gatewayAccountExternalId = gatewayAccountExternalId;
         this.paymentProvider = paymentProvider;
-        this.paymentRequestDescription = paymentRequestDescription;
-        this.paymentRequestReference = paymentRequestReference;
-        this.paymentRequestReturnUrl = paymentRequestReturnUrl;
         this.amount = amount;
         this.type = type;
         this.state = state;
@@ -52,28 +55,36 @@ public class Transaction {
         this.id = id;
     }
 
+    public PaymentRequest getPaymentRequest() {
+        return paymentRequest;
+    }
+
+    public void setPaymentProvider(PaymentProvider paymentProvider) {
+        this.paymentProvider = paymentProvider;
+    }
+
     public Long getPaymentRequestId() {
-        return paymentRequestId;
+        return this.paymentRequest.getId();
     }
 
     public void setPaymentRequestId(Long paymentRequestId) {
-        this.paymentRequestId = paymentRequestId;
+        this.paymentRequest.setId(paymentRequestId);
     }
 
     public String getPaymentRequestExternalId() {
-        return paymentRequestExternalId;
+        return this.paymentRequest.getExternalId();
     }
 
     public void setPaymentRequestExternalId(String paymentRequestExternalId) {
-        this.paymentRequestExternalId = paymentRequestExternalId;
+        this.paymentRequest.setExternalId(paymentRequestExternalId);
     }
 
     public String getPaymentRequestReturnUrl() {
-        return paymentRequestReturnUrl;
+        return this.paymentRequest.getReturnUrl();
     }
 
     public void setPaymentRequestReturnUrl(String paymentRequestReturnUrl) {
-        this.paymentRequestReturnUrl = paymentRequestReturnUrl;
+        this.paymentRequest.setReturnUrl(paymentRequestReturnUrl);
     }
 
     public Long getGatewayAccountId() {
@@ -93,19 +104,19 @@ public class Transaction {
     }
 
     public String getPaymentRequestDescription() {
-        return paymentRequestDescription;
+        return this.paymentRequest.getDescription();
     }
 
     public void setPaymentRequestDescription(String paymentRequestDescription) {
-        this.paymentRequestDescription = paymentRequestDescription;
+        this.paymentRequest.setDescription(paymentRequestDescription);
     }
 
     public String getPaymentRequestReference() {
-        return paymentRequestReference;
+        return this.paymentRequest.getReference();
     }
 
     public Transaction setPaymentRequestReference(String paymentRequestReference) {
-        this.paymentRequestReference = paymentRequestReference;
+        this.paymentRequest.setReference(paymentRequestReference);
         return this;
     }
 
@@ -149,14 +160,10 @@ public class Transaction {
         Transaction that = (Transaction) o;
 
         if (id != null ? !id.equals(that.id) : that.id != null) return false;
-        if (!paymentRequestExternalId.equals(that.paymentRequestExternalId)) return false;
+        if (!paymentRequest.equals(that.paymentRequest)) return false;
         if (!gatewayAccountId.equals(that.gatewayAccountId)) return false;
         if (!gatewayAccountExternalId.equals(that.gatewayAccountExternalId)) return false;
-        if (!paymentRequestDescription.equals(that.paymentRequestDescription)) return false;
-        if (!paymentProvider.equals(that.paymentProvider)) return false;
-        if (!paymentRequestId.equals(that.paymentRequestId)) return false;
-        if (!paymentRequestReturnUrl.equals(that.paymentRequestReturnUrl)) return false;
-        if (!paymentRequestReference.equals(that.paymentRequestReference)) return false;
+        if (paymentProvider != that.paymentProvider) return false;
         if (!amount.equals(that.amount)) return false;
         if (type != that.type) return false;
         return state == that.state;
@@ -165,14 +172,10 @@ public class Transaction {
     @Override
     public int hashCode() {
         int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + paymentRequestExternalId.hashCode();
-        result = 31 * result + paymentRequestId.hashCode();
+        result = 31 * result + paymentRequest.hashCode();
         result = 31 * result + gatewayAccountId.hashCode();
         result = 31 * result + gatewayAccountExternalId.hashCode();
         result = 31 * result + paymentProvider.hashCode();
-        result = 31 * result + paymentRequestDescription.hashCode();
-        result = 31 * result + paymentRequestReturnUrl.hashCode();
-        result = 31 * result + paymentRequestReference.hashCode();
         result = 31 * result + amount.hashCode();
         result = 31 * result + type.hashCode();
         result = 31 * result + state.hashCode();

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -1,11 +1,7 @@
 package uk.gov.pay.directdebit.payments.model;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class Transaction {
 
     private Long id;
@@ -46,32 +42,6 @@ public class Transaction {
         this.amount = amount;
         this.type = type;
         this.state = state;
-    }
-
-    public Transaction(Long paymentRequestId,
-                       String paymentRequestExternalId,
-                       String paymentRequestDescription,
-                       String paymentRequestReference,
-                       Long gatewayAccountId,
-                       String gatewayAccountExternalId,
-                       PaymentProvider paymentProvider,
-                       String paymentRequestReturnUrl,
-                       Long amount,
-                       Type type,
-                       PaymentState state) {
-        this(null,
-                paymentRequestId,
-                paymentRequestExternalId,
-                paymentRequestDescription,
-                paymentRequestReference,
-                gatewayAccountId,
-                gatewayAccountExternalId,
-                paymentProvider,
-                paymentRequestReturnUrl,
-                amount,
-                type,
-                state
-        );
     }
 
     public Long getId() {

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -16,6 +16,10 @@ public class Transaction {
     private Type type;
     private PaymentState state;
 
+    public enum Type {
+        CHARGE
+    }
+
     public Transaction(Long id,
                        Long paymentRequestId,
                        String paymentRequestExternalId,
@@ -63,61 +67,28 @@ public class Transaction {
         this.paymentProvider = paymentProvider;
     }
 
-    public Long getPaymentRequestId() {
-        return this.paymentRequest.getId();
-    }
-
-    public void setPaymentRequestId(Long paymentRequestId) {
-        this.paymentRequest.setId(paymentRequestId);
-    }
-
     public String getPaymentRequestExternalId() {
         return this.paymentRequest.getExternalId();
-    }
-
-    public void setPaymentRequestExternalId(String paymentRequestExternalId) {
-        this.paymentRequest.setExternalId(paymentRequestExternalId);
     }
 
     public String getPaymentRequestReturnUrl() {
         return this.paymentRequest.getReturnUrl();
     }
 
-    public void setPaymentRequestReturnUrl(String paymentRequestReturnUrl) {
-        this.paymentRequest.setReturnUrl(paymentRequestReturnUrl);
-    }
-
     public Long getGatewayAccountId() {
         return gatewayAccountId;
-    }
-
-    public void setGatewayAccountId(Long gatewayAccountId) {
-        this.gatewayAccountId = gatewayAccountId;
     }
 
     public String getGatewayAccountExternalId() {
         return gatewayAccountExternalId;
     }
 
-    public void setGatewayAccountExternalId(String gatewayAccountExternalId) {
-        this.gatewayAccountExternalId = gatewayAccountExternalId;
-    }
-
     public String getPaymentRequestDescription() {
         return this.paymentRequest.getDescription();
     }
 
-    public void setPaymentRequestDescription(String paymentRequestDescription) {
-        this.paymentRequest.setDescription(paymentRequestDescription);
-    }
-
     public String getPaymentRequestReference() {
         return this.paymentRequest.getReference();
-    }
-
-    public Transaction setPaymentRequestReference(String paymentRequestReference) {
-        this.paymentRequest.setReference(paymentRequestReference);
-        return this;
     }
 
     public PaymentProvider getPaymentProvider() {
@@ -146,10 +117,6 @@ public class Transaction {
 
     public void setState(PaymentState state) {
         this.state = state;
-    }
-
-    public enum Type {
-        CHARGE
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -67,10 +67,6 @@ public class Transaction {
         this.paymentProvider = paymentProvider;
     }
 
-    public String getPaymentRequestExternalId() {
-        return this.paymentRequest.getExternalId();
-    }
-
     public String getPaymentRequestReturnUrl() {
         return this.paymentRequest.getReturnUrl();
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -67,10 +67,6 @@ public class Transaction {
         this.paymentProvider = paymentProvider;
     }
 
-    public String getPaymentRequestReturnUrl() {
-        return this.paymentRequest.getReturnUrl();
-    }
-
     public Long getGatewayAccountId() {
         return gatewayAccountId;
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -2,9 +2,6 @@ package uk.gov.pay.directdebit.payments.model;
 
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-
 public class Transaction {
 
     private Long id;
@@ -21,28 +18,15 @@ public class Transaction {
     }
 
     public Transaction(Long id,
-                       Long paymentRequestId,
-                       String paymentRequestExternalId,
-                       String paymentRequestDescription,
-                       String paymentRequestReference,
+                       PaymentRequest paymentRequest,
                        Long gatewayAccountId,
                        String gatewayAccountExternalId,
                        PaymentProvider paymentProvider,
-                       String paymentRequestReturnUrl,
                        Long amount,
                        Type type,
                        PaymentState state) {
         this.id = id;
-        this.paymentRequest = new PaymentRequest(
-                paymentRequestId,
-                amount,
-                paymentRequestReturnUrl,
-                gatewayAccountId,
-                paymentRequestDescription,
-                paymentRequestReference,
-                paymentRequestExternalId,
-                ZonedDateTime.now(ZoneOffset.UTC)
-        );
+        this.paymentRequest = paymentRequest;
         this.gatewayAccountId = gatewayAccountId;
         this.gatewayAccountExternalId = gatewayAccountExternalId;
         this.paymentProvider = paymentProvider;

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -40,7 +40,7 @@ public class PaymentRequestEventService {
 
     private PaymentRequestEvent insertEventFor(Transaction charge, PaymentRequestEvent event) {
         LOGGER.info("Creating event for {} {}: {} - {}",
-                charge.getType(), charge.getPaymentRequestExternalId(),
+                charge.getType(), charge.getPaymentRequest().getExternalId(),
                 event.getEventType(), event.getEvent());
         Long id = paymentRequestEventDao.insert(event);
         event.setId(id);

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestEventService.java
@@ -54,76 +54,76 @@ public class PaymentRequestEventService {
     }
 
     public void registerDirectDebitReceivedEventFor(Transaction charge) {
-        insertEventFor(charge, directDebitDetailsReceived(charge.getPaymentRequestId()));
+        insertEventFor(charge, directDebitDetailsReceived(charge.getPaymentRequest().getId()));
     }
 
     public void registerDirectDebitConfirmedEventFor(Transaction charge) {
-        PaymentRequestEvent event = directDebitDetailsConfirmed(charge.getPaymentRequestId());
+        PaymentRequestEvent event = directDebitDetailsConfirmed(charge.getPaymentRequest().getId());
         insertEventFor(charge, event);
     }
 
     public void registerPayerCreatedEventFor(Transaction charge) {
-        PaymentRequestEvent event = payerCreated(charge.getPaymentRequestId());
+        PaymentRequestEvent event = payerCreated(charge.getPaymentRequest().getId());
         insertEventFor(charge, event);
     }
 
     public void registerTokenExchangedEventFor(Transaction charge) {
-        PaymentRequestEvent event = tokenExchanged(charge.getPaymentRequestId());
+        PaymentRequestEvent event = tokenExchanged(charge.getPaymentRequest().getId());
         insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerPaymentCreatedEventFor(Transaction charge) {
-        PaymentRequestEvent event = paymentCreated(charge.getPaymentRequestId());
+        PaymentRequestEvent event = paymentCreated(charge.getPaymentRequest().getId());
         return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerPaymentCancelledEventFor(Transaction charge) {
-        PaymentRequestEvent event = paymentCancelled(charge.getPaymentRequestId());
+        PaymentRequestEvent event = paymentCancelled(charge.getPaymentRequest().getId());
         return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerMandateFailedEventFor(Transaction charge) {
-        PaymentRequestEvent event = mandateFailed(charge.getPaymentRequestId());
+        PaymentRequestEvent event = mandateFailed(charge.getPaymentRequest().getId());
         return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerMandateCancelledEventFor(Transaction charge) {
-        PaymentRequestEvent event = mandateCancelled(charge.getPaymentRequestId());
+        PaymentRequestEvent event = mandateCancelled(charge.getPaymentRequest().getId());
         return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerPaymentFailedEventFor(Transaction charge) {
-        PaymentRequestEvent event = paymentFailed(charge.getPaymentRequestId());
+        PaymentRequestEvent event = paymentFailed(charge.getPaymentRequest().getId());
         return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerPaymentPendingEventFor(Transaction charge) {
-        PaymentRequestEvent event = paymentPending(charge.getPaymentRequestId());
+        PaymentRequestEvent event = paymentPending(charge.getPaymentRequest().getId());
         return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerPaymentSubmittedEventFor(Transaction charge) {
-        PaymentRequestEvent event = paymentSubmitted(charge.getPaymentRequestId());
+        PaymentRequestEvent event = paymentSubmitted(charge.getPaymentRequest().getId());
         return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerPaymentPaidOutEventFor(Transaction charge) {
-        PaymentRequestEvent event = paidOut(charge.getPaymentRequestId());
+        PaymentRequestEvent event = paidOut(charge.getPaymentRequest().getId());
         return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerPayoutPaidEventFor(Transaction charge) {
-        PaymentRequestEvent event = payoutPaid(charge.getPaymentRequestId());
+        PaymentRequestEvent event = payoutPaid(charge.getPaymentRequest().getId());
         return insertEventFor(charge, event);
     }
 
     public PaymentRequestEvent registerMandatePendingEventFor(Transaction transaction) {
-        PaymentRequestEvent event = mandatePending(transaction.getPaymentRequestId());
+        PaymentRequestEvent event = mandatePending(transaction.getPaymentRequest().getId());
         return insertEventFor(transaction, event);
     }
 
     public PaymentRequestEvent registerMandateActiveEventFor(Transaction transaction) {
-        PaymentRequestEvent event = mandateActive(transaction.getPaymentRequestId());
+        PaymentRequestEvent event = mandateActive(transaction.getPaymentRequest().getId());
         return insertEventFor(transaction, event);
     }
 
@@ -132,7 +132,7 @@ public class PaymentRequestEventService {
     }
 
     public PaymentRequestEvent registerPaymentMethodChangedEventFor(Transaction transaction) {
-        PaymentRequestEvent event = paymentMethodChanged(transaction.getPaymentRequestId());
+        PaymentRequestEvent event = paymentMethodChanged(transaction.getPaymentRequest().getId());
         return insertEventFor(transaction, event);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -57,14 +57,10 @@ public class TransactionService {
     Transaction createChargeFor(PaymentRequest paymentRequest, GatewayAccount gatewayAccount) {
         Transaction transaction = new Transaction(
                 null,
-                paymentRequest.getId(),
-                paymentRequest.getExternalId(),
-                paymentRequest.getDescription(),
-                paymentRequest.getReference(),
+                paymentRequest,
                 gatewayAccount.getId(),
                 gatewayAccount.getExternalId(),
                 gatewayAccount.getPaymentProvider(),
-                paymentRequest.getReturnUrl(),
                 paymentRequest.getAmount(),
                 Transaction.Type.CHARGE,
                 PaymentStatesGraph.initialState()

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -56,6 +56,7 @@ public class TransactionService {
 
     Transaction createChargeFor(PaymentRequest paymentRequest, GatewayAccount gatewayAccount) {
         Transaction transaction = new Transaction(
+                null,
                 paymentRequest.getId(),
                 paymentRequest.getExternalId(),
                 paymentRequest.getDescription(),
@@ -66,7 +67,8 @@ public class TransactionService {
                 paymentRequest.getReturnUrl(),
                 paymentRequest.getAmount(),
                 Transaction.Type.CHARGE,
-                PaymentStatesGraph.initialState());
+                PaymentStatesGraph.initialState()
+        );
         LOGGER.info("Created transaction for payment request {}", paymentRequest.getExternalId());
         Long id = transactionDao.insert(transaction);
         transaction.setId(id);
@@ -87,6 +89,7 @@ public class TransactionService {
                     return newCharge;
                 });
     }
+
     public Transaction findTransactionFor(Long transactionId) {
         return transactionDao
                 .findById(transactionId)

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -167,11 +167,11 @@ public class TransactionService {
     }
 
     public Optional<PaymentRequestEvent> findPaymentSubmittedEventFor(Transaction transaction) {
-        return paymentRequestEventService.findBy(transaction.getPaymentRequestId(), CHARGE, PAYMENT_SUBMITTED);
+        return paymentRequestEventService.findBy(transaction.getPaymentRequest().getId(), CHARGE, PAYMENT_SUBMITTED);
     }
 
     public Optional<PaymentRequestEvent> findMandatePendingEventFor(Transaction transaction) {
-        return paymentRequestEventService.findBy(transaction.getPaymentRequestId(), MANDATE, MANDATE_PENDING);
+        return paymentRequestEventService.findBy(transaction.getPaymentRequest().getId(), MANDATE, MANDATE_PENDING);
     }
 
     public PaymentRequestEvent paymentMethodChangedFor(Transaction transaction) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -159,7 +159,7 @@ public class TransactionService {
                 event);
         transactionDao.updateState(transaction.getId(), newState);
         LOGGER.info("Updating transaction {} - from {} to {}",
-                transaction.getPaymentRequestExternalId(),
+                transaction.getPaymentRequest().getExternalId(),
                 transaction.getState(),
                 newState);
         transaction.setState(newState);

--- a/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
@@ -57,7 +57,7 @@ public class TokenResponse {
                 transaction.getPaymentRequest().getExternalId(),
                 transaction.getGatewayAccountId(),
                 transaction.getGatewayAccountExternalId(),
-                transaction.getPaymentRequestDescription(),
+                transaction.getPaymentRequest().getDescription(),
                 transaction.getPaymentRequest().getReturnUrl(),
                 transaction.getAmount(),
                 transaction.getType().toString(),

--- a/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
@@ -58,7 +58,7 @@ public class TokenResponse {
                 transaction.getGatewayAccountId(),
                 transaction.getGatewayAccountExternalId(),
                 transaction.getPaymentRequestDescription(),
-                transaction.getPaymentRequestReturnUrl(),
+                transaction.getPaymentRequest().getReturnUrl(),
                 transaction.getAmount(),
                 transaction.getType().toString(),
                 transaction.getState().toString()

--- a/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
@@ -54,7 +54,7 @@ public class TokenResponse {
 
     public static TokenResponse from(Transaction transaction) {
         return new TokenResponse(
-                transaction.getPaymentRequestExternalId(),
+                transaction.getPaymentRequest().getExternalId(),
                 transaction.getGatewayAccountId(),
                 transaction.getGatewayAccountExternalId(),
                 transaction.getPaymentRequestDescription(),

--- a/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.tokens.api;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -53,12 +54,13 @@ public class TokenResponse {
     }
 
     public static TokenResponse from(Transaction transaction) {
+        PaymentRequest paymentRequest = transaction.getPaymentRequest();
         return new TokenResponse(
-                transaction.getPaymentRequest().getExternalId(),
+                paymentRequest.getExternalId(),
                 transaction.getGatewayAccountId(),
                 transaction.getGatewayAccountExternalId(),
-                transaction.getPaymentRequest().getDescription(),
-                transaction.getPaymentRequest().getReturnUrl(),
+                paymentRequest.getDescription(),
+                paymentRequest.getReturnUrl(),
                 transaction.getAmount(),
                 transaction.getType().toString(),
                 transaction.getState().toString()

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -56,7 +56,7 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
                 GoCardlessPaymentAction.SUBMITTED, transactionService::paymentSubmittedFor,
                 GoCardlessPaymentAction.CONFIRMED, (Transaction transaction) ->
                         transactionService.findPaymentSubmittedEventFor(transaction)
-                                .orElseThrow(() -> new InvalidStateException("Could not find payment submitted event for payment request with id: " + transaction.getPaymentRequestExternalId())),
+                                .orElseThrow(() -> new InvalidStateException("Could not find payment submitted event for payment request with id: " + transaction.getPaymentRequest().getExternalId())),
                 GoCardlessPaymentAction.PAID_OUT, transactionService::paymentPaidOutFor,
                 GoCardlessPaymentAction.PAID, transactionService::payoutPaidFor
         );

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -126,7 +126,7 @@ public class MandateServiceTest {
 
         PaymentRequestEvent event = PaymentRequestEventFixture.aPaymentRequestEventFixture().toEntity();
 
-        when(mockedPaymentRequestEventService.findBy(transaction.getPaymentRequestId(), PaymentRequestEvent.Type.MANDATE, MANDATE_PENDING))
+        when(mockedPaymentRequestEventService.findBy(transaction.getPaymentRequest().getId(), PaymentRequestEvent.Type.MANDATE, MANDATE_PENDING))
                 .thenReturn(Optional.of(event));
 
         PaymentRequestEvent foundEvent = service.findMandatePendingEventFor(transaction).get();

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -150,7 +150,7 @@ public class UserNotificationServiceTest {
         HashMap<String, String> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put("service name", gatewayAccount.getServiceName());
         emailPersonalisation.put("amount", "123.45");
-        emailPersonalisation.put("payment reference", transaction.getPaymentRequestReference());
+        emailPersonalisation.put("payment reference", transaction.getPaymentRequest().getReference());
         emailPersonalisation.put("collection date", "21/05/2018");
         emailPersonalisation.put("bank account last 2 digits", "******" + payer.getAccountNumberLastTwoDigits());
         emailPersonalisation.put("SUN", "THE-CAKE-IS-A-LIE");

--- a/src/test/java/uk/gov/pay/directdebit/payers/api/PayerParserTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/api/PayerParserTest.java
@@ -6,8 +6,9 @@ import org.junit.runner.RunWith;
 import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.directdebit.payers.api.PayerParser;
 import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
 import java.time.ZonedDateTime;
@@ -33,11 +34,13 @@ public class PayerParserTest {
     private static final String NAME = "name";
     private static final String ADDRESS_LINE2 = "this is address line 2";
 
-
     @Mock
     private Transaction mockedTransaction;
 
     private PayerParser payerParser = new PayerParser();
+
+    private PaymentRequest paymentRequest =
+            PaymentRequestFixture.aPaymentRequestFixture().withId(19L).toEntity();
 
     @Test
     public void shouldCreateAPayerWhenAllFieldsAreThere() {
@@ -53,7 +56,7 @@ public class PayerParserTest {
             put("country_code", COUNTRY_CODE);
             put("requires_authorisation", "true");
         }};
-        when(mockedTransaction.getPaymentRequestId()).thenReturn(19L);
+        when(mockedTransaction.getPaymentRequest()).thenReturn(paymentRequest);
         Payer payer = payerParser.parse(createPaymentRequestWithAllFields, mockedTransaction);
         assertThat(payer.getExternalId(), is(notNullValue()));
         assertThat(payer.getPaymentRequestId(), is(19L));
@@ -70,6 +73,7 @@ public class PayerParserTest {
         assertThat(payer.getAddressCountry(), is(COUNTRY_CODE));
         assertThat(payer.getCreatedDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }
+
     @Test
     public void shouldCreateAPayerWithoutMandatoryFields() {
         Map<String, String> createPaymentRequestWithAllFields = new HashMap<String, String>() {{
@@ -83,7 +87,7 @@ public class PayerParserTest {
             put("country_code", COUNTRY_CODE);
             put("requires_authorisation", "true");
         }};
-        when(mockedTransaction.getPaymentRequestId()).thenReturn(19L);
+        when(mockedTransaction.getPaymentRequest()).thenReturn(paymentRequest);
         Payer payer = payerParser.parse(createPaymentRequestWithAllFields, mockedTransaction);
         assertThat(payer.getExternalId(), is(notNullValue()));
         assertThat(payer.getPaymentRequestId(), is(19L));

--- a/src/test/java/uk/gov/pay/directdebit/payers/services/PayerServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/services/PayerServiceTest.java
@@ -72,7 +72,7 @@ public class PayerServiceTest {
 
     @Test
     public void shouldReturnPayerForTransactionIfItExists() {
-        when(mockedPayerDao.findByPaymentRequestId(transaction.getPaymentRequestId())).thenReturn(Optional.of(payer));
+        when(mockedPayerDao.findByPaymentRequestId(transaction.getPaymentRequest().getId())).thenReturn(Optional.of(payer));
         Payer payer = service.getPayerFor(transaction);
         assertThat(payer.getId(), is(payer.getId()));
         assertThat(payer.getExternalId(), is(payer.getExternalId()));
@@ -80,7 +80,7 @@ public class PayerServiceTest {
 
     @Test
     public void shouldThrowIfGatewayAccountDoesNotExist() {
-        when(mockedPayerDao.findByPaymentRequestId(transaction.getPaymentRequestId())).thenReturn(Optional.empty());
+        when(mockedPayerDao.findByPaymentRequestId(transaction.getPaymentRequest().getId())).thenReturn(Optional.empty());
         thrown.expect(PayerNotFoundException.class);
         thrown.expectMessage("Couldn't find payer for payment request with external id: sdkfhsdkjfhjdks");
         thrown.reportMissingExceptionWithMessage("PayerNotFoundException expected");

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
@@ -71,7 +71,7 @@ public class TransactionDaoIT {
         testTransaction.insert(testContext.getJdbi());
         Transaction transaction = transactionDao.findById(testTransaction.getId()).get();
         assertThat(transaction.getId(), is(testTransaction.getId()));
-        assertThat(transaction.getPaymentRequestId(), is(testPaymentRequest.getId()));
+        assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
         assertThat(transaction.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
@@ -85,7 +85,7 @@ public class TransactionDaoIT {
         testTransaction.insert(testContext.getJdbi());
         Transaction transaction = transactionDao.findByPaymentRequestId(testPaymentRequest.getId()).get();
         assertThat(transaction.getId(), is(testTransaction.getId()));
-        assertThat(transaction.getPaymentRequestId(), is(testPaymentRequest.getId()));
+        assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
         assertThat(transaction.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
@@ -99,7 +99,7 @@ public class TransactionDaoIT {
         testTransaction.insert(testContext.getJdbi());
         Transaction transaction = transactionDao.findTransactionForExternalIdAndGatewayAccountExternalId(testPaymentRequest.getExternalId(), testGatewayAccount.getExternalId()).get();
         assertThat(transaction.getId(), is(testTransaction.getId()));
-        assertThat(transaction.getPaymentRequestId(), is(testTransaction.getPaymentRequestId()));
+        assertThat(transaction.getPaymentRequest().getId(), is(testTransaction.getPaymentRequestId()));
         assertThat(transaction.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
@@ -116,7 +116,7 @@ public class TransactionDaoIT {
         testTransaction.insert(testContext.getJdbi());
         Transaction transaction = transactionDao.findByTokenId(token.getToken()).get();
         assertThat(transaction.getId(), is(testTransaction.getId()));
-        assertThat(transaction.getPaymentRequestId(), is(testPaymentRequest.getId()));
+        assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
         assertThat(transaction.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
@@ -175,7 +175,7 @@ public class TransactionDaoIT {
         Transaction transactionAfterUpdate = transactionDao.findByPaymentRequestId(testTransaction.getPaymentRequestId()).get();
         assertThat(numOfUpdatedTransactions, is(1));
         assertThat(transactionAfterUpdate.getId(), is(testTransaction.getId()));
-        assertThat(transactionAfterUpdate.getPaymentRequestId(), is(testPaymentRequest.getId()));
+        assertThat(transactionAfterUpdate.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
         assertThat(transactionAfterUpdate.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transactionAfterUpdate.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transactionAfterUpdate.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
@@ -72,7 +72,7 @@ public class TransactionDaoIT {
         Transaction transaction = transactionDao.findById(testTransaction.getId()).get();
         assertThat(transaction.getId(), is(testTransaction.getId()));
         assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
-        assertThat(transaction.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
@@ -86,7 +86,7 @@ public class TransactionDaoIT {
         Transaction transaction = transactionDao.findByPaymentRequestId(testPaymentRequest.getId()).get();
         assertThat(transaction.getId(), is(testTransaction.getId()));
         assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
-        assertThat(transaction.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
@@ -100,7 +100,7 @@ public class TransactionDaoIT {
         Transaction transaction = transactionDao.findTransactionForExternalIdAndGatewayAccountExternalId(testPaymentRequest.getExternalId(), testGatewayAccount.getExternalId()).get();
         assertThat(transaction.getId(), is(testTransaction.getId()));
         assertThat(transaction.getPaymentRequest().getId(), is(testTransaction.getPaymentRequestId()));
-        assertThat(transaction.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
@@ -117,7 +117,7 @@ public class TransactionDaoIT {
         Transaction transaction = transactionDao.findByTokenId(token.getToken()).get();
         assertThat(transaction.getId(), is(testTransaction.getId()));
         assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
-        assertThat(transaction.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
@@ -176,7 +176,7 @@ public class TransactionDaoIT {
         assertThat(numOfUpdatedTransactions, is(1));
         assertThat(transactionAfterUpdate.getId(), is(testTransaction.getId()));
         assertThat(transactionAfterUpdate.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
-        assertThat(transactionAfterUpdate.getPaymentRequestExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(transactionAfterUpdate.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transactionAfterUpdate.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
         assertThat(transactionAfterUpdate.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transactionAfterUpdate.getType(), is(TYPE));

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
@@ -74,7 +74,7 @@ public class TransactionDaoIT {
         assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
         assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(transaction.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
         assertThat(transaction.getAmount(), is(AMOUNT));
         assertThat(transaction.getState(), is(STATE));
@@ -88,7 +88,7 @@ public class TransactionDaoIT {
         assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
         assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(transaction.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
         assertThat(transaction.getAmount(), is(AMOUNT));
         assertThat(transaction.getState(), is(STATE));
@@ -102,7 +102,7 @@ public class TransactionDaoIT {
         assertThat(transaction.getPaymentRequest().getId(), is(testTransaction.getPaymentRequestId()));
         assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(transaction.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
         assertThat(transaction.getAmount(), is(AMOUNT));
         assertThat(transaction.getState(), is(STATE));
@@ -119,7 +119,7 @@ public class TransactionDaoIT {
         assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
         assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(transaction.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
         assertThat(transaction.getAmount(), is(AMOUNT));
         assertThat(transaction.getState(), is(STATE));
@@ -178,7 +178,7 @@ public class TransactionDaoIT {
         assertThat(transactionAfterUpdate.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
         assertThat(transactionAfterUpdate.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transactionAfterUpdate.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transactionAfterUpdate.getPaymentRequestDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(transactionAfterUpdate.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transactionAfterUpdate.getType(), is(TYPE));
         assertThat(transactionAfterUpdate.getAmount(), is(AMOUNT));
         assertThat(transactionAfterUpdate.getState(), is(newState));

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.tokens.fixtures.TokenFixture;
@@ -70,11 +71,12 @@ public class TransactionDaoIT {
     public void shouldGetATransactionById() {
         testTransaction.insert(testContext.getJdbi());
         Transaction transaction = transactionDao.findById(testTransaction.getId()).get();
+        PaymentRequest paymentRequest = transaction.getPaymentRequest();
         assertThat(transaction.getId(), is(testTransaction.getId()));
-        assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
-        assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(paymentRequest.getId(), is(testPaymentRequest.getId()));
+        assertThat(paymentRequest.getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(paymentRequest.getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
         assertThat(transaction.getAmount(), is(AMOUNT));
         assertThat(transaction.getState(), is(STATE));
@@ -84,11 +86,12 @@ public class TransactionDaoIT {
     public void shouldGetATransactionByPaymentRequestId() {
         testTransaction.insert(testContext.getJdbi());
         Transaction transaction = transactionDao.findByPaymentRequestId(testPaymentRequest.getId()).get();
+        PaymentRequest paymentRequest = transaction.getPaymentRequest();
         assertThat(transaction.getId(), is(testTransaction.getId()));
-        assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
-        assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(paymentRequest.getId(), is(testPaymentRequest.getId()));
+        assertThat(paymentRequest.getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(paymentRequest.getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
         assertThat(transaction.getAmount(), is(AMOUNT));
         assertThat(transaction.getState(), is(STATE));
@@ -98,11 +101,12 @@ public class TransactionDaoIT {
     public void shouldGetATransactionByPaymentRequestExternalIdAndGatewayAccountId() {
         testTransaction.insert(testContext.getJdbi());
         Transaction transaction = transactionDao.findTransactionForExternalIdAndGatewayAccountExternalId(testPaymentRequest.getExternalId(), testGatewayAccount.getExternalId()).get();
+        PaymentRequest paymentRequest = transaction.getPaymentRequest();
         assertThat(transaction.getId(), is(testTransaction.getId()));
-        assertThat(transaction.getPaymentRequest().getId(), is(testTransaction.getPaymentRequestId()));
-        assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(paymentRequest.getId(), is(testTransaction.getPaymentRequestId()));
+        assertThat(paymentRequest.getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(paymentRequest.getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
         assertThat(transaction.getAmount(), is(AMOUNT));
         assertThat(transaction.getState(), is(STATE));
@@ -115,11 +119,12 @@ public class TransactionDaoIT {
                 .insert(testContext.getJdbi());
         testTransaction.insert(testContext.getJdbi());
         Transaction transaction = transactionDao.findByTokenId(token.getToken()).get();
+        PaymentRequest paymentRequest = transaction.getPaymentRequest();
         assertThat(transaction.getId(), is(testTransaction.getId()));
-        assertThat(transaction.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
-        assertThat(transaction.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(paymentRequest.getId(), is(testPaymentRequest.getId()));
+        assertThat(paymentRequest.getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transaction.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(paymentRequest.getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transaction.getType(), is(TYPE));
         assertThat(transaction.getAmount(), is(AMOUNT));
         assertThat(transaction.getState(), is(STATE));
@@ -173,12 +178,13 @@ public class TransactionDaoIT {
         testTransaction.insert(testContext.getJdbi());
         int numOfUpdatedTransactions = transactionDao.updateState(testTransaction.getId(), newState);
         Transaction transactionAfterUpdate = transactionDao.findByPaymentRequestId(testTransaction.getPaymentRequestId()).get();
+        PaymentRequest paymentRequest = transactionAfterUpdate.getPaymentRequest();
         assertThat(numOfUpdatedTransactions, is(1));
         assertThat(transactionAfterUpdate.getId(), is(testTransaction.getId()));
-        assertThat(transactionAfterUpdate.getPaymentRequest().getId(), is(testPaymentRequest.getId()));
-        assertThat(transactionAfterUpdate.getPaymentRequest().getExternalId(), is(testPaymentRequest.getExternalId()));
+        assertThat(paymentRequest.getId(), is(testPaymentRequest.getId()));
+        assertThat(paymentRequest.getExternalId(), is(testPaymentRequest.getExternalId()));
         assertThat(transactionAfterUpdate.getGatewayAccountId(), is(testPaymentRequest.getGatewayAccountId()));
-        assertThat(transactionAfterUpdate.getPaymentRequest().getDescription(), is(testPaymentRequest.getDescription()));
+        assertThat(paymentRequest.getDescription(), is(testPaymentRequest.getDescription()));
         assertThat(transactionAfterUpdate.getType(), is(TYPE));
         assertThat(transactionAfterUpdate.getAmount(), is(AMOUNT));
         assertThat(transactionAfterUpdate.getState(), is(newState));

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
@@ -6,8 +6,12 @@ import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.directdebit.common.fixtures.DbFixture;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.Transaction;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 public class TransactionFixture implements DbFixture<TransactionFixture, Transaction> {
 
@@ -170,7 +174,18 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
 
     @Override
     public Transaction toEntity() {
-        return new Transaction(id, paymentRequestId, paymentRequestExternalId, paymentRequestDescription, paymentRequestReference, gatewayAccountId, gatewayAccountExternalId, paymentProvider, paymentRequestReturnUrl, amount, type, state);
+        PaymentRequest paymentRequest = new PaymentRequest(
+                paymentRequestId,
+                amount,
+                paymentRequestReturnUrl,
+                gatewayAccountId,
+                paymentRequestDescription,
+                paymentRequestReference,
+                paymentRequestExternalId,
+                ZonedDateTime.now(ZoneOffset.UTC)
+        );
+
+        return new Transaction(id, paymentRequest, gatewayAccountId, gatewayAccountExternalId, paymentProvider, amount, type, state);
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
@@ -12,7 +12,7 @@ import uk.gov.pay.directdebit.mandate.services.PaymentConfirmService;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payers.services.PayerService;
-import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+import uk.gov.pay.directdebit.payments.model.Transaction;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -39,6 +39,7 @@ public class SandboxServiceTest {
 
     private GatewayAccount gatewayAccount = aGatewayAccountFixture().toEntity();
     private Payer payer = PayerFixture.aPayerFixture().toEntity();
+
     @Before
     public void setUp() {
         service = new SandboxService(mockedPayerService, mockedPaymentConfirmService, mockedTransactionService);
@@ -53,17 +54,17 @@ public class SandboxServiceTest {
 
     @Test
     public void confirm_shouldRegisterAPaymentCreatedEventWhenSuccessfullyConfirmed() {
-        TransactionFixture transactionFixture = aTransactionFixture();
         ConfirmationDetails confirmationDetails = confirmationDetails()
-                .withTransaction(transactionFixture)
+                .withTransaction(aTransactionFixture())
                 .withMandate(aMandateFixture())
                 .build();
+        Transaction transaction = confirmationDetails.getTransaction();
 
         when(mockedPaymentConfirmService.confirm(gatewayAccount.getExternalId(), paymentRequestExternalId))
                 .thenReturn(confirmationDetails);
-        when(mockedPayerService.getPayerFor(transactionFixture.toEntity())).thenReturn(payer);
+        when(mockedPayerService.getPayerFor(transaction)).thenReturn(payer);
 
         service.confirm(paymentRequestExternalId, gatewayAccount);
-        verify(mockedTransactionService).paymentCreatedFor(confirmationDetails.getTransaction(), payer, LocalDate.now().plusDays(4));
+        verify(mockedTransactionService).paymentCreatedFor(transaction, payer, LocalDate.now().plusDays(4));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -86,7 +86,7 @@ public class TransactionServiceTest {
 
         assertThat(transaction.getId(), is(notNullValue()));
         assertThat(transaction.getPaymentRequest().getId(), is(paymentRequestFixture.getId()));
-        assertThat(transaction.getPaymentRequestExternalId(), is(paymentRequestFixture.getExternalId()));
+        assertThat(transaction.getPaymentRequest().getExternalId(), is(paymentRequestFixture.getExternalId()));
         assertThat(transaction.getPaymentRequestReturnUrl(), is(paymentRequestFixture.getReturnUrl()));
         assertThat(transaction.getGatewayAccountId(), is(paymentRequestFixture.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(paymentRequestFixture.getDescription()));
@@ -110,7 +110,7 @@ public class TransactionServiceTest {
         Transaction foundTransaction = service.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequestFixture.getExternalId(), gatewayAccountFixture.getExternalId());
         assertThat(foundTransaction.getId(), is(notNullValue()));
         assertThat(foundTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(foundTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(foundTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
         assertThat(foundTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(foundTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(foundTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
@@ -137,7 +137,7 @@ public class TransactionServiceTest {
         Transaction newTransaction = service.payerCreatedFor(transactionFixture.toEntity());
         assertThat(newTransaction.getId(), is(notNullValue()));
         assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(newTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(newTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
         assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
@@ -159,7 +159,7 @@ public class TransactionServiceTest {
         Transaction newTransaction = service.receiveDirectDebitDetailsFor(gatewayAccountFixture.getExternalId(), transactionFixture.getPaymentRequestExternalId());
         assertThat(newTransaction.getId(), is(notNullValue()));
         assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(newTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(newTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
         assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
@@ -182,7 +182,7 @@ public class TransactionServiceTest {
         Transaction newTransaction = service.findTransactionForToken(token).get();
         assertThat(newTransaction.getId(), is(notNullValue()));
         assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(newTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(newTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
         assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -85,7 +85,7 @@ public class TransactionServiceTest {
         PaymentRequestEvent createdPaymentRequestEvent = preCaptor.getValue();
 
         assertThat(transaction.getId(), is(notNullValue()));
-        assertThat(transaction.getPaymentRequestId(), is(paymentRequestFixture.getId()));
+        assertThat(transaction.getPaymentRequest().getId(), is(paymentRequestFixture.getId()));
         assertThat(transaction.getPaymentRequestExternalId(), is(paymentRequestFixture.getExternalId()));
         assertThat(transaction.getPaymentRequestReturnUrl(), is(paymentRequestFixture.getReturnUrl()));
         assertThat(transaction.getGatewayAccountId(), is(paymentRequestFixture.getGatewayAccountId()));
@@ -109,7 +109,7 @@ public class TransactionServiceTest {
                 .thenReturn(Optional.of(transactionFixture.toEntity()));
         Transaction foundTransaction = service.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequestFixture.getExternalId(), gatewayAccountFixture.getExternalId());
         assertThat(foundTransaction.getId(), is(notNullValue()));
-        assertThat(foundTransaction.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(foundTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(foundTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
         assertThat(foundTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(foundTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
@@ -136,7 +136,7 @@ public class TransactionServiceTest {
                 .withState(PROCESSING_DIRECT_DEBIT_DETAILS);
         Transaction newTransaction = service.payerCreatedFor(transactionFixture.toEntity());
         assertThat(newTransaction.getId(), is(notNullValue()));
-        assertThat(newTransaction.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(newTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
         assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
@@ -158,7 +158,7 @@ public class TransactionServiceTest {
                 .thenReturn(Optional.of(transactionFixture.toEntity()));
         Transaction newTransaction = service.receiveDirectDebitDetailsFor(gatewayAccountFixture.getExternalId(), transactionFixture.getPaymentRequestExternalId());
         assertThat(newTransaction.getId(), is(notNullValue()));
-        assertThat(newTransaction.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(newTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
         assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
@@ -181,7 +181,7 @@ public class TransactionServiceTest {
                 .thenReturn(Optional.of(transactionFixture.toEntity()));
         Transaction newTransaction = service.findTransactionForToken(token).get();
         assertThat(newTransaction.getId(), is(notNullValue()));
-        assertThat(newTransaction.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(newTransaction.getPaymentRequestExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
         assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
@@ -301,7 +301,7 @@ public class TransactionServiceTest {
 
         PaymentRequestEvent event = aPaymentRequestEventFixture().toEntity();
 
-        when(mockedPaymentRequestEventService.findBy(transaction.getPaymentRequestId(), Type.CHARGE, PAYMENT_SUBMITTED))
+        when(mockedPaymentRequestEventService.findBy(transaction.getPaymentRequest().getId(), Type.CHARGE, PAYMENT_SUBMITTED))
                 .thenReturn(Optional.of(event));
 
         PaymentRequestEvent foundEvent = service.findPaymentSubmittedEventFor(transaction).get();
@@ -319,7 +319,7 @@ public class TransactionServiceTest {
 
         PaymentRequestEvent event = aPaymentRequestEventFixture().toEntity();
 
-        when(mockedPaymentRequestEventService.findBy(transaction.getPaymentRequestId(), Type.MANDATE, MANDATE_PENDING))
+        when(mockedPaymentRequestEventService.findBy(transaction.getPaymentRequest().getId(), Type.MANDATE, MANDATE_PENDING))
                 .thenReturn(Optional.of(event));
 
         PaymentRequestEvent foundEvent = service.findMandatePendingEventFor(transaction).get();

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -87,7 +87,7 @@ public class TransactionServiceTest {
         assertThat(transaction.getId(), is(notNullValue()));
         assertThat(transaction.getPaymentRequest().getId(), is(paymentRequestFixture.getId()));
         assertThat(transaction.getPaymentRequest().getExternalId(), is(paymentRequestFixture.getExternalId()));
-        assertThat(transaction.getPaymentRequestReturnUrl(), is(paymentRequestFixture.getReturnUrl()));
+        assertThat(transaction.getPaymentRequest().getReturnUrl(), is(paymentRequestFixture.getReturnUrl()));
         assertThat(transaction.getGatewayAccountId(), is(paymentRequestFixture.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequestDescription(), is(paymentRequestFixture.getDescription()));
         assertThat(transaction.getPaymentRequestReference(), is(paymentRequestFixture.getReference()));
@@ -111,7 +111,7 @@ public class TransactionServiceTest {
         assertThat(foundTransaction.getId(), is(notNullValue()));
         assertThat(foundTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(foundTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
-        assertThat(foundTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
+        assertThat(foundTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(foundTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(foundTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
         assertThat(foundTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
@@ -138,7 +138,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getId(), is(notNullValue()));
         assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(newTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
-        assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
+        assertThat(newTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
         assertThat(newTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
@@ -160,7 +160,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getId(), is(notNullValue()));
         assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(newTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
-        assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
+        assertThat(newTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
         assertThat(newTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
@@ -183,7 +183,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getId(), is(notNullValue()));
         assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
         assertThat(newTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
-        assertThat(newTransaction.getPaymentRequestReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
+        assertThat(newTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
         assertThat(newTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -83,14 +83,15 @@ public class TransactionServiceTest {
         verify(mockedPaymentRequestEventService).insertEventFor(prCaptor.capture(), preCaptor.capture());
         verify(mockedTransactionDao).insert(transaction);
         PaymentRequestEvent createdPaymentRequestEvent = preCaptor.getValue();
+        PaymentRequest transactionPaymentRequest = transaction.getPaymentRequest();
 
         assertThat(transaction.getId(), is(notNullValue()));
-        assertThat(transaction.getPaymentRequest().getId(), is(paymentRequestFixture.getId()));
-        assertThat(transaction.getPaymentRequest().getExternalId(), is(paymentRequestFixture.getExternalId()));
-        assertThat(transaction.getPaymentRequest().getReturnUrl(), is(paymentRequestFixture.getReturnUrl()));
+        assertThat(transactionPaymentRequest.getId(), is(paymentRequestFixture.getId()));
+        assertThat(transactionPaymentRequest.getExternalId(), is(paymentRequestFixture.getExternalId()));
+        assertThat(transactionPaymentRequest.getReturnUrl(), is(paymentRequestFixture.getReturnUrl()));
         assertThat(transaction.getGatewayAccountId(), is(paymentRequestFixture.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequest().getDescription(), is(paymentRequestFixture.getDescription()));
-        assertThat(transaction.getPaymentRequest().getReference(), is(paymentRequestFixture.getReference()));
+        assertThat(transactionPaymentRequest.getDescription(), is(paymentRequestFixture.getDescription()));
+        assertThat(transactionPaymentRequest.getReference(), is(paymentRequestFixture.getReference()));
         assertThat(transaction.getAmount(), is(paymentRequestFixture.getAmount()));
         assertThat(transaction.getType(), is(Transaction.Type.CHARGE));
         assertThat(transaction.getState(), is(NEW));
@@ -108,14 +109,15 @@ public class TransactionServiceTest {
         when(mockedTransactionDao.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequestFixture.getExternalId(), gatewayAccountFixture.getExternalId()))
                 .thenReturn(Optional.of(transactionFixture.toEntity()));
         Transaction foundTransaction = service.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequestFixture.getExternalId(), gatewayAccountFixture.getExternalId());
+        PaymentRequest paymentRequest = foundTransaction.getPaymentRequest();
         assertThat(foundTransaction.getId(), is(notNullValue()));
-        assertThat(foundTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(foundTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
-        assertThat(foundTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
+        assertThat(paymentRequest.getId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequest.getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(paymentRequest.getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(foundTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(foundTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
-        assertThat(foundTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
-        assertThat(foundTransaction.getPaymentRequest().getReference(), is(transactionFixture.getPaymentRequestReference()));
+        assertThat(paymentRequest.getDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(paymentRequest.getReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(foundTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(foundTransaction.getType(), is(transactionFixture.getType()));
         assertThat(foundTransaction.getState(), is(transactionFixture.getState()));
@@ -135,14 +137,15 @@ public class TransactionServiceTest {
                 .aTransactionFixture()
                 .withState(PROCESSING_DIRECT_DEBIT_DETAILS);
         Transaction newTransaction = service.payerCreatedFor(transactionFixture.toEntity());
+        PaymentRequest paymentRequest = newTransaction.getPaymentRequest();
         assertThat(newTransaction.getId(), is(notNullValue()));
-        assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(newTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
-        assertThat(newTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
+        assertThat(paymentRequest.getId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequest.getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(paymentRequest.getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
-        assertThat(newTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
-        assertThat(newTransaction.getPaymentRequest().getReference(), is(transactionFixture.getPaymentRequestReference()));
+        assertThat(paymentRequest.getDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(paymentRequest.getReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
         assertThat(newTransaction.getState(), is(AWAITING_CONFIRMATION));
@@ -157,14 +160,15 @@ public class TransactionServiceTest {
         when(mockedTransactionDao.findTransactionForExternalIdAndGatewayAccountExternalId(transactionFixture.getPaymentRequestExternalId(), gatewayAccountFixture.getExternalId()))
                 .thenReturn(Optional.of(transactionFixture.toEntity()));
         Transaction newTransaction = service.receiveDirectDebitDetailsFor(gatewayAccountFixture.getExternalId(), transactionFixture.getPaymentRequestExternalId());
+        PaymentRequest paymentRequest = newTransaction.getPaymentRequest();
         assertThat(newTransaction.getId(), is(notNullValue()));
-        assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(newTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
-        assertThat(newTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
+        assertThat(paymentRequest.getId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequest.getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(paymentRequest.getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
-        assertThat(newTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
-        assertThat(newTransaction.getPaymentRequest().getReference(), is(transactionFixture.getPaymentRequestReference()));
+        assertThat(paymentRequest.getDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(paymentRequest.getReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
         assertThat(newTransaction.getState(), is(PROCESSING_DIRECT_DEBIT_DETAILS));
@@ -180,14 +184,15 @@ public class TransactionServiceTest {
         when(mockedTransactionDao.findByTokenId(token))
                 .thenReturn(Optional.of(transactionFixture.toEntity()));
         Transaction newTransaction = service.findTransactionForToken(token).get();
+        PaymentRequest paymentRequest = newTransaction.getPaymentRequest();
         assertThat(newTransaction.getId(), is(notNullValue()));
-        assertThat(newTransaction.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
-        assertThat(newTransaction.getPaymentRequest().getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
-        assertThat(newTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
+        assertThat(paymentRequest.getId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(paymentRequest.getExternalId(), is(transactionFixture.getPaymentRequestExternalId()));
+        assertThat(paymentRequest.getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
-        assertThat(newTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
-        assertThat(newTransaction.getPaymentRequest().getReference(), is(transactionFixture.getPaymentRequestReference()));
+        assertThat(paymentRequest.getDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(paymentRequest.getReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
         assertThat(newTransaction.getState(), is(AWAITING_DIRECT_DEBIT_DETAILS));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -89,7 +89,7 @@ public class TransactionServiceTest {
         assertThat(transaction.getPaymentRequest().getExternalId(), is(paymentRequestFixture.getExternalId()));
         assertThat(transaction.getPaymentRequest().getReturnUrl(), is(paymentRequestFixture.getReturnUrl()));
         assertThat(transaction.getGatewayAccountId(), is(paymentRequestFixture.getGatewayAccountId()));
-        assertThat(transaction.getPaymentRequestDescription(), is(paymentRequestFixture.getDescription()));
+        assertThat(transaction.getPaymentRequest().getDescription(), is(paymentRequestFixture.getDescription()));
         assertThat(transaction.getPaymentRequestReference(), is(paymentRequestFixture.getReference()));
         assertThat(transaction.getAmount(), is(paymentRequestFixture.getAmount()));
         assertThat(transaction.getType(), is(Transaction.Type.CHARGE));
@@ -114,7 +114,7 @@ public class TransactionServiceTest {
         assertThat(foundTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(foundTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(foundTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
-        assertThat(foundTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(foundTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
         assertThat(foundTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(foundTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(foundTransaction.getType(), is(transactionFixture.getType()));
@@ -141,7 +141,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
-        assertThat(newTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(newTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
         assertThat(newTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
@@ -163,7 +163,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
-        assertThat(newTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(newTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
         assertThat(newTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
@@ -186,7 +186,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getPaymentRequest().getReturnUrl(), is(transactionFixture.getPaymentRequestReturnUrl()));
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
-        assertThat(newTransaction.getPaymentRequestDescription(), is(transactionFixture.getPaymentRequestDescription()));
+        assertThat(newTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
         assertThat(newTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -90,7 +90,7 @@ public class TransactionServiceTest {
         assertThat(transaction.getPaymentRequest().getReturnUrl(), is(paymentRequestFixture.getReturnUrl()));
         assertThat(transaction.getGatewayAccountId(), is(paymentRequestFixture.getGatewayAccountId()));
         assertThat(transaction.getPaymentRequest().getDescription(), is(paymentRequestFixture.getDescription()));
-        assertThat(transaction.getPaymentRequestReference(), is(paymentRequestFixture.getReference()));
+        assertThat(transaction.getPaymentRequest().getReference(), is(paymentRequestFixture.getReference()));
         assertThat(transaction.getAmount(), is(paymentRequestFixture.getAmount()));
         assertThat(transaction.getType(), is(Transaction.Type.CHARGE));
         assertThat(transaction.getState(), is(NEW));
@@ -115,7 +115,7 @@ public class TransactionServiceTest {
         assertThat(foundTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(foundTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
         assertThat(foundTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
-        assertThat(foundTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
+        assertThat(foundTransaction.getPaymentRequest().getReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(foundTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(foundTransaction.getType(), is(transactionFixture.getType()));
         assertThat(foundTransaction.getState(), is(transactionFixture.getState()));
@@ -142,7 +142,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
         assertThat(newTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
-        assertThat(newTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
+        assertThat(newTransaction.getPaymentRequest().getReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
         assertThat(newTransaction.getState(), is(AWAITING_CONFIRMATION));
@@ -164,7 +164,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
         assertThat(newTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
-        assertThat(newTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
+        assertThat(newTransaction.getPaymentRequest().getReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
         assertThat(newTransaction.getState(), is(PROCESSING_DIRECT_DEBIT_DETAILS));
@@ -187,7 +187,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));
         assertThat(newTransaction.getGatewayAccountExternalId(), is(transactionFixture.getGatewayAccountExternalId()));
         assertThat(newTransaction.getPaymentRequest().getDescription(), is(transactionFixture.getPaymentRequestDescription()));
-        assertThat(newTransaction.getPaymentRequestReference(), is(transactionFixture.getPaymentRequestReference()));
+        assertThat(newTransaction.getPaymentRequest().getReference(), is(transactionFixture.getPaymentRequestReference()));
         assertThat(newTransaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(newTransaction.getType(), is(transactionFixture.getType()));
         assertThat(newTransaction.getState(), is(AWAITING_DIRECT_DEBIT_DETAILS));

--- a/src/test/java/uk/gov/pay/directdebit/tokens/services/TokenServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/tokens/services/TokenServiceTest.java
@@ -59,7 +59,7 @@ public class TokenServiceTest {
     @Test
     public void shouldValidateAPaymentRequestWithAToken() {
         Transaction charge = service.validateChargeWithToken(TOKEN);
-        assertThat(charge.getPaymentRequestId(), is(transactionFixture.getPaymentRequestId()));
+        assertThat(charge.getPaymentRequest().getId(), is(transactionFixture.getPaymentRequestId()));
     }
 
     @Test


### PR DESCRIPTION
## WHAT

`Transaction` constructor refactoring to use `PaymentRequest` object.
See commits for more details.
