### PR TITLE
PP-3701 Add payer to payment request

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/GatewayAccountParamConverterProvider.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/GatewayAccountParamConverterProvider.java
@@ -35,11 +35,14 @@ public class GatewayAccountParamConverterProvider implements ParamConverterProvi
         public GatewayAccount fromString(String externalAccountId) {
             //backward compatibility - this will be removed once frontend is in
             if (ApiValidation.isNumeric(externalAccountId)) {
+                System.out.println("AAAAAAAAAAA?????????");
                 Long accountId = convertAccountId(externalAccountId);
                 return gatewayAccountDao
                         .findById(accountId)
-                        .orElseThrow(() -> new GatewayAccountNotFoundException(accountId.toString()));
+                        .orElseThrow(
+                                () -> new GatewayAccountNotFoundException(accountId.toString()));
             }
+            System.out.println("BBBBBBBBBB?????????");
             return gatewayAccountDao
                     .findByExternalId(externalAccountId)
                     .orElseThrow(() -> new GatewayAccountNotFoundException(externalAccountId));

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/GatewayAccountParamConverterProvider.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/GatewayAccountParamConverterProvider.java
@@ -33,16 +33,6 @@ public class GatewayAccountParamConverterProvider implements ParamConverterProvi
 
         @Override
         public GatewayAccount fromString(String externalAccountId) {
-            //backward compatibility - this will be removed once frontend is in
-            if (ApiValidation.isNumeric(externalAccountId)) {
-                System.out.println("AAAAAAAAAAA?????????");
-                Long accountId = convertAccountId(externalAccountId);
-                return gatewayAccountDao
-                        .findById(accountId)
-                        .orElseThrow(
-                                () -> new GatewayAccountNotFoundException(accountId.toString()));
-            }
-            System.out.println("BBBBBBBBBB?????????");
             return gatewayAccountDao
                     .findByExternalId(externalAccountId)
                     .orElseThrow(() -> new GatewayAccountNotFoundException(externalAccountId));
@@ -51,15 +41,6 @@ public class GatewayAccountParamConverterProvider implements ParamConverterProvi
         @Override
         public String toString(GatewayAccount gatewayAccount) {
             return gatewayAccount.getId().toString();
-        }
-
-        private Long convertAccountId(String param) {
-            try {
-                return Long.parseLong(param);
-            } catch (Exception exc) {
-                LOGGER.error("Could not retrieve gateway account for request from URL");
-                throw new InvalidGatewayAccountException("invalid id");
-            }
         }
     }
     @Override

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/ConfirmDetailsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/ConfirmDetailsRequestValidator.java
@@ -9,20 +9,20 @@ import uk.gov.pay.directdebit.common.validation.FieldSizeValidator;
 
 public class ConfirmDetailsRequestValidator extends ApiValidation {
 
-    public final static String SORTCODE_KEY = "sort_code";
+    public final static String SORT_CODE_KEY = "sort_code";
     public final static String ACCOUNT_NUMBER_KEY = "account_number";
 
     private final static Map<String, Function<String, Boolean>> validators =
             ImmutableMap.<String, Function<String, Boolean>>builder()
-                    .put(SORTCODE_KEY, ApiValidation::isNumeric)
+                    .put(SORT_CODE_KEY, ApiValidation::isNumeric)
                     .put(ACCOUNT_NUMBER_KEY, ApiValidation::isNumeric)
                     .build();
 
-    private final static String[] requiredFields = {SORTCODE_KEY, ACCOUNT_NUMBER_KEY};
+    private final static String[] requiredFields = {SORT_CODE_KEY, ACCOUNT_NUMBER_KEY};
 
     private final static Map<String, FieldSize> fieldSizes =
             ImmutableMap.<String, FieldSize>builder()
-                    .put(SORTCODE_KEY, FieldSizeValidator.SORT_CODE.getFieldSize())
+                    .put(SORT_CODE_KEY, FieldSizeValidator.SORT_CODE.getFieldSize())
                     .put(ACCOUNT_NUMBER_KEY, FieldSizeValidator.ACCOUNT_NUMBER.getFieldSize())
                     .build();
 

--- a/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidator.java
@@ -11,7 +11,7 @@ import uk.gov.pay.directdebit.common.validation.FieldSizeValidator;
 public class CreatePayerValidator extends ApiValidation {
 
     public final static String NAME_KEY = "account_holder_name";
-    public final static String SORTCODE_KEY = "sort_code";
+    public final static String SORT_CODE_KEY = "sort_code";
     public final static String ACCOUNT_NUMBER_KEY = "account_number";
     public final static String ADDRESS_COUNTRY_KEY = "country_code";
     public final static String ADDRESS_LINE1_KEY = "address_line1";
@@ -22,7 +22,7 @@ public class CreatePayerValidator extends ApiValidation {
     private final static Map<String, Function<String, Boolean>> validators =
             ImmutableMap.<String, Function<String, Boolean>>builder()
                     .put(NAME_KEY, ApiValidation::isNotNullOrEmpty)
-                    .put(SORTCODE_KEY, ApiValidation::isNumeric)
+                    .put(SORT_CODE_KEY, ApiValidation::isNumeric)
                     .put(ACCOUNT_NUMBER_KEY, ApiValidation::isNumeric)
                     .put(ADDRESS_COUNTRY_KEY, ApiValidation::isNotNullOrEmpty)
                     .put(ADDRESS_LINE1_KEY, ApiValidation::isNotNullOrEmpty)
@@ -31,11 +31,11 @@ public class CreatePayerValidator extends ApiValidation {
                     .put(EMAIL_KEY, ApiValidation::isNotNullOrEmpty)
                     .build();
 
-    private final static String[] requiredFields = {NAME_KEY, SORTCODE_KEY, ACCOUNT_NUMBER_KEY, EMAIL_KEY};
+    private final static String[] requiredFields = {NAME_KEY, SORT_CODE_KEY, ACCOUNT_NUMBER_KEY, EMAIL_KEY};
 
     private final static Map<String, FieldSize> fieldSizes =
             ImmutableMap.<String, FieldSize>builder()
-                    .put(SORTCODE_KEY, FieldSizeValidator.SORT_CODE.getFieldSize())
+                    .put(SORT_CODE_KEY, FieldSizeValidator.SORT_CODE.getFieldSize())
                     .put(ACCOUNT_NUMBER_KEY, FieldSizeValidator.ACCOUNT_NUMBER.getFieldSize())
                     .put(EMAIL_KEY, new FieldSize(0, 254))
                     .build();

--- a/src/main/java/uk/gov/pay/directdebit/payers/api/PayerParser.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/PayerParser.java
@@ -22,12 +22,6 @@ public class PayerParser {
                 encrypt(sortCode),
                 encrypt(accountNumber),
                 accountNumber.substring(accountNumber.length()-2),
-                Boolean.parseBoolean(createPayerMap.get("requires_authorisation")),
-                createPayerMap.get("address_line1"),
-                createPayerMap.get("address_line2"),
-                createPayerMap.get("postcode"),
-                createPayerMap.get("city"),
-                createPayerMap.get("country_code")
-        );
+                Boolean.parseBoolean(createPayerMap.get("requires_authorisation")));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payers/dao/PayerDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/dao/PayerDao.java
@@ -23,10 +23,10 @@ public interface PayerDao {
     @SqlQuery("SELECT * FROM payers p WHERE p.payment_request_id = :paymentRequestId LIMIT 1")
     Optional<Payer> findByPaymentRequestId(@Bind("paymentRequestId") Long paymentRequestId);
 
-    @SqlUpdate("INSERT INTO payers(payment_request_id, external_id, name, email, bank_account_number_last_two_digits, bank_account_requires_authorisation, bank_account_number, bank_account_sort_code, address_line1, address_line2, address_postcode, address_city, address_country, created_date ) VALUES (:paymentRequestId, :externalId, :name, :email, :accountNumberLastTwoDigits, :accountRequiresAuthorisation, :accountNumber, :sortCode, :addressLine1, :addressLine2, :addressPostcode, :addressCity, :addressCountry, :createdDate)")
+    @SqlUpdate("INSERT INTO payers(payment_request_id, external_id, name, email, bank_account_number_last_two_digits, bank_account_requires_authorisation, bank_account_number, bank_account_sort_code, created_date ) VALUES (:paymentRequestId, :externalId, :name, :email, :accountNumberLastTwoDigits, :accountRequiresAuthorisation, :accountNumber, :sortCode, :createdDate)")
     @GetGeneratedKeys
     Long insert(@BindBean Payer payer);
 
-    @SqlUpdate("UPDATE payers p SET name = :name,  email = :email, bank_account_number_last_two_digits = :accountNumberLastTwoDigits, bank_account_requires_authorisation = :accountRequiresAuthorisation, bank_account_number = :accountNumber, bank_account_sort_code = :sortCode, address_line1 = :addressLine1, address_line2 = :addressLine2, address_postcode = :addressPostcode, address_city = :addressCity, address_country = :addressCountry WHERE p.id = :id")
+    @SqlUpdate("UPDATE payers p SET name = :name,  email = :email, bank_account_number_last_two_digits = :accountNumberLastTwoDigits, bank_account_requires_authorisation = :accountRequiresAuthorisation, bank_account_number = :accountNumber, bank_account_sort_code = :sortCode WHERE p.id = :id")
     int updatePayerDetails(@Bind("id")Long id, @BindBean Payer payer);
 }

--- a/src/main/java/uk/gov/pay/directdebit/payers/dao/mapper/PayerMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/dao/mapper/PayerMapper.java
@@ -19,11 +19,6 @@ public class PayerMapper implements RowMapper<Payer> {
     private static final String BANK_ACCOUNT_REQUIRES_AUTH_COLUMN = "bank_account_requires_authorisation";
     private static final String BANK_ACCOUNT_NUMBER_COLUMN = "bank_account_number";
     private static final String BANK_ACCOUNT_SORT_CODE_COLUMN = "bank_account_sort_code";
-    private static final String ADDRESS_LINE1_COLUMN = "address_line1";
-    private static final String ADDRESS_LINE2_COLUMN = "address_line2";
-    private static final String ADDRESS_POSTCODE_COLUMN = "address_postcode";
-    private static final String ADDRESS_CITY_COLUMN = "address_city";
-    private static final String ADDRESS_COUNTRY_COLUMN = "address_country";
     private static final String CREATED_DATE_COLUMN = "created_date";
 
     @Override
@@ -38,11 +33,6 @@ public class PayerMapper implements RowMapper<Payer> {
                 resultSet.getString(BANK_ACCOUNT_NUMBER_COLUMN),
                 resultSet.getString(BANK_ACCOUNT_LAST_DIGITS_COLUMN),
                 resultSet.getBoolean(BANK_ACCOUNT_REQUIRES_AUTH_COLUMN),
-                resultSet.getString(ADDRESS_LINE1_COLUMN),
-                resultSet.getString(ADDRESS_LINE2_COLUMN),
-                resultSet.getString(ADDRESS_POSTCODE_COLUMN),
-                resultSet.getString(ADDRESS_CITY_COLUMN),
-                resultSet.getString(ADDRESS_COUNTRY_COLUMN),
                 ZonedDateTime.ofInstant(resultSet.getTimestamp(CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/Payer.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/Payer.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.payers.model;
 
-import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 
 import java.time.ZoneOffset;
@@ -16,14 +15,9 @@ public class Payer {
     private String accountNumber;
     private String accountNumberLastTwoDigits;
     private boolean accountRequiresAuthorisation;
-    private String addressLine1;
-    private String addressLine2;
-    private String addressPostcode;
-    private String addressCity;
-    private String addressCountry;
     private ZonedDateTime createdDate;
 
-    public Payer(Long id, Long paymentRequestId, String externalId, String name, String email, String sortCode, String accountNumber, String accountNumberLastTwoDigits, boolean accountRequiresAuthorisation, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCountry, ZonedDateTime createdDate) {
+    public Payer(Long id, Long paymentRequestId, String externalId, String name, String email, String sortCode, String accountNumber, String accountNumberLastTwoDigits, boolean accountRequiresAuthorisation, ZonedDateTime createdDate) {
         this.id = id;
         this.paymentRequestId = paymentRequestId;
         this.externalId = externalId;
@@ -33,16 +27,11 @@ public class Payer {
         this.accountRequiresAuthorisation = accountRequiresAuthorisation;
         this.sortCode = sortCode;
         this.accountNumber = accountNumber;
-        this.addressLine1 = addressLine1;
-        this.addressLine2 = addressLine2;
-        this.addressPostcode = addressPostcode;
-        this.addressCity = addressCity;
-        this.addressCountry = addressCountry;
         this.createdDate = createdDate;
     }
 
-    public Payer(Long paymentRequestId, String name, String email, String sortCode, String accountNumber, String accountNumberLastTwoDigits, boolean accountRequiresAuthorisation, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCountry) {
-        this(null, paymentRequestId, RandomIdGenerator.newId(), name, email, sortCode, accountNumber, accountNumberLastTwoDigits, accountRequiresAuthorisation, addressLine1, addressLine2, addressPostcode, addressCity, addressCountry, ZonedDateTime.now(ZoneOffset.UTC));
+    public Payer(Long paymentRequestId, String name, String email, String sortCode, String accountNumber, String accountNumberLastTwoDigits, boolean accountRequiresAuthorisation) {
+        this(null, paymentRequestId, RandomIdGenerator.newId(), name, email, sortCode, accountNumber, accountNumberLastTwoDigits, accountRequiresAuthorisation, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
     public void setId(Long id) {
@@ -83,26 +72,6 @@ public class Payer {
 
     public String getAccountNumber() {
         return accountNumber;
-    }
-
-    public String getAddressLine1() {
-        return addressLine1;
-    }
-
-    public String getAddressLine2() {
-        return addressLine2;
-    }
-
-    public String getAddressPostcode() {
-        return addressPostcode;
-    }
-
-    public String getAddressCity() {
-        return addressCity;
-    }
-
-    public String getAddressCountry() {
-        return addressCountry;
     }
 
     public ZonedDateTime getCreatedDate() {
@@ -147,26 +116,6 @@ public class Payer {
         if (!accountNumber.equals(payer.accountNumber)) {
             return false;
         }
-        if (addressLine1 != null ? !addressLine1.equals(payer.addressLine1)
-                : payer.addressLine1 != null) {
-            return false;
-        }
-        if (addressLine2 != null ? !addressLine2.equals(payer.addressLine2)
-                : payer.addressLine2 != null) {
-            return false;
-        }
-        if (addressPostcode != null ? !addressPostcode.equals(payer.addressPostcode)
-                : payer.addressPostcode != null) {
-            return false;
-        }
-        if (addressCity != null ? !addressCity.equals(payer.addressCity)
-                : payer.addressCity != null) {
-            return false;
-        }
-        if (addressCountry != null ? !addressCountry.equals(payer.addressCountry)
-                : payer.addressCountry != null) {
-            return false;
-        }
         return createdDate.equals(payer.createdDate);
     }
 
@@ -181,11 +130,6 @@ public class Payer {
         result = 31 * result + accountNumberLastTwoDigits.hashCode();
         result = 31 * result + (accountRequiresAuthorisation ? 1 : 0);
         result = 31 * result + accountNumber.hashCode();
-        result = 31 * result + (addressLine1 != null ? addressLine1.hashCode() : 0);
-        result = 31 * result + (addressLine2 != null ? addressLine2.hashCode() : 0);
-        result = 31 * result + (addressPostcode != null ? addressPostcode.hashCode() : 0);
-        result = 31 * result + (addressCity != null ? addressCity.hashCode() : 0);
-        result = 31 * result + (addressCountry != null ? addressCountry.hashCode() : 0);
         result = 31 * result + createdDate.hashCode();
         return result;
     }

--- a/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
@@ -37,26 +37,6 @@ public class PayerResource {
         this.paymentProviderFactory = paymentProviderFactory;
     }
 
-
-    // fixme backward compatibility, will remove the POST after frontend is updated
-    @POST
-    @Path("/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/payers")
-    @Consumes(APPLICATION_JSON)
-    @Produces(APPLICATION_JSON)
-    public Response createPayerOld(@PathParam("accountId") GatewayAccount gatewayAccount, @PathParam("paymentRequestExternalId") String paymentRequestExternalId, Map<String, String> createPayerRequest, @Context UriInfo uriInfo) {
-        createPayerValidator.validate(paymentRequestExternalId, createPayerRequest);
-
-        LOGGER.info("Received create payer request for payment request with id: {}", paymentRequestExternalId);
-
-        DirectDebitPaymentProvider payerService = paymentProviderFactory.getServiceFor(gatewayAccount.getPaymentProvider());
-        Payer payer = payerService.createPayer(paymentRequestExternalId, gatewayAccount, createPayerRequest);
-
-        CreatePayerResponse createPayerResponse = CreatePayerResponse.from(payer);
-
-        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, gatewayAccount.getId().toString(), paymentRequestExternalId, createPayerResponse.getPayerExternalId());
-        return Response.created(newPayerLocation).entity(createPayerResponse).build();
-    }
-
     @PUT
     @Path("/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/payers")
     @Consumes(APPLICATION_JSON)

--- a/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
@@ -51,7 +51,7 @@ public class PayerResource {
 
         CreatePayerResponse createPayerResponse = CreatePayerResponse.from(payer);
 
-        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, gatewayAccount.getId().toString(), paymentRequestExternalId, createPayerResponse.getPayerExternalId());
+        URI newPayerLocation = URIBuilder.selfUriFor(uriInfo, PAYER_API_PATH, gatewayAccount.getExternalId(), paymentRequestExternalId, createPayerResponse.getPayerExternalId());
         return Response.created(newPayerLocation).entity(createPayerResponse).build();
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentRequestFrontendResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentRequestFrontendResponse.java
@@ -11,8 +11,54 @@ import uk.gov.pay.directdebit.payers.model.Payer;
 @JsonInclude(Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class PaymentRequestFrontendResponse {
-    @JsonProperty
-    private Payer payer;
+
+    @JsonFormat(shape = JsonFormat.Shape.OBJECT)
+    public static class PayerDetails {
+        @JsonProperty("payer_external_id")
+        private String externalId;
+        
+        @JsonProperty("account_holder_name")
+        private String name;
+        
+        @JsonProperty
+        private String email;
+
+        @JsonProperty("requires_authorisation")
+        private boolean accountRequiresAuthorisation;
+
+        PayerDetails(String externalId, String name, String email, boolean accountRequiresAuthorisation) {
+            this.externalId = externalId;
+            this.name = name;
+            this.email = email;
+            this.accountRequiresAuthorisation = accountRequiresAuthorisation;
+        }
+
+        public String getExternalId() {
+            return externalId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public boolean getAccountRequiresAuthorisation() {
+            return accountRequiresAuthorisation;
+        }
+
+        @Override
+        public String toString() {
+            return "PayerDetails{" +
+                    "externalId='" + externalId + '\'' +
+                    '}';
+        }
+    }
+
+    @JsonProperty("payer")
+    private PayerDetails payer;
     
     @JsonProperty("external_id")
     private String paymentExternalId;
@@ -51,10 +97,20 @@ public class PaymentRequestFrontendResponse {
         this.description = description;
         this.reference = reference;
         this.createdDate = createdDate;
-        this.payer = payer;
+        this.payer = initPayer(payer);
     }
 
-    public Payer getPayer() {
+    private PayerDetails initPayer(Payer payer) {
+        if (payer != null ) {
+            return new PayerDetails(
+                    payer.getExternalId(),
+                    payer.getName(),
+                    payer.getEmail(),
+                    payer.getAccountRequiresAuthorisation());
+        } 
+        return null;
+    }
+    public PayerDetails getPayerDetails() {
         return payer;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
@@ -14,59 +14,59 @@ import java.util.Optional;
 
 @RegisterRowMapper(PaymentRequestMapper.class)
 public interface PaymentRequestDao {
-    @SqlQuery("SELECT\n"+
-            "  p.id AS payment_request_id,\n" +
-            "  p.external_id AS payment_request_external_id,\n" +
-            "  p.gateway_account_id AS payment_request_gateway_account_id,\n" +
-            "  p.amount AS payment_request_amount,\n" +
-            "  p.reference AS payment_request_reference,\n" +
-            "  p.description AS payment_request_description,\n" +
-            "  p.return_url AS payment_request_return_url,\n" +
-            "  p.created_date AS payment_request_created_date,\n" +
-            "  y.id AS payer_id,\n" +
-            "  y.payment_request_id AS payer_payment_request_id,\n" +
-            "  y.external_id AS payer_external_id,\n" +
-            "  y.name AS payer_name,\n" +
-            "  y.email AS payer_email,\n" +
-            "  y.bank_account_number_last_two_digits AS payer_bank_account_number_last_two_digits,\n" +
-            "  y.bank_account_requires_authorisation AS payer_bank_account_requires_authorisation,\n" +
-            "  y.bank_account_number AS payer_bank_account_number,\n" +
-            "  y.bank_account_sort_code AS payer_bank_account_sort_code,\n" +
-            "  y.created_date AS payer_created_date\n" +
-            " FROM payment_requests p LEFT JOIN payers y ON y.payment_request_id = p.id\n" +
+    @SqlQuery("SELECT"+
+            "  p.id AS payment_request_id," +
+            "  p.external_id AS payment_request_external_id," +
+            "  p.gateway_account_id AS payment_request_gateway_account_id," +
+            "  p.amount AS payment_request_amount," +
+            "  p.reference AS payment_request_reference," +
+            "  p.description AS payment_request_description," +
+            "  p.return_url AS payment_request_return_url," +
+            "  p.created_date AS payment_request_created_date," +
+            "  y.id AS payer_id," +
+            "  y.payment_request_id AS payer_payment_request_id," +
+            "  y.external_id AS payer_external_id," +
+            "  y.name AS payer_name," +
+            "  y.email AS payer_email," +
+            "  y.bank_account_number_last_two_digits AS payer_bank_account_number_last_two_digits," +
+            "  y.bank_account_requires_authorisation AS payer_bank_account_requires_authorisation," +
+            "  y.bank_account_number AS payer_bank_account_number," +
+            "  y.bank_account_sort_code AS payer_bank_account_sort_code," +
+            "  y.created_date AS payer_created_date" +
+            " FROM payment_requests p LEFT JOIN payers y ON y.payment_request_id = p.id" +
             " WHERE p.id = :id")
     Optional<PaymentRequest> findById(@Bind("id") Long id);
 
-    @SqlQuery("SELECT\n" +
-            "  p.id AS payment_request_id,\n" +
-            "  p.external_id AS payment_request_external_id,\n" +
-            "  p.gateway_account_id AS payment_request_gateway_account_id,\n" +
-            "  p.amount AS payment_request_amount,\n" +
-            "  p.reference AS payment_request_reference,\n" +
-            "  p.description AS payment_request_description,\n" +
-            "  p.return_url AS payment_request_return_url,\n" +
-            "  p.created_date AS payment_request_created_date,\n" +
-            "  y.id AS payer_id,\n" +
-            "  y.payment_request_id AS payer_payment_request_id,\n" +
-            "  y.external_id AS payer_external_id,\n" +
-            "  y.name AS payer_name,\n" +
-            "  y.email AS payer_email,\n" +
-            "  y.bank_account_number_last_two_digits AS payer_bank_account_number_last_two_digits,\n" +
-            "  y.bank_account_requires_authorisation AS payer_bank_account_requires_authorisation,\n" +
-            "  y.bank_account_number AS payer_bank_account_number,\n" +
-            "  y.bank_account_sort_code AS payer_bank_account_sort_code,\n" +
-            "  y.created_date AS payer_created_date,\n" +
-            "  g.id AS gateway_account_id,\n" +
-            "  g.external_id AS gateway_account_external_id,\n" +
-            "  g.payment_provider AS gateway_account_payment_provider,\n" +
-            "  g.service_name AS gateway_account_service_name,\n" +
-            "  g.type AS gateway_account_type,\n" +
-            "  g.description AS gateway_account_description,\n" +
-            "  g.analytics_id AS gateway_account_analytics_id\n" +
-            "FROM payment_requests p\n" +
-            "JOIN gateway_accounts g ON p.gateway_account_id = g.id\n" +
-            "LEFT JOIN payers y ON y.payment_request_id = p.id\n" +
-            "WHERE p.external_id = :externalId AND g.external_id = :accountExternalId")
+    @SqlQuery("SELECT" +
+            "  p.id AS payment_request_id," +
+            "  p.external_id AS payment_request_external_id," +
+            "  p.gateway_account_id AS payment_request_gateway_account_id," +
+            "  p.amount AS payment_request_amount," +
+            "  p.reference AS payment_request_reference," +
+            "  p.description AS payment_request_description," +
+            "  p.return_url AS payment_request_return_url," +
+            "  p.created_date AS payment_request_created_date," +
+            "  y.id AS payer_id," +
+            "  y.payment_request_id AS payer_payment_request_id," +
+            "  y.external_id AS payer_external_id," +
+            "  y.name AS payer_name," +
+            "  y.email AS payer_email," +
+            "  y.bank_account_number_last_two_digits AS payer_bank_account_number_last_two_digits," +
+            "  y.bank_account_requires_authorisation AS payer_bank_account_requires_authorisation," +
+            "  y.bank_account_number AS payer_bank_account_number," +
+            "  y.bank_account_sort_code AS payer_bank_account_sort_code," +
+            "  y.created_date AS payer_created_date," +
+            "  g.id AS gateway_account_id," +
+            "  g.external_id AS gateway_account_external_id," +
+            "  g.payment_provider AS gateway_account_payment_provider," +
+            "  g.service_name AS gateway_account_service_name," +
+            "  g.type AS gateway_account_type," +
+            "  g.description AS gateway_account_description," +
+            "  g.analytics_id AS gateway_account_analytics_id" +
+            " FROM payment_requests p" +
+            " JOIN gateway_accounts g ON p.gateway_account_id = g.id" +
+            " LEFT JOIN payers y ON y.payment_request_id = p.id" +
+            " WHERE p.external_id = :externalId AND g.external_id = :accountExternalId")
     Optional<PaymentRequest> findByExternalIdAndAccountExternalId(@Bind("externalId") String externalId, @Bind("accountExternalId") String accountExternalId);
 
     @SqlUpdate("INSERT INTO payment_requests(external_id, gateway_account_id, amount, reference, description, return_url, created_date) VALUES (:externalId, :gatewayAccountId, :amount, :reference, :description, :returnUrl, :createdDate)")

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentRequestDao.java
@@ -6,6 +6,7 @@ import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payments.dao.mapper.PaymentRequestMapper;
 import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 
@@ -13,10 +14,59 @@ import java.util.Optional;
 
 @RegisterRowMapper(PaymentRequestMapper.class)
 public interface PaymentRequestDao {
-    @SqlQuery("SELECT * FROM payment_requests p WHERE p.id = :id")
+    @SqlQuery("SELECT\n"+
+            "  p.id AS payment_request_id,\n" +
+            "  p.external_id AS payment_request_external_id,\n" +
+            "  p.gateway_account_id AS payment_request_gateway_account_id,\n" +
+            "  p.amount AS payment_request_amount,\n" +
+            "  p.reference AS payment_request_reference,\n" +
+            "  p.description AS payment_request_description,\n" +
+            "  p.return_url AS payment_request_return_url,\n" +
+            "  p.created_date AS payment_request_created_date,\n" +
+            "  y.id AS payer_id,\n" +
+            "  y.payment_request_id AS payer_payment_request_id,\n" +
+            "  y.external_id AS payer_external_id,\n" +
+            "  y.name AS payer_name,\n" +
+            "  y.email AS payer_email,\n" +
+            "  y.bank_account_number_last_two_digits AS payer_bank_account_number_last_two_digits,\n" +
+            "  y.bank_account_requires_authorisation AS payer_bank_account_requires_authorisation,\n" +
+            "  y.bank_account_number AS payer_bank_account_number,\n" +
+            "  y.bank_account_sort_code AS payer_bank_account_sort_code,\n" +
+            "  y.created_date AS payer_created_date\n" +
+            " FROM payment_requests p LEFT JOIN payers y ON y.payment_request_id = p.id\n" +
+            " WHERE p.id = :id")
     Optional<PaymentRequest> findById(@Bind("id") Long id);
 
-    @SqlQuery("SELECT * FROM payment_requests p JOIN gateway_accounts g ON p.gateway_account_id = g.id WHERE p.external_id = :externalId AND g.external_id = :accountExternalId")
+    @SqlQuery("SELECT\n" +
+            "  p.id AS payment_request_id,\n" +
+            "  p.external_id AS payment_request_external_id,\n" +
+            "  p.gateway_account_id AS payment_request_gateway_account_id,\n" +
+            "  p.amount AS payment_request_amount,\n" +
+            "  p.reference AS payment_request_reference,\n" +
+            "  p.description AS payment_request_description,\n" +
+            "  p.return_url AS payment_request_return_url,\n" +
+            "  p.created_date AS payment_request_created_date,\n" +
+            "  y.id AS payer_id,\n" +
+            "  y.payment_request_id AS payer_payment_request_id,\n" +
+            "  y.external_id AS payer_external_id,\n" +
+            "  y.name AS payer_name,\n" +
+            "  y.email AS payer_email,\n" +
+            "  y.bank_account_number_last_two_digits AS payer_bank_account_number_last_two_digits,\n" +
+            "  y.bank_account_requires_authorisation AS payer_bank_account_requires_authorisation,\n" +
+            "  y.bank_account_number AS payer_bank_account_number,\n" +
+            "  y.bank_account_sort_code AS payer_bank_account_sort_code,\n" +
+            "  y.created_date AS payer_created_date,\n" +
+            "  g.id AS gateway_account_id,\n" +
+            "  g.external_id AS gateway_account_external_id,\n" +
+            "  g.payment_provider AS gateway_account_payment_provider,\n" +
+            "  g.service_name AS gateway_account_service_name,\n" +
+            "  g.type AS gateway_account_type,\n" +
+            "  g.description AS gateway_account_description,\n" +
+            "  g.analytics_id AS gateway_account_analytics_id\n" +
+            "FROM payment_requests p\n" +
+            "JOIN gateway_accounts g ON p.gateway_account_id = g.id\n" +
+            "LEFT JOIN payers y ON y.payment_request_id = p.id\n" +
+            "WHERE p.external_id = :externalId AND g.external_id = :accountExternalId")
     Optional<PaymentRequest> findByExternalIdAndAccountExternalId(@Bind("externalId") String externalId, @Bind("accountExternalId") String accountExternalId);
 
     @SqlUpdate("INSERT INTO payment_requests(external_id, gateway_account_id, amount, reference, description, return_url, created_date) VALUES (:externalId, :gatewayAccountId, :amount, :reference, :description, :returnUrl, :createdDate)")

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
@@ -17,163 +17,58 @@ import java.util.Optional;
 @RegisterRowMapper(TransactionMapper.class)
 public interface TransactionDao {
 
-    @SqlQuery("SELECT\n" +
-            "  t.id AS transaction_id,\n" +
-            "  t.payment_request_id AS transaction_payment_request_id,\n" +
-            "  t.amount AS transaction_amount,\n" +
-            "  t.type AS transaction_type,\n" +
-            "  t.state AS transaction_state,\n" +
-            "  p.id AS payment_request_id,\n" +
-            "  p.external_id AS payment_request_external_id,\n" +
-            "  p.gateway_account_id AS payment_request_gateway_account_id,\n" +
-            "  p.amount AS payment_request_amount,\n" +
-            "  p.reference AS payment_request_reference,\n" +
-            "  p.description AS payment_request_description,\n" +
-            "  p.return_url AS payment_request_return_url,\n" +
-            "  p.created_date AS payment_request_created_date,\n" +
-            "  g.id AS gateway_account_id,\n" +
-            "  g.external_id AS gateway_account_external_id,\n" +
-            "  g.payment_provider AS gateway_account_payment_provider,\n" +
-            "  g.service_name AS gateway_account_service_name,\n" +
-            "  g.type AS gateway_account_type,\n" +
-            "  g.description AS gateway_account_description,\n" +
-            "  g.analytics_id AS gateway_account_analytics_id\n" +
-            "FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id\n" +
-            "  JOIN gateway_accounts g ON p.gateway_account_id = g.id\n" +
-            "WHERE t.id = :id")
+    String joinQuery = "SELECT" +
+            "  t.id AS transaction_id," +
+            "  t.payment_request_id AS transaction_payment_request_id," +
+            "  t.amount AS transaction_amount," +
+            "  t.type AS transaction_type," +
+            "  t.state AS transaction_state," +
+            "  p.id AS payment_request_id," +
+            "  p.external_id AS payment_request_external_id," +
+            "  p.gateway_account_id AS payment_request_gateway_account_id," +
+            "  p.amount AS payment_request_amount," +
+            "  p.reference AS payment_request_reference," +
+            "  p.description AS payment_request_description," +
+            "  p.return_url AS payment_request_return_url," +
+            "  p.created_date AS payment_request_created_date," +
+            "  g.id AS gateway_account_id," +
+            "  g.external_id AS gateway_account_external_id," +
+            "  g.payment_provider AS gateway_account_payment_provider," +
+            "  g.service_name AS gateway_account_service_name," +
+            "  g.type AS gateway_account_type," +
+            "  g.description AS gateway_account_description," +
+            "  g.analytics_id AS gateway_account_analytics_id," +
+            "  y.id AS payer_id," +
+            "  y.payment_request_id AS payer_payment_request_id," +
+            "  y.external_id AS payer_external_id," +
+            "  y.name AS payer_name," +
+            "  y.email AS payer_email," +
+            "  y.bank_account_number_last_two_digits AS payer_bank_account_number_last_two_digits," +
+            "  y.bank_account_requires_authorisation AS payer_bank_account_requires_authorisation," +
+            "  y.bank_account_number AS payer_bank_account_number," +
+            "  y.bank_account_sort_code AS payer_bank_account_sort_code," +
+            "  y.created_date AS payer_created_date" +
+            " FROM transactions t " + 
+            "  JOIN payment_requests p ON t.payment_request_id = p.id" +
+            "  JOIN gateway_accounts g ON p.gateway_account_id = g.id" +
+            "  LEFT JOIN payers y ON y.payment_request_id = p.id";
+    
+    @SqlQuery(joinQuery + " WHERE t.id = :id")
     Optional<Transaction> findById(@Bind("id") Long id);
 
-    @SqlQuery("SELECT\n" +
-            "  t.id AS transaction_id,\n" +
-            "  t.payment_request_id AS transaction_payment_request_id,\n" +
-            "  t.amount AS transaction_amount,\n" +
-            "  t.type AS transaction_type,\n" +
-            "  t.state AS transaction_state,\n" +
-            "  p.id AS payment_request_id,\n" +
-            "  p.external_id AS payment_request_external_id,\n" +
-            "  p.gateway_account_id AS payment_request_gateway_account_id,\n" +
-            "  p.amount AS payment_request_amount,\n" +
-            "  p.reference AS payment_request_reference,\n" +
-            "  p.description AS payment_request_description,\n" +
-            "  p.return_url AS payment_request_return_url,\n" +
-            "  p.created_date AS payment_request_created_date,\n" +
-            "  g.id AS gateway_account_id,\n" +
-            "  g.external_id AS gateway_account_external_id,\n" +
-            "  g.payment_provider AS gateway_account_payment_provider,\n" +
-            "  g.service_name AS gateway_account_service_name,\n" +
-            "  g.type AS gateway_account_type,\n" +
-            "  g.description AS gateway_account_description,\n" +
-            "  g.analytics_id AS gateway_account_analytics_id\n" +
-            "FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id\n" +
-            "  JOIN gateway_accounts g ON p.gateway_account_id = g.id\n" +
-            "WHERE t.payment_request_id = :paymentRequestId")
+    @SqlQuery(joinQuery + " WHERE t.payment_request_id = :paymentRequestId")
     Optional<Transaction> findByPaymentRequestId(@Bind("paymentRequestId") Long paymentRequestId);
 
-    @SqlQuery("SELECT\n" +
-            "  t.id AS transaction_id,\n" +
-            "  t.payment_request_id AS transaction_payment_request_id,\n" +
-            "  t.amount AS transaction_amount,\n" +
-            "  t.type AS transaction_type,\n" +
-            "  t.state AS transaction_state,\n" +
-            "  p.id AS payment_request_id,\n" +
-            "  p.external_id AS payment_request_external_id,\n" +
-            "  p.gateway_account_id AS payment_request_gateway_account_id,\n" +
-            "  p.amount AS payment_request_amount,\n" +
-            "  p.reference AS payment_request_reference,\n" +
-            "  p.description AS payment_request_description,\n" +
-            "  p.return_url AS payment_request_return_url,\n" +
-            "  p.created_date AS payment_request_created_date,\n" +
-            "  g.id AS gateway_account_id,\n" +
-            "  g.external_id AS gateway_account_external_id,\n" +
-            "  g.payment_provider AS gateway_account_payment_provider,\n" +
-            "  g.service_name AS gateway_account_service_name,\n" +
-            "  g.type AS gateway_account_type,\n" +
-            "  g.description AS gateway_account_description,\n" +
-            "  g.analytics_id AS gateway_account_analytics_id\n" +
-            "FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id\n" +
-            "  JOIN gateway_accounts g ON p.gateway_account_id = g.id\n" +
-            "WHERE p.external_id = :paymentRequestExternalId AND g.external_id = :accountExternalId")
+    @SqlQuery(joinQuery + " WHERE p.external_id = :paymentRequestExternalId AND g.external_id = :accountExternalId")
     Optional<Transaction> findTransactionForExternalIdAndGatewayAccountExternalId(@Bind("paymentRequestExternalId") String paymentRequestExternalId, @Bind("accountExternalId") String accountExternalId);
 
-    @SqlQuery("SELECT\n" +
-            "  tr.id AS transaction_id,\n" +
-            "  tr.payment_request_id AS transaction_payment_request_id,\n" +
-            "  tr.amount AS transaction_amount,\n" +
-            "  tr.type AS transaction_type,\n" +
-            "  tr.state AS transaction_state,\n" +
-            "  p.id AS payment_request_id,\n" +
-            "  p.external_id AS payment_request_external_id,\n" +
-            "  p.gateway_account_id AS payment_request_gateway_account_id,\n" +
-            "  p.amount AS payment_request_amount,\n" +
-            "  p.reference AS payment_request_reference,\n" +
-            "  p.description AS payment_request_description,\n" +
-            "  p.return_url AS payment_request_return_url,\n" +
-            "  p.created_date AS payment_request_created_date,\n" +
-            "  g.id AS gateway_account_id,\n" +
-            "  g.external_id AS gateway_account_external_id,\n" +
-            "  g.payment_provider AS gateway_account_payment_provider,\n" +
-            "  g.service_name AS gateway_account_service_name,\n" +
-            "  g.type AS gateway_account_type,\n" +
-            "  g.description AS gateway_account_description,\n" +
-            "  g.analytics_id AS gateway_account_analytics_id\n" +
-            "FROM transactions tr JOIN tokens t ON tr.payment_request_id = t.payment_request_id\n" +
-            "  JOIN payment_requests p ON tr.payment_request_id = p.id\n" +
-            "  JOIN gateway_accounts g ON p.gateway_account_id = g.id\n" +
-            "WHERE t.secure_redirect_token = :tokenId")
+    @SqlQuery(joinQuery + " JOIN tokens k ON k.payment_request_id = t.payment_request_id WHERE k.secure_redirect_token = :tokenId")
     Optional<Transaction> findByTokenId(@Bind("tokenId") String tokenId);
 
-    @SqlQuery("SELECT\n" +
-            "  t.id AS transaction_id,\n" +
-            "  t.payment_request_id AS transaction_payment_request_id,\n" +
-            "  t.amount AS transaction_amount,\n" +
-            "  t.type AS transaction_type,\n" +
-            "  t.state AS transaction_state,\n" +
-            "  p.id AS payment_request_id,\n" +
-            "  p.external_id AS payment_request_external_id,\n" +
-            "  p.gateway_account_id AS payment_request_gateway_account_id,\n" +
-            "  p.amount AS payment_request_amount,\n" +
-            "  p.reference AS payment_request_reference,\n" +
-            "  p.description AS payment_request_description,\n" +
-            "  p.return_url AS payment_request_return_url,\n" +
-            "  p.created_date AS payment_request_created_date,\n" +
-            "  g.id AS gateway_account_id,\n" +
-            "  g.external_id AS gateway_account_external_id,\n" +
-            "  g.payment_provider AS gateway_account_payment_provider,\n" +
-            "  g.service_name AS gateway_account_service_name,\n" +
-            "  g.type AS gateway_account_type,\n" +
-            "  g.description AS gateway_account_description,\n" +
-            "  g.analytics_id AS gateway_account_analytics_id\n" +
-            "FROM transactions t JOIN payment_requests p ON p.id = t.payment_request_id\n" +
-            "  JOIN gateway_accounts g ON p.gateway_account_id = g.id\n" +
-            "WHERE t.state = :state AND g.payment_provider = :paymentProvider")
+    @SqlQuery(joinQuery + " WHERE t.state = :state AND g.payment_provider = :paymentProvider")
     List<Transaction> findAllByPaymentStateAndProvider(@Bind("state") PaymentState paymentState, @Bind("paymentProvider") PaymentProvider paymentProvider);
 
-    @SqlQuery("SELECT\n" +
-            "  t.id AS transaction_id,\n" +
-            "  t.payment_request_id AS transaction_payment_request_id,\n" +
-            "  t.amount AS transaction_amount,\n" +
-            "  t.type AS transaction_type,\n" +
-            "  t.state AS transaction_state,\n" +
-            "  r.id AS payment_request_id,\n" +
-            "  r.external_id AS payment_request_external_id,\n" +
-            "  r.gateway_account_id AS payment_request_gateway_account_id,\n" +
-            "  r.amount AS payment_request_amount,\n" +
-            "  r.reference AS payment_request_reference,\n" +
-            "  r.description AS payment_request_description,\n" +
-            "  r.return_url AS payment_request_return_url,\n" +
-            "  r.created_date AS payment_request_created_date,\n" +
-            "  g.id AS gateway_account_id,\n" +
-            "  g.external_id AS gateway_account_external_id,\n" +
-            "  g.payment_provider AS gateway_account_payment_provider,\n" +
-            "  g.service_name AS gateway_account_service_name,\n" +
-            "  g.type AS gateway_account_type,\n" +
-            "  g.description AS gateway_account_description,\n" +
-            "  g.analytics_id AS gateway_account_analytics_id\n" +
-            "FROM transactions t JOIN payment_requests r ON r.id = t.payment_request_id\n" +
-            "  JOIN gateway_accounts g ON r.gateway_account_id = g.id\n" +
-            "  JOIN payers p ON p.payment_request_id = t.payment_request_id\n" +
-            "  JOIN mandates m ON m.payer_id = p.id\n" +
-            "WHERE m.id = :mandateId")
+    @SqlQuery(joinQuery + " JOIN mandates m ON m.payer_id = y.id WHERE m.id = :mandateId")
     Optional<Transaction> findByMandateId(@Bind("mandateId") Long mandateId);
 
     @SqlUpdate("UPDATE transactions t SET state = :state WHERE t.id = :id")

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentRequestMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentRequestMapper.java
@@ -2,6 +2,7 @@ package uk.gov.pay.directdebit.payments.dao.mapper;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 
 import java.sql.ResultSet;
@@ -10,17 +11,41 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 public class PaymentRequestMapper implements RowMapper<PaymentRequest> {
-    private static final String ID_COLUMN = "id";
-    private static final String EXTERNAL_ID_COLUMN = "external_id";
-    private static final String GATEWAY_ACCOUNT_ID_COLUMN = "gateway_account_id";
-    private static final String AMOUNT_COLUMN = "amount";
-    private static final String REFERENCE_COLUMN = "reference";
-    private static final String DESCRIPTION_COLUMN = "description";
-    private static final String RETURN_URL_COLUMN = "return_url";
-    private static final String CREATED_DATE_COLUMN = "created_date";
+    private static final String ID_COLUMN = "payment_request_id";
+    private static final String EXTERNAL_ID_COLUMN = "payment_request_external_id";
+    private static final String GATEWAY_ACCOUNT_ID_COLUMN = "payment_request_gateway_account_id";
+    private static final String AMOUNT_COLUMN = "payment_request_amount";
+    private static final String REFERENCE_COLUMN = "payment_request_reference";
+    private static final String DESCRIPTION_COLUMN = "payment_request_description";
+    private static final String RETURN_URL_COLUMN = "payment_request_return_url";
+    private static final String CREATED_DATE_COLUMN = "payment_request_created_date";
+    private static final String PAYER_ID_COLUMN = "payer_id";
+    private static final String PAYER_PAYMENT_REQUEST_ID_COLUMN = "payer_payment_request_id";
+    private static final String PAYER_EXTERNAL_ID_COLUMN = "payer_external_id";
+    private static final String PAYER_NAME_COLUMN = "payer_name";
+    private static final String PAYER_EMAIL_COLUMN = "payer_email";
+    private static final String PAYER_BANK_ACCOUNT_NUMBER_LAST_TWO_DIGITS_COLUMN = "payer_bank_account_number_last_two_digits";
+    private static final String PAYER_BANK_ACCOUNT_REQUIRES_AUTHORISATION_COLUMN = "payer_bank_account_requires_authorisation";
+    private static final String PAYER_BANK_ACCOUNT_NUMBER_COLUMN = "payer_bank_account_number";
+    private static final String PAYER_BANK_ACCOUNT_SORT_CODE_COLUMN = "payer_bank_account_sort_code";
+    private static final String PAYER_CREATED_DATE_COLUMN= "payer_created_date";
 
     @Override
     public PaymentRequest map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        Payer payer = null;
+        if (resultSet.getTimestamp(PAYER_CREATED_DATE_COLUMN) != null) {
+            payer = new Payer(
+                    resultSet.getLong(PAYER_ID_COLUMN),
+                    resultSet.getLong(PAYER_PAYMENT_REQUEST_ID_COLUMN),
+                    resultSet.getString(PAYER_EXTERNAL_ID_COLUMN),
+                    resultSet.getString(PAYER_NAME_COLUMN),
+                    resultSet.getString(PAYER_EMAIL_COLUMN),
+                    resultSet.getString(PAYER_BANK_ACCOUNT_SORT_CODE_COLUMN),
+                    resultSet.getString(PAYER_BANK_ACCOUNT_NUMBER_COLUMN),
+                    resultSet.getString(PAYER_BANK_ACCOUNT_NUMBER_LAST_TWO_DIGITS_COLUMN),
+                    resultSet.getBoolean(PAYER_BANK_ACCOUNT_REQUIRES_AUTHORISATION_COLUMN),
+                    ZonedDateTime.ofInstant(resultSet.getTimestamp(PAYER_CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC));
+        }
         return new PaymentRequest(
                 resultSet.getLong(ID_COLUMN),
                 resultSet.getLong(AMOUNT_COLUMN),
@@ -29,6 +54,7 @@ public class PaymentRequestMapper implements RowMapper<PaymentRequest> {
                 resultSet.getString(DESCRIPTION_COLUMN),
                 resultSet.getString(REFERENCE_COLUMN),
                 resultSet.getString(EXTERNAL_ID_COLUMN),
+                payer,
                 ZonedDateTime.ofInstant(resultSet.getTimestamp(CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.payments.dao.mapper;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.Transaction;
@@ -27,9 +28,33 @@ public class TransactionMapper implements RowMapper<Transaction> {
     private static final String GATEWAY_ACCOUNT_ID_COLUMN = "gateway_account_id";
     private static final String GATEWAY_ACCOUNT_EXTERNAL_ID_COLUMN = "gateway_account_external_id";
     private static final String GATEWAY_ACCOUNT_PAYMENT_PROVIDER_COLUMN = "gateway_account_payment_provider";
+    private static final String PAYER_ID_COLUMN = "payer_id";
+    private static final String PAYER_PAYMENT_REQUEST_ID_COLUMN = "payer_payment_request_id";
+    private static final String PAYER_EXTERNAL_ID_COLUMN = "payer_external_id";
+    private static final String PAYER_NAME_COLUMN = "payer_name";
+    private static final String PAYER_EMAIL_COLUMN = "payer_email";
+    private static final String PAYER_BANK_ACCOUNT_NUMBER_LAST_TWO_DIGITS_COLUMN = "payer_bank_account_number_last_two_digits";
+    private static final String PAYER_BANK_ACCOUNT_REQUIRES_AUTHORISATION_COLUMN = "payer_bank_account_requires_authorisation";
+    private static final String PAYER_BANK_ACCOUNT_NUMBER_COLUMN = "payer_bank_account_number";
+    private static final String PAYER_BANK_ACCOUNT_SORT_CODE_COLUMN = "payer_bank_account_sort_code";
+    private static final String PAYER_CREATED_DATE_COLUMN= "payer_created_date";
 
     @Override
     public Transaction map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        Payer payer = null;
+        if (resultSet.getTimestamp(PAYER_CREATED_DATE_COLUMN) != null) {
+            payer = new Payer(
+                    resultSet.getLong(PAYER_ID_COLUMN),
+                    resultSet.getLong(PAYER_PAYMENT_REQUEST_ID_COLUMN),
+                    resultSet.getString(PAYER_EXTERNAL_ID_COLUMN),
+                    resultSet.getString(PAYER_NAME_COLUMN),
+                    resultSet.getString(PAYER_EMAIL_COLUMN),
+                    resultSet.getString(PAYER_BANK_ACCOUNT_SORT_CODE_COLUMN),
+                    resultSet.getString(PAYER_BANK_ACCOUNT_NUMBER_COLUMN),
+                    resultSet.getString(PAYER_BANK_ACCOUNT_NUMBER_LAST_TWO_DIGITS_COLUMN),
+                    resultSet.getBoolean(PAYER_BANK_ACCOUNT_REQUIRES_AUTHORISATION_COLUMN),
+                    ZonedDateTime.ofInstant(resultSet.getTimestamp(PAYER_CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC));
+        }
         PaymentRequest paymentRequest = new PaymentRequest(
                 resultSet.getLong(PAYMENT_REQUEST_ID_COLUMN),
                 resultSet.getLong(PAYMENT_REQUEST_AMOUNT_COLUMN),
@@ -38,10 +63,10 @@ public class TransactionMapper implements RowMapper<Transaction> {
                 resultSet.getString(PAYMENT_REQUEST_DESCRIPTION_COLUMN),
                 resultSet.getString(PAYMENT_REQUEST_REFERENCE_COLUMN),
                 resultSet.getString(PAYMENT_REQUEST_EXTERNAL_ID_COLUMN),
+                payer,
                 ZonedDateTime.now(ZoneOffset.UTC)
         );
-
-
+        
         return new Transaction(
                 resultSet.getLong(TRANSACTION_ID_COLUMN),
                 paymentRequest,

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
@@ -5,6 +5,7 @@ import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import uk.gov.pay.directdebit.payers.model.Payer;
 
 public class PaymentRequest {
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentRequest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.payments.model;
 
 
+import org.jdbi.v3.core.mapper.Nested;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 
 import java.time.ZoneOffset;
@@ -16,9 +17,11 @@ public class PaymentRequest {
     private Long gatewayAccountId;
     private String description;
     private String reference;
+    @Nested("payer")
+    private Payer payer;
     private ZonedDateTime createdDate;
 
-    public PaymentRequest(Long id, Long amount, String returnUrl, Long gatewayAccountId, String description, String reference, String externalId, ZonedDateTime createdDate) {
+    public PaymentRequest(Long id, Long amount, String returnUrl, Long gatewayAccountId, String description, String reference, String externalId, Payer payer, ZonedDateTime createdDate) {
         this.id = id;
         this.amount = amount;
         this.returnUrl = returnUrl;
@@ -27,10 +30,11 @@ public class PaymentRequest {
         this.reference = reference;
         this.createdDate = createdDate;
         this.externalId = externalId;
+        this.payer = payer;
     }
 
     public PaymentRequest(Long amount, String returnUrl, Long gatewayAccountId, String description, String reference) {
-        this(null, amount, returnUrl, gatewayAccountId, description, reference, RandomIdGenerator.newId(), ZonedDateTime.now(ZoneOffset.UTC));
+        this(null, amount, returnUrl, gatewayAccountId, description, reference, RandomIdGenerator.newId(), null, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
     public String getExternalId() {
@@ -97,32 +101,62 @@ public class PaymentRequest {
         this.id = id;
     }
 
+    public Payer getPayer() {
+        return payer;
+    }
+
+    public void setPayer(Payer payer) {
+        this.payer = payer;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         PaymentRequest that = (PaymentRequest) o;
 
-        if (!id.equals(that.id)) return false;
-        if (!externalId.equals(that.externalId)) return false;
-        if (!amount.equals(that.amount)) return false;
-        if (!returnUrl.equals(that.returnUrl)) return false;
-        if (!gatewayAccountId.equals(that.gatewayAccountId)) return false;
-        if (!description.equals(that.description)) return false;
-        if (!reference.equals(that.reference)) return false;
+        if (id != null ? !id.equals(that.id) : that.id != null) {
+            return false;
+        }
+        if (!externalId.equals(that.externalId)) {
+            return false;
+        }
+        if (!amount.equals(that.amount)) {
+            return false;
+        }
+        if (!returnUrl.equals(that.returnUrl)) {
+            return false;
+        }
+        if (!gatewayAccountId.equals(that.gatewayAccountId)) {
+            return false;
+        }
+        if (!description.equals(that.description)) {
+            return false;
+        }
+        if (!reference.equals(that.reference)) {
+            return false;
+        }
+        if (payer != null ? !payer.equals(that.payer) : that.payer != null) {
+            return false;
+        }
         return createdDate.equals(that.createdDate);
     }
 
     @Override
     public int hashCode() {
-        int result = id.hashCode();
+        int result = id != null ? id.hashCode() : 0;
         result = 31 * result + externalId.hashCode();
         result = 31 * result + amount.hashCode();
         result = 31 * result + returnUrl.hashCode();
         result = 31 * result + gatewayAccountId.hashCode();
         result = 31 * result + description.hashCode();
         result = 31 * result + reference.hashCode();
+        result = 31 * result + (payer != null ? payer.hashCode() : 0);
         result = 31 * result + createdDate.hashCode();
         return result;
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -89,18 +89,36 @@ public class Transaction {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Transaction that = (Transaction) o;
 
-        if (id != null ? !id.equals(that.id) : that.id != null) return false;
-        if (!paymentRequest.equals(that.paymentRequest)) return false;
-        if (!gatewayAccountId.equals(that.gatewayAccountId)) return false;
-        if (!gatewayAccountExternalId.equals(that.gatewayAccountExternalId)) return false;
-        if (paymentProvider != that.paymentProvider) return false;
-        if (!amount.equals(that.amount)) return false;
-        if (type != that.type) return false;
+        if (id != null ? !id.equals(that.id) : that.id != null) {
+            return false;
+        }
+        if (!paymentRequest.equals(that.paymentRequest)) {
+            return false;
+        }
+        if (!gatewayAccountId.equals(that.gatewayAccountId)) {
+            return false;
+        }
+        if (!gatewayAccountExternalId.equals(that.gatewayAccountExternalId)) {
+            return false;
+        }
+        if (paymentProvider != that.paymentProvider) {
+            return false;
+        }
+        if (!amount.equals(that.amount)) {
+            return false;
+        }
+        if (type != that.type) {
+            return false;
+        }
         return state == that.state;
     }
 
@@ -116,5 +134,4 @@ public class Transaction {
         result = 31 * result + state.hashCode();
         return result;
     }
-
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResource.java
@@ -23,7 +23,7 @@ import static javax.ws.rs.core.Response.created;
 
 @Path("/")
 public class PaymentRequestResource {
-    //have to be /charges unless we change public api
+    //has to be /charges unless we change public api
     public static final String CHARGE_API_PATH = "/v1/api/accounts/{accountId}/charges/{paymentRequestExternalId}";
     public static final String CHARGES_API_PATH = "/v1/api/accounts/{accountId}/charges";
     public static final String CANCEL_CHARGE_API_PATH = "/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/cancel";

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentRequestService.java
@@ -115,7 +115,6 @@ public class PaymentRequestService {
                 .findByExternalIdAndAccountExternalId(paymentRequestExternalId, accountExternalId)
                 .map(paymentRequest ->  {
                     Transaction transaction = transactionService.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequestExternalId, accountExternalId);
-                    // payer will be populated in the next PR
                     return new PaymentRequestFrontendResponse(
                             paymentRequest.getExternalId(),
                             paymentRequest.getGatewayAccountId(),
@@ -126,7 +125,7 @@ public class PaymentRequestService {
                             paymentRequest.getDescription(),
                             paymentRequest.getReference(),
                             paymentRequest.getCreatedDate().toString(),
-                            null);
+                            paymentRequest.getPayer());
                 })
                 .orElseThrow(() -> new PaymentRequestNotFoundException(paymentRequestExternalId, accountExternalId));
     }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -50,7 +50,7 @@ database:
   # the maximum amount of time to wait on an empty pool before throwing an maception
   maxWaitForConnection: 1s
 
-  # the SQL joinQuery to run when validating a connection's liveness
+  # the SQL query to run when validating a connection's liveness
   validationQuery: "SELECT '1'"
 
   # the timeout before a connection validation queries fail

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -50,7 +50,7 @@ database:
   # the maximum amount of time to wait on an empty pool before throwing an maception
   maxWaitForConnection: 1s
 
-  # the SQL query to run when validating a connection's liveness
+  # the SQL joinQuery to run when validating a connection's liveness
   validationQuery: "SELECT '1'"
 
   # the timeout before a connection validation queries fail

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/GatewayAccountParamConverterProviderTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/GatewayAccountParamConverterProviderTest.java
@@ -38,18 +38,18 @@ public class GatewayAccountParamConverterProviderTest {
     }
 
     @Test
-    public void shouldRetrieveTheCorrectGatewayAccountForAValidId() throws IOException {
-        when(mockedGatewayAccountDao.findById(gatewayAccount.getId())).thenReturn(Optional.of(gatewayAccount));
-        GatewayAccount convertedGatewayAccount = paramConverter.fromString(this.gatewayAccount.getId().toString());
+    public void shouldRetrieveTheCorrectGatewayAccountForAValidId() {
+        when(mockedGatewayAccountDao.findByExternalId(gatewayAccount.getExternalId())).thenReturn(Optional.of(gatewayAccount));
+        GatewayAccount convertedGatewayAccount = paramConverter.fromString(gatewayAccount.getExternalId());
         Assert.assertThat(convertedGatewayAccount, is(gatewayAccount));
     }
 
     @Test
-    public void shouldThrow_ifGatewayAccountDoesNotExist() throws IOException {
-        when(mockedGatewayAccountDao.findById(10L)).thenReturn(Optional.empty());
+    public void shouldThrow_ifGatewayAccountDoesNotExist() {
+        when(mockedGatewayAccountDao.findByExternalId("not-existing")).thenReturn(Optional.empty());
         thrown.expect(GatewayAccountNotFoundException.class);
-        thrown.expectMessage("Unknown gateway account: 10");
+        thrown.expectMessage("Unknown gateway account: not-existing");
         thrown.reportMissingExceptionWithMessage("GatewayAccountNotFoundException expected");
-        paramConverter.fromString("10");
+        paramConverter.fromString("not-existing");
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/api/ConfirmDetailsRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/api/ConfirmDetailsRequestValidatorTest.java
@@ -29,7 +29,7 @@ public class ConfirmDetailsRequestValidatorTest {
         Map<String, String> request = new HashMap<>();
         thrown.expect(MissingMandatoryFieldsException.class);
         thrown.expectMessage("Field(s) missing: [" +
-                ConfirmDetailsRequestValidator.SORTCODE_KEY + ", " +
+                ConfirmDetailsRequestValidator.SORT_CODE_KEY + ", " +
                 ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
@@ -40,10 +40,9 @@ public class ConfirmDetailsRequestValidatorTest {
     public void shouldThrowMissingMandatoryFieldsExceptionIfSortCodeFieldIsMissing() {
         Map<String, String> request = new HashMap<>();
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
-        request.remove(ConfirmDetailsRequestValidator.SORTCODE_KEY);
         thrown.expect(MissingMandatoryFieldsException.class);
         thrown.expectMessage("Field(s) missing: [" +
-                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                ConfirmDetailsRequestValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
         confirmDetailsRequestValidator.validate(request);
@@ -53,10 +52,10 @@ public class ConfirmDetailsRequestValidatorTest {
     public void shouldThrowInvalidSizeFieldsExceptionIfSortCodeFieldIsEmptyString() {
         Map<String, String> request = new HashMap<>();
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "");
         thrown.expect(InvalidSizeFieldsException.class);
         thrown.expectMessage("The size of a field(s) is invalid: [" +
-                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                ConfirmDetailsRequestValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
         confirmDetailsRequestValidator.validate(request);
@@ -66,10 +65,10 @@ public class ConfirmDetailsRequestValidatorTest {
     public void shouldThrowInvalidFieldsExceptionIfSortCodeFieldIsNull() {
         Map<String, String> request = new HashMap<>();
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, null);
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, null);
         thrown.expect(InvalidFieldsException.class);
         thrown.expectMessage("Field(s) are invalid: [" +
-                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                ConfirmDetailsRequestValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
         confirmDetailsRequestValidator.validate(request);
@@ -79,10 +78,10 @@ public class ConfirmDetailsRequestValidatorTest {
     public void shouldThrowInvalidFieldsExceptionIfSortCodeFieldIsNonNumeric() {
         Map<String, String> request = new HashMap<>();
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123abc");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "123abc");
         thrown.expect(InvalidFieldsException.class);
         thrown.expectMessage("Field(s) are invalid: [" +
-                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                ConfirmDetailsRequestValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
         confirmDetailsRequestValidator.validate(request);
@@ -92,10 +91,10 @@ public class ConfirmDetailsRequestValidatorTest {
     public void shouldThrowInvalidSizeFieldsExceptionIfSortCodeFieldHasInvalidSize() {
         Map<String, String> request = new HashMap<>();
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "123");
         thrown.expect(InvalidSizeFieldsException.class);
         thrown.expectMessage("The size of a field(s) is invalid: [" +
-                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                ConfirmDetailsRequestValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
         confirmDetailsRequestValidator.validate(request);
@@ -105,15 +104,14 @@ public class ConfirmDetailsRequestValidatorTest {
     public void shouldNotThrowExceptionIfSortCodeStartsWithZeros() {
         Map<String, String> request = new HashMap<>();
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "012345");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "012345");
         confirmDetailsRequestValidator.validate(request);
     }
 
     @Test
     public void shouldThrowMissingMandatoryFieldsExceptionIfAccountNumberFieldIsMissing() {
         Map<String, String> request = new HashMap<>();
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
-        request.remove(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY);
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "123456");
         thrown.expect(MissingMandatoryFieldsException.class);
         thrown.expectMessage("Field(s) missing: [" +
                 ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY +
@@ -125,7 +123,7 @@ public class ConfirmDetailsRequestValidatorTest {
     @Test
     public void shouldThrowInvalidSizeFieldsExceptionIfAccountNumberFieldIsEmptyString() {
         Map<String, String> request = new HashMap<>();
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "123456");
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "");
         thrown.expect(InvalidSizeFieldsException.class);
         thrown.expectMessage("The size of a field(s) is invalid: [" +
@@ -138,7 +136,7 @@ public class ConfirmDetailsRequestValidatorTest {
     @Test
     public void shouldThrowInvalidFieldsExceptionIfAccountNumberFieldIsNull() {
         Map<String, String> request = new HashMap<>();
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "123456");
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, null);
         thrown.expect(InvalidFieldsException.class);
         thrown.expectMessage("Field(s) are invalid: [" +
@@ -151,7 +149,7 @@ public class ConfirmDetailsRequestValidatorTest {
     @Test
     public void shouldThrowInvalidFieldsExceptionIfAccountNumberFieldIsNonNumeric() {
         Map<String, String> request = new HashMap<>();
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "123456");
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "12345abc");
         thrown.expect(InvalidFieldsException.class);
         thrown.expectMessage("Field(s) are invalid: [" +
@@ -164,7 +162,7 @@ public class ConfirmDetailsRequestValidatorTest {
     @Test
     public void shouldThrowInvalidSizeFieldsExceptionIfAccountNumberFieldHasInvalidSizeBelowMinimum() {
         Map<String, String> request = new HashMap<>();
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "123456");
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "12345");
         thrown.expect(InvalidSizeFieldsException.class);
         thrown.expectMessage("The size of a field(s) is invalid: [" +
@@ -177,7 +175,7 @@ public class ConfirmDetailsRequestValidatorTest {
     @Test
     public void shouldThrowInvalidSizeFieldsExceptionIfAccountNumberFieldHasInvalidSizeAboveMaximum() {
         Map<String, String> request = new HashMap<>();
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "123456");
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456780");
         thrown.expect(InvalidSizeFieldsException.class);
         thrown.expectMessage("The size of a field(s) is invalid: [" +
@@ -190,7 +188,7 @@ public class ConfirmDetailsRequestValidatorTest {
     @Test
     public void shouldNotThrowExceptionIfAccountNumberStartsWithZeros() {
         Map<String, String> request = new HashMap<>();
-        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORT_CODE_KEY, "123456");
         request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "01234567");
         confirmDetailsRequestValidator.validate(request);
     }

--- a/src/test/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidatorTest.java
@@ -33,7 +33,7 @@ public class CreatePayerValidatorTest {
         thrown.expect(MissingMandatoryFieldsException.class);
         thrown.expectMessage("Field(s) missing: [" +
                 CreatePayerValidator.NAME_KEY + ", " +
-                CreatePayerValidator.SORTCODE_KEY + ", " +
+                CreatePayerValidator.SORT_CODE_KEY + ", " +
                 CreatePayerValidator.ACCOUNT_NUMBER_KEY + ", " +
                 CreatePayerValidator.EMAIL_KEY +
                 "]");
@@ -80,10 +80,10 @@ public class CreatePayerValidatorTest {
     @Test
     public void shouldThrowMissingMandatoryFieldsExceptionIfSortCodeFieldIsMissing() {
         Map<String, String> request = generateValidRequest();
-        request.remove(CreatePayerValidator.SORTCODE_KEY);
+        request.remove(CreatePayerValidator.SORT_CODE_KEY);
         thrown.expect(MissingMandatoryFieldsException.class);
         thrown.expectMessage("Field(s) missing: [" +
-                CreatePayerValidator.SORTCODE_KEY +
+                CreatePayerValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
         createPayerValidator.validate(request);
@@ -92,10 +92,10 @@ public class CreatePayerValidatorTest {
     @Test
     public void shouldThrowInvalidSizeFieldsExceptionIfSortCodeFieldIsEmptyString() {
         Map<String, String> request = generateValidRequest();
-        request.put(CreatePayerValidator.SORTCODE_KEY, "");
+        request.put(CreatePayerValidator.SORT_CODE_KEY, "");
         thrown.expect(InvalidSizeFieldsException.class);
         thrown.expectMessage("The size of a field(s) is invalid: [" +
-                CreatePayerValidator.SORTCODE_KEY +
+                CreatePayerValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
         createPayerValidator.validate(request);
@@ -104,10 +104,10 @@ public class CreatePayerValidatorTest {
     @Test
     public void shouldThrowInvalidFieldsExceptionIfSortCodeFieldIsNull() {
         Map<String, String> request = generateValidRequest();
-        request.put(CreatePayerValidator.SORTCODE_KEY, null);
+        request.put(CreatePayerValidator.SORT_CODE_KEY, null);
         thrown.expect(InvalidFieldsException.class);
         thrown.expectMessage("Field(s) are invalid: [" +
-                CreatePayerValidator.SORTCODE_KEY +
+                CreatePayerValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
         createPayerValidator.validate(request);
@@ -116,10 +116,10 @@ public class CreatePayerValidatorTest {
     @Test
     public void shouldThrowInvalidFieldsExceptionIfSortCodeFieldIsNonNumeric() {
         Map<String, String> request = generateValidRequest();
-        request.put(CreatePayerValidator.SORTCODE_KEY, "123abc");
+        request.put(CreatePayerValidator.SORT_CODE_KEY, "123abc");
         thrown.expect(InvalidFieldsException.class);
         thrown.expectMessage("Field(s) are invalid: [" +
-                CreatePayerValidator.SORTCODE_KEY +
+                CreatePayerValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
         createPayerValidator.validate(request);
@@ -128,10 +128,10 @@ public class CreatePayerValidatorTest {
     @Test
     public void shouldThrowInvalidSizeFieldsExceptionIfSortCodeFieldHasInvalidSize() {
         Map<String, String> request = generateValidRequest();
-        request.put(CreatePayerValidator.SORTCODE_KEY, "1234560");
+        request.put(CreatePayerValidator.SORT_CODE_KEY, "1234560");
         thrown.expect(InvalidSizeFieldsException.class);
         thrown.expectMessage("The size of a field(s) is invalid: [" +
-                CreatePayerValidator.SORTCODE_KEY +
+                CreatePayerValidator.SORT_CODE_KEY +
                 "]");
         thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
         createPayerValidator.validate(request);
@@ -140,7 +140,7 @@ public class CreatePayerValidatorTest {
     @Test
     public void shouldNotThrowExceptionIfSortCodeStartsWithZeros() {
         Map<String, String> request = generateValidRequest();
-        request.put(CreatePayerValidator.SORTCODE_KEY, "012345");
+        request.put(CreatePayerValidator.SORT_CODE_KEY, "012345");
         createPayerValidator.validate(request);
     }
 
@@ -371,12 +371,8 @@ public class CreatePayerValidatorTest {
         PayerFixture payerFixture = aPayerFixture();
         Map<String, String> request = new HashMap<>();
         request.put(CreatePayerValidator.NAME_KEY, payerFixture.getName());
-        request.put(CreatePayerValidator.SORTCODE_KEY, payerFixture.getSortCode());
+        request.put(CreatePayerValidator.SORT_CODE_KEY, payerFixture.getSortCode());
         request.put(CreatePayerValidator.ACCOUNT_NUMBER_KEY, payerFixture.getAccountNumber());
-        request.put(CreatePayerValidator.ADDRESS_COUNTRY_KEY, payerFixture.getAddressCountry());
-        request.put(CreatePayerValidator.ADDRESS_LINE1_KEY, payerFixture.getAddressLine1());
-        request.put(CreatePayerValidator.ADDRESS_CITY_KEY, payerFixture.getAddressCity());
-        request.put(CreatePayerValidator.ADDRESS_POSTCODE_KEY, payerFixture.getAddressPostcode());
         request.put(CreatePayerValidator.EMAIL_KEY, payerFixture.getEmail());
         return request;
     }

--- a/src/test/java/uk/gov/pay/directdebit/payers/api/PayerParserTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/api/PayerParserTest.java
@@ -18,21 +18,15 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PayerParserTest {
     private static final String EMAIL = "aaa@bbb.com";
-    private static final String ADDRESS_LINE1 = "this is address line 1";
-    private static final String CITY = "London";
-    private static final String POSTCODE = "AB1CD4";
-    private static final String COUNTRY_CODE = "GB";
     private static final String SORT_CODE = "654321";
     private static final String ACCOUNT_NUMBER = "12345678";
     private static final String NAME = "name";
-    private static final String ADDRESS_LINE2 = "this is address line 2";
 
     @Mock
     private Transaction mockedTransaction;
@@ -49,11 +43,6 @@ public class PayerParserTest {
             put("account_number", ACCOUNT_NUMBER);
             put("sort_code", SORT_CODE);
             put("email", EMAIL);
-            put("address_line1", ADDRESS_LINE1);
-            put("address_line2", ADDRESS_LINE2);
-            put("city", CITY);
-            put("postcode", POSTCODE);
-            put("country_code", COUNTRY_CODE);
             put("requires_authorisation", "true");
         }};
         when(mockedTransaction.getPaymentRequest()).thenReturn(paymentRequest);
@@ -66,42 +55,6 @@ public class PayerParserTest {
         assertThat(payer.getAccountRequiresAuthorisation(), is(true));
         assertThat(BCrypt.checkpw(ACCOUNT_NUMBER, payer.getAccountNumber()), is(true));
         assertThat(BCrypt.checkpw(SORT_CODE, payer.getSortCode()), is(true));
-        assertThat(payer.getAddressLine1(), is(ADDRESS_LINE1));
-        assertThat(payer.getAddressLine2(), is(ADDRESS_LINE2));
-        assertThat(payer.getAddressPostcode(), is(POSTCODE));
-        assertThat(payer.getAddressCity(), is(CITY));
-        assertThat(payer.getAddressCountry(), is(COUNTRY_CODE));
-        assertThat(payer.getCreatedDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
-    }
-
-    @Test
-    public void shouldCreateAPayerWithoutMandatoryFields() {
-        Map<String, String> createPaymentRequestWithAllFields = new HashMap<String, String>() {{
-            put("account_holder_name", NAME);
-            put("account_number", ACCOUNT_NUMBER);
-            put("sort_code", SORT_CODE);
-            put("email", EMAIL);
-            put("address_line1", ADDRESS_LINE1);
-            put("city", CITY);
-            put("postcode", POSTCODE);
-            put("country_code", COUNTRY_CODE);
-            put("requires_authorisation", "true");
-        }};
-        when(mockedTransaction.getPaymentRequest()).thenReturn(paymentRequest);
-        Payer payer = payerParser.parse(createPaymentRequestWithAllFields, mockedTransaction);
-        assertThat(payer.getExternalId(), is(notNullValue()));
-        assertThat(payer.getPaymentRequestId(), is(19L));
-        assertThat(payer.getName(), is(NAME));
-        assertThat(payer.getEmail(), is(EMAIL));
-        assertThat(payer.getAccountNumberLastTwoDigits(), is("78"));
-        assertThat(payer.getAccountRequiresAuthorisation(), is(true));
-        assertThat(BCrypt.checkpw(ACCOUNT_NUMBER, payer.getAccountNumber()), is(true));
-        assertThat(BCrypt.checkpw(SORT_CODE, payer.getSortCode()), is(true));
-        assertThat(payer.getAddressLine1(), is(ADDRESS_LINE1));
-        assertThat(payer.getAddressLine2(), is(nullValue()));
-        assertThat(payer.getAddressPostcode(), is(POSTCODE));
-        assertThat(payer.getAddressCity(), is(CITY));
-        assertThat(payer.getAddressCountry(), is(COUNTRY_CODE));
         assertThat(payer.getCreatedDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
@@ -40,17 +40,13 @@ public class PayerDaoIT {
 
     private PaymentRequestFixture testPaymentRequest;
     private PayerFixture testPayer;
-    private GatewayAccountFixture gatewayAccountFixture;
 
     @Before
     public void setup() {
         payerDao = testContext.getJdbi().onDemand(PayerDao.class);
-        this.gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
-        this.testPaymentRequest = aPaymentRequestFixture()
-                .withGatewayAccountId(gatewayAccountFixture.getId())
+        GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()
                 .insert(testContext.getJdbi());
         this.testPayer = PayerFixture.aPayerFixture()
-                .withPaymentRequestId(testPaymentRequest.getId())
                 .withEmail(EMAIL)
                 .withExternalId(EXTERNAL_ID)
                 .withName(PAYER_NAME)
@@ -59,6 +55,10 @@ public class PayerDaoIT {
                 .withAccountNumberLastTwoDigits(ACCOUNT_NUMBER_LAST_TWO_DIGITS)
                 .withAccountRequiresAuthorisation(ACCOUNT_REQUIRES_AUTHORISATION)
                 .withCreatedDate(CREATED_DATE);
+        this.testPaymentRequest = aPaymentRequestFixture()
+                .withGatewayAccountId(gatewayAccountFixture.getId())
+                .withPayerFixture(testPayer)
+                .insert(testContext.getJdbi());
     }
 
     @Test
@@ -80,7 +80,6 @@ public class PayerDaoIT {
 
     @Test
     public void shouldGetAPayerById() {
-        testPayer.insert(testContext.getJdbi());
         Payer payer = payerDao.findById(testPayer.getId()).get();
         assertThat(payer.getId(), is(testPayer.getId()));
         assertThat(payer.getPaymentRequestId(), is(testPaymentRequest.getId()));
@@ -101,7 +100,6 @@ public class PayerDaoIT {
 
     @Test
     public void shouldGetAPayerByExternalId() {
-        testPayer.insert(testContext.getJdbi());
         Payer payer = payerDao.findByExternalId(testPayer.getExternalId()).get();
         assertThat(payer.getId(), is(testPayer.getId()));
         assertThat(payer.getPaymentRequestId(), is(testPaymentRequest.getId()));
@@ -122,7 +120,6 @@ public class PayerDaoIT {
 
     @Test
     public void shouldGetAPayerByPaymentRequestId() {
-        testPayer.insert(testContext.getJdbi());
         Payer payer = payerDao.findByPaymentRequestId(testPaymentRequest.getId()).get();
         assertThat(payer.getId(), is(testPayer.getId()));
         assertThat(payer.getPaymentRequestId(), is(testPaymentRequest.getId()));
@@ -143,8 +140,6 @@ public class PayerDaoIT {
 
     @Test
     public void shouldUpdatePayerDetailsAndReturnNumberOfAffectedRows() {
-        testPayer.insert(testContext.getJdbi());
-
         String newName = "coffee";
         String newAccountNumber = "87654321";
         String newSortCode = "123456";

--- a/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
@@ -1,5 +1,13 @@
 package uk.gov.pay.directdebit.payers.dao;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.aPaymentRequestFixture;
+import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.isDate;
+
+import java.sql.Timestamp;
+import java.time.ZonedDateTime;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,15 +21,6 @@ import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 
-import java.sql.Timestamp;
-import java.time.ZonedDateTime;
-import java.util.Map;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.aPaymentRequestFixture;
-import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.isDate;
-
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
 public class PayerDaoIT {
@@ -30,11 +29,6 @@ public class PayerDaoIT {
     private static final String SORT_CODE = "654321";
     private static final String ACCOUNT_NUMBER_LAST_TWO_DIGITS = "78";
     private static final boolean ACCOUNT_REQUIRES_AUTHORISATION = false;
-    private static final String ADDRESS_LINE_1 = "address line 1";
-    private static final String ADDRESS_LINE_2 = "address line 2";
-    private static final String ADDRESS_CITY = "london";
-    private static final String ADDRESS_POSTCODE = "a postcode";
-    private static final String ADDRESS_COUNTRY = "italy";
     private static final ZonedDateTime CREATED_DATE = ZonedDateTime.parse("2017-12-30T12:30:40Z");
     private static final String EMAIL = "aaa@bb.test";
     private static final String EXTERNAL_ID = "ablijfslkj234";
@@ -64,11 +58,6 @@ public class PayerDaoIT {
                 .withSortCode(SORT_CODE)
                 .withAccountNumberLastTwoDigits(ACCOUNT_NUMBER_LAST_TWO_DIGITS)
                 .withAccountRequiresAuthorisation(ACCOUNT_REQUIRES_AUTHORISATION)
-                .withAddressLine1(ADDRESS_LINE_1)
-                .withAddressLine2(ADDRESS_LINE_2)
-                .withAddressCity(ADDRESS_CITY)
-                .withAddressPostcode(ADDRESS_POSTCODE)
-                .withAddressCountry(ADDRESS_COUNTRY)
                 .withCreatedDate(CREATED_DATE);
     }
 
@@ -85,11 +74,6 @@ public class PayerDaoIT {
         assertThat(foundPayer.get("bank_account_requires_authorisation"), is(ACCOUNT_REQUIRES_AUTHORISATION));
         assertThat(foundPayer.get("bank_account_number"), is(ACCOUNT_NUMBER));
         assertThat(foundPayer.get("bank_account_sort_code"), is(SORT_CODE));
-        assertThat(foundPayer.get("address_line1"), is(ADDRESS_LINE_1));
-        assertThat(foundPayer.get("address_line2"), is(ADDRESS_LINE_2));
-        assertThat(foundPayer.get("address_postcode"), is(ADDRESS_POSTCODE));
-        assertThat(foundPayer.get("address_city"), is(ADDRESS_CITY));
-        assertThat(foundPayer.get("address_country"), is(ADDRESS_COUNTRY));
         assertThat((Timestamp) foundPayer.get("created_date"), isDate(CREATED_DATE));
     }
 
@@ -107,11 +91,6 @@ public class PayerDaoIT {
         assertThat(payer.getAccountRequiresAuthorisation(), is(ACCOUNT_REQUIRES_AUTHORISATION));
         assertThat(payer.getAccountNumber(), is(ACCOUNT_NUMBER));
         assertThat(payer.getSortCode(), is(SORT_CODE));
-        assertThat(payer.getAddressLine1(), is(ADDRESS_LINE_1));
-        assertThat(payer.getAddressLine2(), is(ADDRESS_LINE_2));
-        assertThat(payer.getAddressPostcode(), is(ADDRESS_POSTCODE));
-        assertThat(payer.getAddressCity(), is(ADDRESS_CITY));
-        assertThat(payer.getAddressCountry(), is(ADDRESS_COUNTRY));
         assertThat(payer.getCreatedDate(), is(CREATED_DATE));
     }
 
@@ -133,11 +112,6 @@ public class PayerDaoIT {
         assertThat(payer.getAccountRequiresAuthorisation(), is(ACCOUNT_REQUIRES_AUTHORISATION));
         assertThat(payer.getAccountNumber(), is(ACCOUNT_NUMBER));
         assertThat(payer.getSortCode(), is(SORT_CODE));
-        assertThat(payer.getAddressLine1(), is(ADDRESS_LINE_1));
-        assertThat(payer.getAddressLine2(), is(ADDRESS_LINE_2));
-        assertThat(payer.getAddressPostcode(), is(ADDRESS_POSTCODE));
-        assertThat(payer.getAddressCity(), is(ADDRESS_CITY));
-        assertThat(payer.getAddressCountry(), is(ADDRESS_COUNTRY));
         assertThat(payer.getCreatedDate(), is(CREATED_DATE));
     }
 
@@ -159,11 +133,6 @@ public class PayerDaoIT {
         assertThat(payer.getAccountRequiresAuthorisation(), is(ACCOUNT_REQUIRES_AUTHORISATION));
         assertThat(payer.getAccountNumber(), is(ACCOUNT_NUMBER));
         assertThat(payer.getSortCode(), is(SORT_CODE));
-        assertThat(payer.getAddressLine1(), is(ADDRESS_LINE_1));
-        assertThat(payer.getAddressLine2(), is(ADDRESS_LINE_2));
-        assertThat(payer.getAddressPostcode(), is(ADDRESS_POSTCODE));
-        assertThat(payer.getAddressCity(), is(ADDRESS_CITY));
-        assertThat(payer.getAddressCountry(), is(ADDRESS_COUNTRY));
         assertThat(payer.getCreatedDate(), is(CREATED_DATE));
     }
 
@@ -189,11 +158,6 @@ public class PayerDaoIT {
                 .withEmail(newEmail)
                 .withAccountRequiresAuthorisation(newRequiresAuthorisation)
                 .withAccountNumberLastTwoDigits("21")
-                .withAddressLine1(ADDRESS_LINE_1)
-                .withAddressLine2(ADDRESS_LINE_2)
-                .withAddressCity(ADDRESS_CITY)
-                .withAddressPostcode(ADDRESS_POSTCODE)
-                .withAddressCountry(ADDRESS_COUNTRY)
                 .withExternalId("this_should_not_be_updated")
                 .withCreatedDate(ZonedDateTime.now())
                 .toEntity();
@@ -207,11 +171,6 @@ public class PayerDaoIT {
         assertThat(payerAfterUpdate.get("bank_account_requires_authorisation"), is(newRequiresAuthorisation));
         assertThat(payerAfterUpdate.get("bank_account_number"), is(newAccountNumber));
         assertThat(payerAfterUpdate.get("bank_account_sort_code"), is(newSortCode));
-        assertThat(payerAfterUpdate.get("address_line1"), is(ADDRESS_LINE_1));
-        assertThat(payerAfterUpdate.get("address_line2"), is(ADDRESS_LINE_2));
-        assertThat(payerAfterUpdate.get("address_postcode"), is(ADDRESS_POSTCODE));
-        assertThat(payerAfterUpdate.get("address_city"), is(ADDRESS_CITY));
-        assertThat(payerAfterUpdate.get("address_country"), is(ADDRESS_COUNTRY));
 
         // These properties should not be updated
         assertThat(payerAfterUpdate.get("id"), is(testPayer.getId()));

--- a/src/test/java/uk/gov/pay/directdebit/payers/fixtures/PayerFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/fixtures/PayerFixture.java
@@ -21,11 +21,6 @@ public class PayerFixture implements DbFixture<PayerFixture, Payer> {
     private String accountNumber = RandomStringUtils.randomNumeric(8);
     private String accountNumberLastTwoDigits = accountNumber.substring(accountNumber.length() - 2);
     private boolean accountRequiresAuthorisation = true;
-    private String addressLine1 = RandomStringUtils.randomAlphanumeric(10);
-    private String addressLine2 = RandomStringUtils.randomAlphanumeric(10);
-    private String addressPostcode = RandomStringUtils.randomAlphanumeric(6);
-    private String addressCity = RandomStringUtils.randomAlphabetic(10);
-    private String addressCountry = RandomStringUtils.randomAlphabetic(10);
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
 
     private PayerFixture() {
@@ -80,31 +75,6 @@ public class PayerFixture implements DbFixture<PayerFixture, Payer> {
         return this;
     }
 
-    public PayerFixture withAddressLine1(String addressLine1) {
-        this.addressLine1 = addressLine1;
-        return this;
-    }
-
-    public PayerFixture withAddressLine2(String addressLine2) {
-        this.addressLine2 = addressLine2;
-        return this;
-    }
-
-    public PayerFixture withAddressPostcode(String addressPostcode) {
-        this.addressPostcode = addressPostcode;
-        return this;
-    }
-
-    public PayerFixture withAddressCity(String addressCity) {
-        this.addressCity = addressCity;
-        return this;
-    }
-
-    public PayerFixture withAddressCountry(String addressCountry) {
-        this.addressCountry = addressCountry;
-        return this;
-    }
-
     public PayerFixture withCreatedDate(ZonedDateTime createdDate) {
         this.createdDate = createdDate;
         return this;
@@ -146,26 +116,6 @@ public class PayerFixture implements DbFixture<PayerFixture, Payer> {
         return accountNumber;
     }
 
-    public String getAddressLine1() {
-        return addressLine1;
-    }
-
-    public String getAddressLine2() {
-        return addressLine2;
-    }
-
-    public String getAddressPostcode() {
-        return addressPostcode;
-    }
-
-    public String getAddressCity() {
-        return addressCity;
-    }
-
-    public String getAddressCountry() {
-        return addressCountry;
-    }
-
     public ZonedDateTime getCreatedDate() {
         return createdDate;
     }
@@ -185,14 +135,9 @@ public class PayerFixture implements DbFixture<PayerFixture, Payer> {
                                 "        bank_account_requires_authorisation,\n" +
                                 "        bank_account_number,\n" +
                                 "        bank_account_sort_code,\n" +
-                                "        address_line1,\n" +
-                                "        address_line2,\n" +
-                                "        address_postcode,\n" +
-                                "        address_city,\n" +
-                                "        address_country,\n" +
                                 "        created_date\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
                         id,
                         paymentRequestId,
                         externalId,
@@ -202,11 +147,6 @@ public class PayerFixture implements DbFixture<PayerFixture, Payer> {
                         accountRequiresAuthorisation,
                         accountNumber,
                         sortCode,
-                        addressLine1,
-                        addressLine2,
-                        addressPostcode,
-                        addressCity,
-                        addressCountry,
                         Timestamp.from(createdDate.toInstant())
                 )
         );
@@ -215,7 +155,7 @@ public class PayerFixture implements DbFixture<PayerFixture, Payer> {
 
     @Override
     public Payer toEntity() {
-        return new Payer(id, paymentRequestId, externalId, name, email, sortCode, accountNumber, accountNumberLastTwoDigits, accountRequiresAuthorisation, addressLine1, addressLine2, addressPostcode, addressCity, addressCountry, createdDate);
+        return new Payer(id, paymentRequestId, externalId, name, email, sortCode, accountNumber, accountNumberLastTwoDigits, accountRequiresAuthorisation, createdDate);
     }
 
     private String generateEmail() {

--- a/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
@@ -38,13 +38,9 @@ import uk.gov.pay.directdebit.payments.model.PaymentState;
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
 public class PayerResourceIT {
     private final static String ACCOUNT_NUMBER_KEY = "account_number";
-    private final static String SORTCODE_KEY = "sort_code";
+    private final static String SORT_CODE_KEY = "sort_code";
     private final static String NAME_KEY = "account_holder_name";
     private final static String EMAIL_KEY = "email";
-    private final static String ADDRESS_LINE1_KEY = "address_line1";
-    private final static String ADDRESS_CITY_KEY = "city";
-    private final static String ADDRESS_COUNTRY_KEY = "country_code";
-    private final static String ADDRESS_POSTCODE_KEY = "postcode";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @DropwizardTestContext
@@ -81,38 +77,7 @@ public class PayerResourceIT {
         insertTransactionFixtureWith(SANDBOX);
         String putBody = OBJECT_MAPPER.writeValueAsString(ImmutableMap.builder()
                 .put(ACCOUNT_NUMBER_KEY, payerFixture.getAccountNumber())
-                .put(SORTCODE_KEY, payerFixture.getSortCode())
-                .put(NAME_KEY, payerFixture.getName())
-                .put(EMAIL_KEY, payerFixture.getEmail())
-                .put(ADDRESS_LINE1_KEY, payerFixture.getAddressLine1())
-                .put(ADDRESS_CITY_KEY, payerFixture.getAddressCity())
-                .put(ADDRESS_COUNTRY_KEY, payerFixture.getAddressCountry())
-                .put(ADDRESS_POSTCODE_KEY, payerFixture.getAddressPostcode())
-                .build());
-
-        ValidatableResponse response = givenSetup()
-                .body(putBody)
-                .put(requestPath)
-                .then()
-                .statusCode(Response.Status.CREATED.getStatusCode());
-
-        Map<String, Object> createdPayer = testContext.getDatabaseTestHelper().getPayerByPaymentRequestExternalId(testPaymentRequest.getExternalId());
-        String createdPayerExternalId = (String) createdPayer.get("external_id");
-        String documentLocation = expectedPayerRequestLocationFor(testPaymentRequest.getExternalId(), createdPayerExternalId);
-
-        response
-                .header("Location", is(documentLocation))
-                .body("payer_external_id", is(createdPayerExternalId))
-                .contentType(JSON);
-    }
-
-    @Test
-    public void shouldCreateAPayer_withoutAddress() throws JsonProcessingException {
-        createGatewayAccountWithPaymentRequestAndRequestPath(SANDBOX);
-        insertTransactionFixtureWith(SANDBOX);
-        String putBody = OBJECT_MAPPER.writeValueAsString(ImmutableMap.builder()
-                .put(ACCOUNT_NUMBER_KEY, payerFixture.getAccountNumber())
-                .put(SORTCODE_KEY, payerFixture.getSortCode())
+                .put(SORT_CODE_KEY, payerFixture.getSortCode())
                 .put(NAME_KEY, payerFixture.getName())
                 .put(EMAIL_KEY, payerFixture.getEmail())
                 .build());
@@ -142,13 +107,9 @@ public class PayerResourceIT {
                 .replace("{paymentRequestExternalId}", testPaymentRequest.getExternalId());
         String putBody = OBJECT_MAPPER.writeValueAsString(ImmutableMap.builder()
                 .put(ACCOUNT_NUMBER_KEY, payerFixture.getAccountNumber())
-                .put(SORTCODE_KEY, payerFixture.getSortCode())
+                .put(SORT_CODE_KEY, payerFixture.getSortCode())
                 .put(NAME_KEY, payerFixture.getName())
                 .put(EMAIL_KEY, payerFixture.getEmail())
-                .put(ADDRESS_LINE1_KEY, payerFixture.getAddressLine1())
-                .put(ADDRESS_CITY_KEY, payerFixture.getAddressCity())
-                .put(ADDRESS_COUNTRY_KEY, payerFixture.getAddressCountry())
-                .put(ADDRESS_POSTCODE_KEY, payerFixture.getAddressPostcode())
                 .build());
 
         ValidatableResponse response = givenSetup()
@@ -178,7 +139,7 @@ public class PayerResourceIT {
     public void shouldReturn400IfMandatoryFieldsMissing() throws JsonProcessingException {
         createGatewayAccountWithPaymentRequestAndRequestPath(SANDBOX);
         String putBody = OBJECT_MAPPER.writeValueAsString(ImmutableMap.builder()
-                .put(SORTCODE_KEY, payerFixture.getSortCode())
+                .put(SORT_CODE_KEY, payerFixture.getSortCode())
                 .put(NAME_KEY, payerFixture.getName())
                 .put(EMAIL_KEY, payerFixture.getEmail())
                 .build());

--- a/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
@@ -51,15 +51,10 @@ public class PayerResourceIT {
     public WireMockRule wireMockRule = new WireMockRule(10107);
 
     private GatewayAccountFixture testGatewayAccount;
+    private PayerFixture payerFixture = aPayerFixture().withAccountNumber("12345678");
     private PaymentRequestFixture testPaymentRequest;
-    private PayerFixture payerFixture;
 
     String requestPath;
-
-    @Before
-    public void setUp() {
-        payerFixture = aPayerFixture().withAccountNumber("12345678");
-    }
 
     private TransactionFixture insertTransactionFixtureWith(PaymentProvider paymentProvider) {
         return  aTransactionFixture()

--- a/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
@@ -98,7 +98,7 @@ public class PayerResourceIT {
         createGatewayAccountWithPaymentRequestAndRequestPath(GOCARDLESS);
         insertTransactionFixtureWith(GOCARDLESS);
         String requestPath = "/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/payers"
-                .replace("{accountId}", testGatewayAccount.getId().toString())
+                .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace("{paymentRequestExternalId}", testPaymentRequest.getExternalId());
         String putBody = OBJECT_MAPPER.writeValueAsString(ImmutableMap.builder()
                 .put(ACCOUNT_NUMBER_KEY, payerFixture.getAccountNumber())
@@ -125,7 +125,7 @@ public class PayerResourceIT {
 
     private String expectedPayerRequestLocationFor(String paymentRequestExternalId, String payerExternalId) {
         return "http://localhost:" + testContext.getPort() + "/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/payers/{payerExternalId}"
-                .replace("{accountId}", testGatewayAccount.getId().toString())
+                .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace("{paymentRequestExternalId}", paymentRequestExternalId)
                 .replace("{payerExternalId}", payerExternalId);
     }
@@ -161,7 +161,7 @@ public class PayerResourceIT {
                 .withGatewayAccountId(testGatewayAccount.getId())
                 .insert(testContext.getJdbi());
         requestPath = "/v1/api/accounts/{accountId}/payment-requests/{paymentRequestExternalId}/payers"
-                .replace("{accountId}", testGatewayAccount.getId().toString())
+                .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace("{paymentRequestExternalId}", testPaymentRequest.getExternalId());
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payers/services/PayerServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/services/PayerServiceTest.java
@@ -2,8 +2,6 @@ package uk.gov.pay.directdebit.payers.services;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/TransactionDaoIT.java
@@ -1,6 +1,16 @@
 package uk.gov.pay.directdebit.payments.dao;
 
-import liquibase.exception.LiquibaseException;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.aPaymentRequestFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
+import static uk.gov.pay.directdebit.tokens.fixtures.TokenFixture.aTokenFixture;
+import static uk.gov.pay.directdebit.util.NumberMatcher.isNumber;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,19 +27,6 @@ import uk.gov.pay.directdebit.payments.model.PaymentRequest;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.tokens.fixtures.TokenFixture;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
-import static uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture.aPaymentRequestFixture;
-import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
-import static uk.gov.pay.directdebit.tokens.fixtures.TokenFixture.aTokenFixture;
-import static uk.gov.pay.directdebit.util.NumberMatcher.isNumber;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
@@ -48,7 +45,7 @@ public class TransactionDaoIT {
     private TransactionFixture testTransaction;
 
     @Before
-    public void setup() throws IOException, LiquibaseException {
+    public void setup() {
         transactionDao = testContext.getJdbi().onDemand(TransactionDao.class);
         this.testGatewayAccount = aGatewayAccountFixture().insert(testContext.getJdbi());
         this.testPaymentRequest = generateNewPaymentRequestFixture(testGatewayAccount.getId());

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
@@ -182,6 +182,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 paymentRequestDescription,
                 paymentRequestReference,
                 paymentRequestExternalId,
+                null,
                 ZonedDateTime.now(ZoneOffset.UTC)
         );
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentRequestResourceIT.java
@@ -33,6 +33,7 @@ import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
@@ -46,7 +47,6 @@ public class PaymentRequestResourceIT {
     private static final String FRONTEND_CARD_DETAILS_URL = "/secure";
     private static final String JSON_AMOUNT_KEY = "amount";
     private static final String JSON_REFERENCE_KEY = "reference";
-    private static final String JSON_PAYER_KEY = "payer";
     private static final String JSON_DESCRIPTION_KEY = "description";
     private static final String JSON_GATEWAY_ACC_KEY = "gateway_account_id";
     private static final String JSON_RETURN_URL_KEY = "return_url";
@@ -203,8 +203,10 @@ public class PaymentRequestResourceIT {
 
         String accountExternalId = testGatewayAccount.getExternalId();
 
+        PayerFixture payerFixture = PayerFixture.aPayerFixture();
         PaymentRequestFixture paymentRequestFixture = PaymentRequestFixture.aPaymentRequestFixture()
                 .withGatewayAccountId(testGatewayAccount.getId())
+                .withPayerFixture(payerFixture)
                 .insert(testContext.getJdbi());
 
         TransactionFixture transactionFixture = TransactionFixture.aTransactionFixture()
@@ -229,7 +231,10 @@ public class PaymentRequestResourceIT {
                 .body(JSON_DESCRIPTION_KEY, is(paymentRequestFixture.getDescription()))
                 .body(JSON_STATE_KEY, is(transactionFixture.getState().toExternal().getState()))
                 .body(JSON_RETURN_URL_KEY, is(paymentRequestFixture.getReturnUrl()))
-                .body(JSON_PAYER_KEY, is(nullValue()));
+                .body("payer.payer_external_id", is(payerFixture.getExternalId()))
+                .body("payer.account_holder_name", is(payerFixture.getName()))
+                .body("payer.email", is(payerFixture.getEmail()))
+                .body("payer.requires_authorisation", is(payerFixture.getAccountRequiresAuthorisation()));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
@@ -249,7 +249,27 @@ public class PaymentRequestServiceTest {
     }
 
     @Test
-    public void getPaymentWithExternalId_shouldPopulateAFrontendResponse_ifPaymentWithNoPayerExists() {
+    public void getPaymentWithExternalId_shouldPopulateAFrontendResponse_ifPaymentHasAPayer() {
+        when(mockedPaymentRequestDao.findByExternalIdAndAccountExternalId(paymentRequest.getExternalId(), gatewayAccountFixture.getExternalId())).thenReturn(Optional.of(paymentRequest.toEntity()));
+        when(mockTransactionService.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequest.getExternalId(), gatewayAccountFixture.getExternalId()))
+                .thenReturn(transactionFixture.toEntity());
+
+        PaymentRequestFrontendResponse response = service.getPaymentWithExternalId(gatewayAccountFixture.getExternalId(), paymentRequest.getExternalId());
+        assertThat(response.getAmount().toString(), is(AMOUNT));
+        assertThat(response.getDescription(), is(DESCRIPTION));
+        assertThat(response.getReference(), is(REFERENCE));
+        assertThat(response.getReturnUrl(), is(RETURN_URL));
+        assertThat(response.getGatewayAccountId(), is(gatewayAccount.getId()));
+        assertThat(response.getGatewayAccountExternalId(), is(gatewayAccount.getExternalId()));
+        assertThat(response.getPaymentExternalId(), is(paymentRequest.getExternalId()));
+        assertThat(response.getPayerDetails().getEmail(), is(payerFixture.getEmail()));
+        assertThat(response.getPayerDetails().getName(), is(payerFixture.getName()));
+        assertThat(response.getPayerDetails().getExternalId(), is(payerFixture.getExternalId()));
+        assertThat(response.getPayerDetails().getAccountRequiresAuthorisation(), is(payerFixture.getAccountRequiresAuthorisation()));
+    }
+    
+    @Test
+    public void getPaymentWithExternalId_shouldPopulateAFrontendResponse_ifPaymentHasNoPayer() {
         PaymentRequestFixture paymentRequest = aPaymentRequestFixture()
                 .withAmount(Long.parseLong(AMOUNT))
                 .withDescription(DESCRIPTION)
@@ -269,26 +289,6 @@ public class PaymentRequestServiceTest {
         assertThat(response.getGatewayAccountExternalId(), is(gatewayAccount.getExternalId()));
         assertThat(response.getPaymentExternalId(), is(paymentRequest.getExternalId()));
         assertThat(response.getPayerDetails(), is(nullValue()));
-    }
-
-    @Test
-    public void getPaymentWithExternalId_shouldPopulateAFrontendResponse_ifPaymentExists_withoutPayer() {
-        when(mockedPaymentRequestDao.findByExternalIdAndAccountExternalId(paymentRequest.getExternalId(), gatewayAccountFixture.getExternalId())).thenReturn(Optional.of(paymentRequest.toEntity()));
-        when(mockTransactionService.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequest.getExternalId(), gatewayAccountFixture.getExternalId()))
-                .thenReturn(transactionFixture.toEntity());
-
-        PaymentRequestFrontendResponse response = service.getPaymentWithExternalId(gatewayAccountFixture.getExternalId(), paymentRequest.getExternalId());
-        assertThat(response.getAmount().toString(), is(AMOUNT));
-        assertThat(response.getDescription(), is(DESCRIPTION));
-        assertThat(response.getReference(), is(REFERENCE));
-        assertThat(response.getReturnUrl(), is(RETURN_URL));
-        assertThat(response.getGatewayAccountId(), is(gatewayAccount.getId()));
-        assertThat(response.getGatewayAccountExternalId(), is(gatewayAccount.getExternalId()));
-        assertThat(response.getPaymentExternalId(), is(paymentRequest.getExternalId()));
-        assertThat(response.getPayerDetails().getEmail(), is(payerFixture.getEmail()));
-        assertThat(response.getPayerDetails().getName(), is(payerFixture.getName()));
-        assertThat(response.getPayerDetails().getExternalId(), is(payerFixture.getExternalId()));
-        assertThat(response.getPayerDetails().getAccountRequiresAuthorisation(), is(payerFixture.getAccountRequiresAuthorisation()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentRequestServiceTest.java
@@ -15,7 +15,9 @@ import uk.gov.pay.directdebit.app.config.LinksConfig;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountNotFoundException;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payments.api.PaymentRequestFrontendResponse;
+import uk.gov.pay.directdebit.payments.api.PaymentRequestFrontendResponse.PayerDetails;
 import uk.gov.pay.directdebit.payments.api.PaymentRequestResponse;
 import uk.gov.pay.directdebit.payments.dao.PaymentRequestDao;
 import uk.gov.pay.directdebit.payments.exception.PaymentRequestNotFoundException;
@@ -71,11 +73,13 @@ public class PaymentRequestServiceTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().withExternalId(GATEWAY_ACCOUNT_EXTERNAL_ID);
+    private PayerFixture payerFixture = PayerFixture.aPayerFixture();
     private GatewayAccount gatewayAccount = gatewayAccountFixture.toEntity();
     private PaymentRequestFixture paymentRequest = aPaymentRequestFixture()
             .withAmount(Long.parseLong(AMOUNT))
             .withDescription(DESCRIPTION)
             .withReference(REFERENCE)
+            .withPayerFixture(payerFixture)
             .withReturnUrl(RETURN_URL)
             .withGatewayAccountId(gatewayAccountFixture.getId());
     private TransactionFixture transactionFixture = aTransactionFixture()
@@ -245,7 +249,13 @@ public class PaymentRequestServiceTest {
     }
 
     @Test
-    public void getPaymentWithExternalId_shouldPopulateAFrontendResponse_ifPaymentExists() {
+    public void getPaymentWithExternalId_shouldPopulateAFrontendResponse_ifPaymentWithNoPayerExists() {
+        PaymentRequestFixture paymentRequest = aPaymentRequestFixture()
+                .withAmount(Long.parseLong(AMOUNT))
+                .withDescription(DESCRIPTION)
+                .withReference(REFERENCE)
+                .withReturnUrl(RETURN_URL)
+                .withGatewayAccountId(gatewayAccountFixture.getId());
         when(mockedPaymentRequestDao.findByExternalIdAndAccountExternalId(paymentRequest.getExternalId(), gatewayAccountFixture.getExternalId())).thenReturn(Optional.of(paymentRequest.toEntity()));
         when(mockTransactionService.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequest.getExternalId(), gatewayAccountFixture.getExternalId()))
                 .thenReturn(transactionFixture.toEntity());
@@ -258,10 +268,28 @@ public class PaymentRequestServiceTest {
         assertThat(response.getGatewayAccountId(), is(gatewayAccount.getId()));
         assertThat(response.getGatewayAccountExternalId(), is(gatewayAccount.getExternalId()));
         assertThat(response.getPaymentExternalId(), is(paymentRequest.getExternalId()));
-        assertThat(response.getPayer(), is(nullValue())
-        );
+        assertThat(response.getPayerDetails(), is(nullValue()));
     }
 
+    @Test
+    public void getPaymentWithExternalId_shouldPopulateAFrontendResponse_ifPaymentExists_withoutPayer() {
+        when(mockedPaymentRequestDao.findByExternalIdAndAccountExternalId(paymentRequest.getExternalId(), gatewayAccountFixture.getExternalId())).thenReturn(Optional.of(paymentRequest.toEntity()));
+        when(mockTransactionService.findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequest.getExternalId(), gatewayAccountFixture.getExternalId()))
+                .thenReturn(transactionFixture.toEntity());
+
+        PaymentRequestFrontendResponse response = service.getPaymentWithExternalId(gatewayAccountFixture.getExternalId(), paymentRequest.getExternalId());
+        assertThat(response.getAmount().toString(), is(AMOUNT));
+        assertThat(response.getDescription(), is(DESCRIPTION));
+        assertThat(response.getReference(), is(REFERENCE));
+        assertThat(response.getReturnUrl(), is(RETURN_URL));
+        assertThat(response.getGatewayAccountId(), is(gatewayAccount.getId()));
+        assertThat(response.getGatewayAccountExternalId(), is(gatewayAccount.getExternalId()));
+        assertThat(response.getPaymentExternalId(), is(paymentRequest.getExternalId()));
+        assertThat(response.getPayerDetails().getEmail(), is(payerFixture.getEmail()));
+        assertThat(response.getPayerDetails().getName(), is(payerFixture.getName()));
+        assertThat(response.getPayerDetails().getExternalId(), is(payerFixture.getExternalId()));
+        assertThat(response.getPayerDetails().getAccountRequiresAuthorisation(), is(payerFixture.getAccountRequiresAuthorisation()));
+    }
 
     @Test
     public void getPaymentWithExternalIdForFrontend_shouldThrow_ifPaymentDoesNotExist()  {

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/TransactionServiceTest.java
@@ -218,35 +218,7 @@ public class TransactionServiceTest {
         assertThat(newTransaction.getState(), is(SUBMITTING_DIRECT_DEBIT_PAYMENT));
         verify(mockedPaymentRequestEventService).registerDirectDebitConfirmedEventFor(newTransaction);
     }
-
-
-
-    @Test
-    public void findTransactionForToken_shouldNotReturnATransactionIfNoTransactionExistsForToken() {
-    public void shouldUpdateTransactionStateAndRegisterEventWhenConfirmingDDDetails() {
-        Transaction transaction = TransactionFixture
-                .aTransactionFixture()
-                .withState(AWAITING_DIRECT_DEBIT_DETAILS)
-                .toEntity();
-        when(mockedTransactionDao.findTransactionForExternalIdAndGatewayAccountExternalId(transaction.getPaymentRequest().getExternalId(), gatewayAccountFixture.getExternalId()))
-                .thenReturn(Optional.of(transaction));
-        Transaction newTransaction = service.confirmedDirectDebitDetailsFor(gatewayAccountFixture.getExternalId(), transaction.getPaymentRequest().getExternalId());
-        PaymentRequest paymentRequest = newTransaction.getPaymentRequest();
-        assertThat(newTransaction.getId(), is(notNullValue()));
-        assertThat(paymentRequest.getId(), is(transaction.getPaymentRequest().getId()));
-        assertThat(paymentRequest.getExternalId(), is(transaction.getPaymentRequest().getExternalId()));
-        assertThat(paymentRequest.getReturnUrl(), is(transaction.getPaymentRequest().getReturnUrl()));
-        assertThat(newTransaction.getGatewayAccountId(), is(transaction.getGatewayAccountId()));
-        assertThat(newTransaction.getGatewayAccountExternalId(), is(transaction.getGatewayAccountExternalId()));
-        assertThat(paymentRequest.getDescription(), is(transaction.getPaymentRequest().getDescription()));
-        assertThat(paymentRequest.getReference(), is(transaction.getPaymentRequest().getReference()));
-        assertThat(newTransaction.getAmount(), is(transaction.getAmount()));
-        assertThat(newTransaction.getType(), is(transaction.getType()));
-        assertThat(newTransaction.getState(), is(SUBMITTING_DIRECT_DEBIT_PAYMENT));
-        verify(mockedPaymentRequestEventService).registerDirectDebitConfirmedEventFor(newTransaction);
-    }
-
-
+    
 
     @Test
     public void findTransactionForToken_shouldNotReturnATransactionIfNoTransactionExistsForToken() {
@@ -290,7 +262,7 @@ public class TransactionServiceTest {
 
         Transaction transaction = TransactionFixture
                 .aTransactionFixture()
-                .withState(PaymentState.AWAITING_DIRECT_DEBIT_DETAILS)
+                .withState(AWAITING_DIRECT_DEBIT_DETAILS)
                 .toEntity();
 
         service.paymentCancelledFor(transaction);

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -62,7 +62,7 @@ database:
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s
 
-  # the SQL joinQuery to run when validating a connection's liveness
+  # the SQL query to run when validating a connection's liveness
   validationQuery: "SELECT '1'"
 
   # the timeout before a connection validation queries fail

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -62,7 +62,7 @@ database:
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s
 
-  # the SQL query to run when validating a connection's liveness
+  # the SQL joinQuery to run when validating a connection's liveness
   validationQuery: "SELECT '1'"
 
   # the timeout before a connection validation queries fail


### PR DESCRIPTION
## WHAT
- We now allow the user to click a link to go back to the enter direct debit details from the confirm page. This means that we need a way to populate the form with payer details. We have all the info in connector, but we have to surface Payer in the Payment Request.

- Removing address from payer, as we are not collecting it. I think it's ok to keep it in the db for now, as it is nullable.

- Removing the `convert internal id to string` function in the GatewayAccountParamConverter, as now frontend has access to all of payment request's data and uses the external gateway account id everywhere.

(for frontend, see https://github.com/alphagov/pay-direct-debit-frontend/pull/76 )