### PR TITLE
PP-3676 Drop type from transactions and drop payment_request_events

### DIFF
--- a/src/main/resources/migrations/00030_alter_table_transactions_drop_type.sql
+++ b/src/main/resources/migrations/00030_alter_table_transactions_drop_type.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-transactions-drop-type
+ALTER TABLE transactions DROP COLUMN type;
+--rollback ADD COLUMN type TEXT;

--- a/src/main/resources/migrations/00031_drop_table_payment_request_events.sql
+++ b/src/main/resources/migrations/00031_drop_table_payment_request_events.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:drop-table-payment-request-events
+DROP TABLE payment_request_events;
+--rollback CREATE TABLE payment_request_events


### PR DESCRIPTION
## WHAT
- transaction type is not used (it's always charge) 
- we are using a table called `events` now, so `payment_request_events` can be dropped