### PR TITLE
PP-3714 Catch exceptions from gc when validating bank account details

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
@@ -90,8 +90,13 @@ public class GoCardlessService implements DirectDebitPaymentProvider {
     public BankAccountValidationResponse validate(String paymentRequestExternalId, Map<String, String> bankAccountDetailsRequest) {
         BankAccountDetails bankAccountDetails = bankAccountDetailsParser.parse(bankAccountDetailsRequest);
         LOGGER.info("Attempting to call gocardless to validate a bank account, payment request id: {}", paymentRequestExternalId);
-        GoCardlessBankAccountLookup lookup = goCardlessClientFacade.validate(bankAccountDetails);
-        return new BankAccountValidationResponse(lookup.isBacs(), lookup.getBankName());
+        try {
+            GoCardlessBankAccountLookup lookup = goCardlessClientFacade.validate(bankAccountDetails);
+            return new BankAccountValidationResponse(lookup.isBacs(), lookup.getBankName());
+        } catch (Exception exc) {
+            LOGGER.warn("Exception while validating bank account details in gocardless, message: {}", exc.getMessage());
+            return new BankAccountValidationResponse(false);
+        }
     }
 
     


### PR DESCRIPTION
## WHAT
GC might throw an exception if the validation fails. We need to handle this properly instead of relying on the exception mapper to catch it and return an internal server error.
