### PR TITLE
PP-3776 Upgrade GoCardless SDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <jackson.version>2.9.5</jackson.version>
         <guice.version>4.2.0</guice.version>
         <guava.version>24.1-jre</guava.version>
-        <gocardless.version>3.4.0</gocardless.version>
+        <gocardless.version>3.5.1</gocardless.version>
         <hamcrest.version>1.3</hamcrest.version>
         <rest-assured.version>3.0.7</rest-assured.version>
         <mockito.version>2.18.0</mockito.version>


### PR DESCRIPTION
## WHAT

Upgrade GoCardless SDK version from `3.4.0` to `3.5.1`
