### PR TITLE
PP-3676 Use the new table events instead of payment_requests_events

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/EventDao.java
@@ -16,10 +16,10 @@ import static uk.gov.pay.directdebit.payments.model.Event.Type;
 @RegisterRowMapper(EventMapper.class)
 public interface EventDao {
 
-    @SqlUpdate("INSERT INTO payment_request_events(mandate_id, transaction_id, event_type, event, event_date) VALUES (:mandateId, :transactionId, :eventType, :event, :eventDate)")
+    @SqlUpdate("INSERT INTO events(mandate_id, transaction_id, event_type, event, event_date) VALUES (:mandateId, :transactionId, :eventType, :event, :eventDate)")
     @GetGeneratedKeys
     Long insert(@BindBean Event event);
 
-    @SqlQuery("SELECT * FROM payment_request_events e WHERE e.mandate_id = :mandateId and e.event_type = :eventType and e.event = :event")
+    @SqlQuery("SELECT * FROM events e WHERE e.mandate_id = :mandateId and e.event_type = :eventType and e.event = :event")
     Optional<Event> findByMandateIdAndEvent(@Bind("mandateId") Long mandateId, @Bind("eventType") Type eventType, @Bind("event") SupportedEvent event);
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/GoCardlessEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/GoCardlessEventDao.java
@@ -11,10 +11,10 @@ import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 @RegisterRowMapper(GoCardlessEventMapper.class)
 public interface GoCardlessEventDao {
 
-    @SqlUpdate("INSERT INTO gocardless_events(payment_request_events_id, event_id, action, resource_type, json, created_at) VALUES (:eventId, :goCardlessEventId, :action, :resourceType, CAST(:json as jsonb), :createdAt)")
+    @SqlUpdate("INSERT INTO gocardless_events(internal_event_id, event_id, action, resource_type, json, created_at) VALUES (:eventId, :goCardlessEventId, :action, :resourceType, CAST(:json as jsonb), :createdAt)")
     @GetGeneratedKeys
     Long insert(@BindBean GoCardlessEvent goCardlessEvent);
     
-    @SqlUpdate("UPDATE gocardless_events t SET payment_request_events_id = :eventId WHERE t.id = :id")
+    @SqlUpdate("UPDATE gocardless_events t SET internal_event_id = :eventId WHERE t.id = :id")
     int updateEventId(@Bind("id") Long id, @Bind("eventId") Long eventId);
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
@@ -62,9 +62,6 @@ public interface TransactionDao {
     @SqlQuery(joinQuery + " WHERE t.external_id = :externalId")
     Optional<Transaction> findByExternalId(@Bind("externalId") String externalId);
 
-    @SqlQuery(joinQuery + " JOIN tokens k ON k.mandate_id = m.id WHERE k.secure_redirect_token = :tokenId")
-    Optional<Transaction> findByTokenId(@Bind("tokenId") String tokenId);
-
     @SqlQuery(joinQuery + " WHERE t.state = :state AND g.payment_provider = :paymentProvider")
     List<Transaction> findAllByPaymentStateAndProvider(@Bind("state") PaymentState paymentState, @Bind("paymentProvider") PaymentProvider paymentProvider);
 
@@ -74,7 +71,7 @@ public interface TransactionDao {
     @SqlUpdate("UPDATE transactions t SET state = :state WHERE t.id = :id")
     int updateState(@Bind("id") Long id, @Bind("state") PaymentState paymentState);
 
-    @SqlUpdate("INSERT INTO transactions(mandate_id, external_id, amount, state, type, description, reference, created_date) VALUES (:mandate.id, :externalId, :amount, :state, 'charge',:description, :reference, :createdDate)")
+    @SqlUpdate("INSERT INTO transactions(mandate_id, external_id, amount, state, description, reference, created_date) VALUES (:mandate.id, :externalId, :amount, :state, :description, :reference, :createdDate)")
     @GetGeneratedKeys
     Long insert(@BindBean Transaction transaction);
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessEventDaoIT.java
@@ -76,7 +76,7 @@ public class GoCardlessEventDaoIT {
         Long id = goCardlessEventDao.insert(goCardlessEvent);
         Map<String, Object> foundGoCardlessEvent = testContext.getDatabaseTestHelper().getGoCardlessEventById(id);
         assertThat(foundGoCardlessEvent.get("id"), is(id));
-        assertThat(foundGoCardlessEvent.get("payment_request_events_id"), is(EVENT_ID));
+        assertThat(foundGoCardlessEvent.get("internal_event_id"), is(EVENT_ID));
         assertThat(foundGoCardlessEvent.get("event_id"), is(GOCARDLESS_EVENT_ID));
         assertThat(foundGoCardlessEvent.get("action"), is(GOCARDLESS_ACTION));
         assertThat(foundGoCardlessEvent.get("resource_type"), is(GOCARDLESS_RESOURCE_TYPE.toString()));
@@ -95,7 +95,7 @@ public class GoCardlessEventDaoIT {
         int numOfUpdatedEvents = goCardlessEventDao.updateEventId(id, newEventId);
         Map<String, Object> eventAfterUpdate = testContext.getDatabaseTestHelper().getGoCardlessEventById(id);
         assertThat(numOfUpdatedEvents, is(1));
-        assertThat(eventAfterUpdate.get("payment_request_events_id"), is(newEventId));
+        assertThat(eventAfterUpdate.get("internal_event_id"), is(newEventId));
         assertThat(eventAfterUpdate.get("event_id"), is(GOCARDLESS_EVENT_ID));
         assertThat(eventAfterUpdate.get("action"), is(GOCARDLESS_ACTION));
         assertThat(eventAfterUpdate.get("resource_type"), is(GOCARDLESS_RESOURCE_TYPE.toString()));

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/EventFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/EventFixture.java
@@ -87,7 +87,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
         jdbi.withHandle(h ->
                 h.execute(
                         "INSERT INTO" +
-                                "    payment_request_events(\n" +
+                                "    events(\n" +
                                 "        id,\n" +
                                 "        mandate_id,\n" +
                                 "        transaction_id,\n" +

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GoCardlessEventFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GoCardlessEventFixture.java
@@ -108,7 +108,7 @@ public class GoCardlessEventFixture implements DbFixture<GoCardlessEventFixture,
                         "INSERT INTO" +
                                 "    gocardless_events(\n" +
                                 "        id,\n" +
-                                "        payment_request_events_id,\n" +
+                                "        internal_event_id,\n" +
                                 "        event_id,\n" +
                                 "        action,\n" +
                                 "        resource_type,\n" +

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/TransactionFixture.java
@@ -114,10 +114,9 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "        state,\n" +
                                 "        reference,\n" +
                                 "        description,\n" +
-                                "        type,\n" +
                                 "        created_date\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?)\n",
                         id,
                         mandateFixture.getId(),
                         externalId,
@@ -125,7 +124,6 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                         state,
                         reference,
                         description,
-                        "charge",
                         createdDate
                 )
         );

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -47,7 +47,7 @@ public class DatabaseTestHelper {
     public Map<String, Object> getEventById(Long id) {
         return jdbi.withHandle(handle ->
                 handle
-                        .createQuery("SELECT * from payment_request_events p WHERE p.id = :id")
+                        .createQuery("SELECT * from events p WHERE p.id = :id")
                         .bind("id", id)
                         .mapToMap()
                         .findFirst()


### PR DESCRIPTION
## WHAT
- Use the new table `events` instead of `payment_requests_events`
- Stop using type in transactions
- Both `type` and the table `payment_requests_events` will be dropped in the next pr
