### PR TITLE
PP-3700 Prevent payment request event duplication

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -105,8 +105,9 @@ public class TransactionService {
 
     public Transaction confirmedDirectDebitDetailsFor(String accountExternalId, String paymentRequestExternalId) {
         Transaction transaction = findTransactionForExternalIdAndGatewayAccountExternalId(paymentRequestExternalId, accountExternalId);
+        transaction = updateStateFor(transaction, DIRECT_DEBIT_DETAILS_CONFIRMED);
         paymentRequestEventService.registerDirectDebitConfirmedEventFor(transaction);
-        return updateStateFor(transaction, DIRECT_DEBIT_DETAILS_CONFIRMED);
+        return transaction;
     }
 
     public Transaction payerCreatedFor(Transaction transaction) {
@@ -165,7 +166,7 @@ public class TransactionService {
         PaymentState newState = getStates().getNextStateForEvent(transaction.getState(),
                 event);
         transactionDao.updateState(transaction.getId(), newState);
-        LOGGER.info("Updating transaction {} - from {} to {}",
+        LOGGER.info("Updated transaction {} - from {} to {}",
                 transaction.getPaymentRequest().getExternalId(),
                 transaction.getState(),
                 newState);


### PR DESCRIPTION
- When submitting the same direct debit details several times for the
same `payment_request`, we were registering state transition events even
if the transition was invalid. This action didn't change the status of
the transaction, but was registering an event. Not it doesn't.
- A tiny spelling correction as the action happened before that line
