### PR TITLE
PP-3677 Make sure mandate has the right gateway account id for pact

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -31,7 +31,7 @@ public class PublicApiContractTest {
     public static Target target;
 
     private GatewayAccountFixture testGatewayAccount = GatewayAccountFixture.aGatewayAccountFixture();
-    private MandateFixture testMandate = MandateFixture.aMandateFixture();
+    private MandateFixture testMandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(testGatewayAccount);
 
     @BeforeClass
     public static void setUpService() {


### PR DESCRIPTION
## WHAT
Mandate needs to link to a valid gateway account.
