### PR TITLE
Use branch of pay-jenkins-library that does not run dd tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
   }
 
   libraries {
-    lib("pay-jenkins-library@master")
+    lib("pay-jenkins-library@no_dd_tests")
   }
 
   environment {


### PR DESCRIPTION
Silvia is in the mioddle of orchestrating the apocalypse, and does not
need these pesky tests in her way. This points the Jenkinsfile at a branch
of pay-jenkins-library that has no-ops for dd tests.