### PR TITLE
PP-3676 Update mandates table schema to handle references

### DIFF
--- a/src/main/resources/migrations/00032_alter_table_mandates_add_column_mandate_reference.sql
+++ b/src/main/resources/migrations/00032_alter_table_mandates_add_column_mandate_reference.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-mandates-mandate_reference
+ALTER TABLE mandates ADD COLUMN mandate_reference VARCHAR(18);
+--rollback ALTER TABLE mandates DROP COLUMN mandate_reference;

--- a/src/main/resources/migrations/00033_alter_table_mandates_add_column_service_reference.sql
+++ b/src/main/resources/migrations/00033_alter_table_mandates_add_column_service_reference.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-mandates-service_reference
+ALTER TABLE mandates ADD COLUMN service_reference VARCHAR(255);
+--rollback ALTER TABLE mandates DROP COLUMN service_reference;


### PR DESCRIPTION
## WHAT

- Added `mandate_reference` column which will replace `reference` column in the next releases.
  This is necessary to distinguish between mandate reference and the future service reference.
- Added `service_reference` column which will hold optional service reference value.

with @georgeracu
