### PR TITLE
PP-3677 Make sure mandate has the right gateway account id for pact, for real. Again.

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -43,8 +43,9 @@ public class PublicApiContractTest {
         testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
     }
 
-    @State("a mandate with external id exists")
-    public void aMandateWithExternalIdExists(Map<String, String> params) {
+    @State("a gateway account with external id and a mandate with external id exist")
+    public void aGatewayAccountWithExternalIdAndAMandateWithExternalIdExist(Map<String, String> params) {
+        testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
         testMandate.withGatewayAccountFixture(testGatewayAccount).withExternalId(params.get("mandate_id")).insert(app.getTestContext().getJdbi());
     }
 }


### PR DESCRIPTION
## WHAT
It looks like pact does not hold state, so to make sure we insert both gateway accounts and mandates it might be necessary to add a state that contains both.