### PR TITLE
PP-3676 Add internal_event_id in gocardless events pointing to the new events table

### DIFF
--- a/src/main/resources/migrations/00029_alter_table_gocardless_events.sql
+++ b/src/main/resources/migrations/00029_alter_table_gocardless_events.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-gocardless-events-internal-id
+ALTER TABLE gocardless_events ADD COLUMN internal_event_id BIGINT;
+--rollback DROP COLUMN internal_event_id;
+
+--changeset uk.gov.pay:add_gocardless-events_events_fk
+ALTER TABLE gocardless_events ADD CONSTRAINT gocardless_events_events_fk FOREIGN KEY (internal_event_id) REFERENCES events (id);
+--rollback drop constraint transactions_mandates_fk;
+
+--changeset uk.gov.pay:alter_table-gocardless-events-payment-request-events-fk
+ALTER TABLE gocardless_events DROP CONSTRAINT payment_request_events_gocardless_events_fk
+--rollback add constraint payment_request_events_gocardless_events_fk FOREIGN KEY (payment_request_events_id) REFERENCES events (id);


### PR DESCRIPTION
## WHAT
- Add `internal_event_id` to gocardless event and make it reference the new `events` table. `payment_request_event_id` will be dropped in the next PR