### PR TITLE
PP-3676 Cleanup migrations after updating the data model

### DIFF
--- a/src/main/resources/migrations/00023_drop_table_payment_requests.sql
+++ b/src/main/resources/migrations/00023_drop_table_payment_requests.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:drop_table-payment-requests
+DROP TABLE payment_requests;
+--rollback CREATE TABLE payment_requests

--- a/src/main/resources/migrations/00024_alter_table_mandate_payer_id.sql
+++ b/src/main/resources/migrations/00024_alter_table_mandate_payer_id.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-mandates-payer-id
+ALTER TABLE mandates DROP COLUMN payer_id;
+--rollback ALTER TABLE mandates ADD COLUMN payer_id BIGINT NOT NULL;

--- a/src/main/resources/migrations/00025_alter_table_transactions.sql
+++ b/src/main/resources/migrations/00025_alter_table_transactions.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-transactions-payment-request-id
+ALTER TABLE transactions DROP COLUMN payment_request_id;
+--rollback ADD COLUMN payment_request_id BIGINT NOT NULL;
+
+--changeset uk.gov.pay:alter_table-transactions-type
+ALTER TABLE transactions ALTER COLUMN type DROP NOT NULL;
+--rollback ALTER COLUMN type NOT NULL;
+

--- a/src/main/resources/migrations/00026_alter_table_payers_payment_request_id.sql.sql
+++ b/src/main/resources/migrations/00026_alter_table_payers_payment_request_id.sql.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-payers-payment-request-id
+ALTER TABLE payers DROP COLUMN payment_request_id;
+--rollback ADD COLUMN payment_request_id BIGINT NOT NULL;

--- a/src/main/resources/migrations/00027_create_table_events.sql
+++ b/src/main/resources/migrations/00027_create_table_events.sql
@@ -1,0 +1,21 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-events
+CREATE TABLE events (
+    id BIGSERIAL PRIMARY KEY,
+    mandate_id BIGINT NOT NULL,
+    transaction_id BIGINT NOT NULL,
+    event_type TEXT NOT NULL,
+    event TEXT NOT NULL,
+    event_date TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'utc') NOT NULL,
+    version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table events;
+
+--changeset uk.gov.pay:add_events_transactions_fk
+ALTER TABLE events ADD CONSTRAINT events_transactions_fk FOREIGN KEY (transaction_id) REFERENCES transactions (id);
+--rollback drop constraint events_transactions_fk;
+
+--changeset uk.gov.pay:add_events_mandates_fk
+ALTER TABLE events ADD CONSTRAINT events_mandates_fk FOREIGN KEY (mandate_id) REFERENCES mandates (id);
+--rollback drop constraint events_mandates_fk;

--- a/src/main/resources/migrations/00028_alter_table_tokens.sql
+++ b/src/main/resources/migrations/00028_alter_table_tokens.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-tokens-request-id
+ALTER TABLE tokens DROP COLUMN payment_request_id;
+--rollback ADD COLUMN payment_request_id BIGINT NOT NULL;

--- a/src/main/resources/migrations/00029_alter_table_gocardless_events.sql
+++ b/src/main/resources/migrations/00029_alter_table_gocardless_events.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-gocardless-events-rename-event-id
+ALTER TABLE gocardless_events RENAME COLUMN event_id TO gocardless_event_id;
+--rollback ALTER TABLE gocardless_events RENAME COLUMN gocardless_event_id TO event_id;
+
+--changeset uk.gov.pay:alter_table-gocardless-events-rename-payment-request-events-id
+ALTER TABLE gocardless_events RENAME COLUMN payment_request_events_id TO event_id;
+--rollback ALTER TABLE gocardless_events RENAME COLUMN event_id TO payment_request_events_id;


### PR DESCRIPTION
## WHAT
Cleaning up migrations from the previous humongous PR. 

- Dropping `payment_requests`
- Removing `payment_request_id` from all the tables
- Removing NOT NULL constraint for `type` from transaction. This column will be completely dropped later on, because all transactions are charges for the foreseeable future.
- Renaming `payment_request_events` to `events`
- In the `gocardless_events` table, `event_id` is our own internal and `gocardless_event_id` is the GoCardless one