### PR TITLE
PP-3701 Create payer using confirm details from frontend

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/validation/FieldSizeValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/validation/FieldSizeValidator.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.directdebit.common.validation;
+
+public enum FieldSizeValidator {
+    ACCOUNT_NUMBER(new FieldSize(6, 8)),
+    SORT_CODE(new FieldSize(6, 6));
+
+    private FieldSize fieldSize;
+
+    FieldSizeValidator(FieldSize fieldSize) {
+        this.fieldSize = fieldSize;
+    }
+
+    public FieldSize getFieldSize() {
+        return fieldSize;
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/ConfirmDetailsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/ConfirmDetailsRequestValidator.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.directdebit.mandate.api;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.function.Function;
+import uk.gov.pay.directdebit.common.validation.ApiValidation;
+import uk.gov.pay.directdebit.common.validation.FieldSize;
+import uk.gov.pay.directdebit.common.validation.FieldSizeValidator;
+
+public class ConfirmDetailsRequestValidator extends ApiValidation {
+
+    public final static String SORTCODE_KEY = "sort_code";
+    public final static String ACCOUNT_NUMBER_KEY = "account_number";
+
+    private final static Map<String, Function<String, Boolean>> validators =
+            ImmutableMap.<String, Function<String, Boolean>>builder()
+                    .put(SORTCODE_KEY, ApiValidation::isNumeric)
+                    .put(ACCOUNT_NUMBER_KEY, ApiValidation::isNumeric)
+                    .build();
+
+    private final static String[] requiredFields = {SORTCODE_KEY, ACCOUNT_NUMBER_KEY};
+
+    private final static Map<String, FieldSize> fieldSizes =
+            ImmutableMap.<String, FieldSize>builder()
+                    .put(SORTCODE_KEY, FieldSizeValidator.SORT_CODE.getFieldSize())
+                    .put(ACCOUNT_NUMBER_KEY, FieldSizeValidator.ACCOUNT_NUMBER.getFieldSize())
+                    .build();
+
+    public ConfirmDetailsRequestValidator() {
+        super(requiredFields, fieldSizes, validators);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/ConfirmationDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/ConfirmationDetails.java
@@ -5,25 +5,30 @@ import uk.gov.pay.directdebit.payments.model.Transaction;
 public class ConfirmationDetails {
     private Transaction transaction;
     private Mandate mandate;
+    private String accountNumber;
+    private String sortCode;
 
-    public ConfirmationDetails(Transaction transaction, Mandate mandate) {
+    public ConfirmationDetails(Transaction transaction,
+            Mandate mandate, String accountNumber, String sortCode) {
         this.transaction = transaction;
         this.mandate = mandate;
+        this.accountNumber = accountNumber;
+        this.sortCode = sortCode;
     }
 
     public Transaction getTransaction() {
         return transaction;
     }
 
-    public void setTransaction(Transaction transaction) {
-        this.transaction = transaction;
-    }
-
     public Mandate getMandate() {
         return mandate;
     }
 
-    public void setMandate(Mandate mandate) {
-        this.mandate = mandate;
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public String getSortCode() {
+        return sortCode;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerValidator.java
@@ -6,6 +6,7 @@ import uk.gov.pay.directdebit.common.validation.FieldSize;
 
 import java.util.Map;
 import java.util.function.Function;
+import uk.gov.pay.directdebit.common.validation.FieldSizeValidator;
 
 public class CreatePayerValidator extends ApiValidation {
 
@@ -34,8 +35,8 @@ public class CreatePayerValidator extends ApiValidation {
 
     private final static Map<String, FieldSize> fieldSizes =
             ImmutableMap.<String, FieldSize>builder()
-                    .put(SORTCODE_KEY, new FieldSize(6, 6))
-                    .put(ACCOUNT_NUMBER_KEY, new FieldSize(6, 8))
+                    .put(SORTCODE_KEY, FieldSizeValidator.SORT_CODE.getFieldSize())
+                    .put(ACCOUNT_NUMBER_KEY, FieldSizeValidator.ACCOUNT_NUMBER.getFieldSize())
                     .put(EMAIL_KEY, new FieldSize(0, 254))
                     .build();
 

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/Payer.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/Payer.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.payers.model;
 
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 
 import java.time.ZoneOffset;
@@ -12,9 +13,9 @@ public class Payer {
     private String name;
     private String email;
     private String sortCode;
+    private String accountNumber;
     private String accountNumberLastTwoDigits;
     private boolean accountRequiresAuthorisation;
-    private String accountNumber;
     private String addressLine1;
     private String addressLine2;
     private String addressPostcode;

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitPaymentProvider.java
@@ -9,5 +9,5 @@ public interface DirectDebitPaymentProvider {
 
     Payer createPayer(String paymentRequestExternalId, GatewayAccount gatewayAccount, Map<String, String> createPayerRequest);
 
-    void confirm(String paymentRequestExternalId, GatewayAccount gatewayAccount);
+    void confirm(String paymentRequestExternalId, GatewayAccount gatewayAccount, Map<String, String> confirmDetailsRequest);
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
@@ -36,9 +36,9 @@ public class SandboxService implements DirectDebitPaymentProvider {
     }
 
     @Override
-    public void confirm(String paymentRequestExternalId, GatewayAccount gatewayAccount) {
+    public void confirm(String paymentRequestExternalId, GatewayAccount gatewayAccount, Map<String, String> confirmDetailsRequest) {
         LOGGER.info("Confirming payment for SANDBOX, payment with id: {}", paymentRequestExternalId);
-        ConfirmationDetails confirmationDetails = paymentConfirmService.confirm(gatewayAccount.getExternalId(), paymentRequestExternalId);
+        ConfirmationDetails confirmationDetails = paymentConfirmService.confirm(gatewayAccount.getExternalId(), paymentRequestExternalId, confirmDetailsRequest);
         Payer payer = payerService.getPayerFor(confirmationDetails.getTransaction());
         transactionService.paymentSubmittedToProviderFor(confirmationDetails.getTransaction(), payer, LocalDate.now().plusDays(DAYS_TO_COLLECTION));
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/api/ConfirmDetailsRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/api/ConfirmDetailsRequestValidatorTest.java
@@ -1,0 +1,197 @@
+package uk.gov.pay.directdebit.mandate.api;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.directdebit.common.exception.validation.InvalidFieldsException;
+import uk.gov.pay.directdebit.common.exception.validation.InvalidSizeFieldsException;
+import uk.gov.pay.directdebit.common.exception.validation.MissingMandatoryFieldsException;
+
+public class ConfirmDetailsRequestValidatorTest {
+
+    private ConfirmDetailsRequestValidator confirmDetailsRequestValidator = new ConfirmDetailsRequestValidator();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldNotThrowExceptionIfRequestIsValid() {
+        Map<String, String> request = ImmutableMap
+                .of("sort_code", "123456", "account_number", "12345678");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowMissingMandatoryFieldsExceptionIfMissingRequiredFields() {
+        Map<String, String> request = new HashMap<>();
+        thrown.expect(MissingMandatoryFieldsException.class);
+        thrown.expectMessage("Field(s) missing: [" +
+                ConfirmDetailsRequestValidator.SORTCODE_KEY + ", " +
+                ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowMissingMandatoryFieldsExceptionIfSortCodeFieldIsMissing() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
+        request.remove(ConfirmDetailsRequestValidator.SORTCODE_KEY);
+        thrown.expect(MissingMandatoryFieldsException.class);
+        thrown.expectMessage("Field(s) missing: [" +
+                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidSizeFieldsExceptionIfSortCodeFieldIsEmptyString() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "");
+        thrown.expect(InvalidSizeFieldsException.class);
+        thrown.expectMessage("The size of a field(s) is invalid: [" +
+                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidFieldsExceptionIfSortCodeFieldIsNull() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, null);
+        thrown.expect(InvalidFieldsException.class);
+        thrown.expectMessage("Field(s) are invalid: [" +
+                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidFieldsExceptionIfSortCodeFieldIsNonNumeric() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123abc");
+        thrown.expect(InvalidFieldsException.class);
+        thrown.expectMessage("Field(s) are invalid: [" +
+                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidSizeFieldsExceptionIfSortCodeFieldHasInvalidSize() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123");
+        thrown.expect(InvalidSizeFieldsException.class);
+        thrown.expectMessage("The size of a field(s) is invalid: [" +
+                ConfirmDetailsRequestValidator.SORTCODE_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldNotThrowExceptionIfSortCodeStartsWithZeros() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "012345");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowMissingMandatoryFieldsExceptionIfAccountNumberFieldIsMissing() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.remove(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY);
+        thrown.expect(MissingMandatoryFieldsException.class);
+        thrown.expectMessage("Field(s) missing: [" +
+                ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidSizeFieldsExceptionIfAccountNumberFieldIsEmptyString() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "");
+        thrown.expect(InvalidSizeFieldsException.class);
+        thrown.expectMessage("The size of a field(s) is invalid: [" +
+                ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidFieldsExceptionIfAccountNumberFieldIsNull() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, null);
+        thrown.expect(InvalidFieldsException.class);
+        thrown.expectMessage("Field(s) are invalid: [" +
+                ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidFieldsExceptionIfAccountNumberFieldIsNonNumeric() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "12345abc");
+        thrown.expect(InvalidFieldsException.class);
+        thrown.expectMessage("Field(s) are invalid: [" +
+                ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidSizeFieldsExceptionIfAccountNumberFieldHasInvalidSizeBelowMinimum() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "12345");
+        thrown.expect(InvalidSizeFieldsException.class);
+        thrown.expectMessage("The size of a field(s) is invalid: [" +
+                ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowInvalidSizeFieldsExceptionIfAccountNumberFieldHasInvalidSizeAboveMaximum() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "123456780");
+        thrown.expect(InvalidSizeFieldsException.class);
+        thrown.expectMessage("The size of a field(s) is invalid: [" +
+                ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY +
+                "]");
+        thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
+        confirmDetailsRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldNotThrowExceptionIfAccountNumberStartsWithZeros() {
+        Map<String, String> request = new HashMap<>();
+        request.put(ConfirmDetailsRequestValidator.SORTCODE_KEY, "123456");
+        request.put(ConfirmDetailsRequestValidator.ACCOUNT_NUMBER_KEY, "01234567");
+        confirmDetailsRequestValidator.validate(request);
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.payers.dao;
 
-import liquibase.exception.LiquibaseException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,7 +13,6 @@ import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentRequestFixture;
 
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.Map;

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/ConfirmationDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/ConfirmationDetailsFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.payments.fixtures;
 
+import org.apache.commons.lang.RandomStringUtils;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.ConfirmationDetails;
 
@@ -7,6 +8,8 @@ public class ConfirmationDetailsFixture {
 
     private TransactionFixture transactionFixture;
     private MandateFixture mandateFixture;
+    private String sortCode = RandomStringUtils.randomNumeric(6);
+    private String accountNumber = RandomStringUtils.randomNumeric(8);
 
     private ConfirmationDetailsFixture() { }
 
@@ -24,8 +27,18 @@ public class ConfirmationDetailsFixture {
         return this;
     }
 
+    public ConfirmationDetailsFixture withSortCode(String sortCode) {
+        this.sortCode = sortCode;
+        return this;
+    }
+
+    public ConfirmationDetailsFixture withAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+        return this;
+    }
+
     public ConfirmationDetails build() {
-        return new ConfirmationDetails(transactionFixture.toEntity(), mandateFixture.toEntity());
+        return new ConfirmationDetails(transactionFixture.toEntity(), mandateFixture.toEntity(), accountNumber, sortCode);
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
@@ -60,11 +60,12 @@ public class SandboxServiceTest {
                 .build();
         Transaction transaction = confirmationDetails.getTransaction();
 
-        when(mockedPaymentConfirmService.confirm(gatewayAccount.getExternalId(), paymentRequestExternalId))
+        Map<String, String> details = ImmutableMap.of("sort_code", "123456", "account_number", "12345678");
+        when(mockedPaymentConfirmService.confirm(gatewayAccount.getExternalId(), paymentRequestExternalId, details))
                 .thenReturn(confirmationDetails);
         when(mockedPayerService.getPayerFor(transaction)).thenReturn(payer);
 
-        service.confirm(paymentRequestExternalId, gatewayAccount);
+        service.confirm(paymentRequestExternalId, gatewayAccount, details);
         verify(mockedTransactionService).paymentSubmittedToProviderFor(transaction, payer, LocalDate.now().plusDays(4));
     }
 }


### PR DESCRIPTION
## WHAT
https://github.com/alphagov/pay-direct-debit-frontend/pull/77 is now sending confirmation details (account number and sort code) to connector. 
This PR creates a payer using those details. This is because with the new call layout we don't have non-hashed details anymore when creating a bank account in our payment provider.
