### PR TITLE
PP-3679 Refactor search transactions to include mandate_id

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewListResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewListResponse.java
@@ -3,12 +3,16 @@ package uk.gov.pay.directdebit.payments.api;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.directdebit.payments.links.Link;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class PaymentViewListResponse {
 
-    @JsonProperty("charge_id")
+    @JsonProperty("transaction_id")
     private String transactionId;
 
     @JsonProperty
@@ -31,6 +35,9 @@ public class PaymentViewListResponse {
 
     @JsonProperty
     private ExternalPaymentState state;
+    
+    @JsonProperty
+    private List<Link> links = new ArrayList<>();
 
 
     public PaymentViewListResponse(String transactionId,
@@ -81,6 +88,13 @@ public class PaymentViewListResponse {
 
     public ExternalPaymentState getState() {
         return state;
+    }
+
+    public List<Link> getLinks() { return links; }
+    
+    public PaymentViewListResponse withLink(Link link) {
+        this.links.add(link);
+        return this;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResponse.java
@@ -3,6 +3,8 @@ package uk.gov.pay.directdebit.payments.api;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.directdebit.payments.model.ViewPaginationBuilder;
+
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -11,20 +13,22 @@ public class PaymentViewResponse {
 
     @JsonProperty("gateway_account_external_id")
     private String gatewayExternalId;
-
+    @JsonProperty("total")
+    private Long total;
+    @JsonProperty("count")
+    private Long count;
     @JsonProperty("page")
     private Long page;
-
-    @JsonProperty("display_size")
-    private Long displaySize;
-
-    @JsonProperty("payment_views")
+    @JsonProperty("results")
     private List<PaymentViewListResponse> paymentViewResponses;
+    @JsonProperty("_links")
+    private ViewPaginationBuilder paginationBuilder;
 
-    public PaymentViewResponse(String gatewayExternalId, Long page, Long displaySize, List<PaymentViewListResponse> paymentViewResponses) {
+    public PaymentViewResponse(String gatewayExternalId, Long total, Long page, List<PaymentViewListResponse> paymentViewResponses) {
         this.gatewayExternalId = gatewayExternalId;
+        this.total = total;
+        this.count = (long)paymentViewResponses.size();
         this.page = page;
-        this.displaySize = displaySize;
         this.paymentViewResponses = paymentViewResponses;
     }
 
@@ -32,11 +36,24 @@ public class PaymentViewResponse {
         return paymentViewResponses;
     }
 
+    public Long getTotal() { return total; }
+
+    public Long getCount() { return count; }
+
+    public Long getPage() { return page; }
+
+    public ViewPaginationBuilder getPaginationBuilder() { return paginationBuilder; }
+
+    public PaymentViewResponse withPaginationBuilder(ViewPaginationBuilder paginationBuilder) {
+        this.paginationBuilder = paginationBuilder;
+        return this;
+    }
+
     @Override
     public int hashCode() {
         int result = gatewayExternalId.hashCode();
         result = 31 * result + page.hashCode();
-        result = 31 * result + displaySize.hashCode();
+        result = 31 * result + total.hashCode();
         return result;
     }
 
@@ -45,7 +62,7 @@ public class PaymentViewResponse {
         return "TransactionResponse{" +
                 " gatewayExternalId='" + gatewayExternalId + '\n' +
                 ", page='" + page + '\'' +
-                ", displaySize=" + displaySize + '\'' +
+                ", total=" + total + '\'' +
                 ", paymentViewResponses='" + paymentViewResponses.toString() + '\'' +
                 "}";
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidator.java
@@ -22,11 +22,17 @@ public class PaymentViewValidator {
     public PaymentViewSearchParams validateParams(PaymentViewSearchParams searchParams) {
         PaginationParams paginationParams = validatePagination(searchParams);
         SearchDateParams searchDateParams = validateSearchDate(searchParams);
-        return new PaymentViewSearchParams(searchParams.getGatewayExternalId(), 
-                searchParams.getPage() == null ? DEFAULT_PAGE_NUMBER : searchParams.getPage(),
-                searchParams.getDisplaySize() == null ? MAX_PAGE_NUMBER : searchParams.getDisplaySize(),
-                searchParams.getFromDateString(), searchParams.getToDateString(), searchParams.getEmail(), searchParams.getReference(),
-                searchParams.getAmount(), paginationParams, searchDateParams);
+        return new PaymentViewSearchParams(searchParams.getGatewayExternalId())
+                .withPage(searchParams.getPage() == null ? DEFAULT_PAGE_NUMBER : searchParams.getPage())        
+                .withDisplaySize(searchParams.getDisplaySize() == null ? MAX_PAGE_NUMBER : searchParams.getDisplaySize())
+                .withFromDateString(searchParams.getFromDateString())
+                .withToDateString(searchParams.getToDateString())
+                .withEmail(searchParams.getEmail())
+                .withReference(searchParams.getReference())
+                .withAmount(searchParams.getAmount())
+                .withMandateId(searchParams.getMandateId())
+                .withPaginationParams(paginationParams)
+                .withSearchDateParams(searchDateParams);
     }
 
     private PaginationParams validatePagination(PaymentViewSearchParams searchParams) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
@@ -2,6 +2,8 @@ package uk.gov.pay.directdebit.payments.dao;
 
 import java.util.List;
 import javax.inject.Inject;
+import javax.ws.rs.QueryParam;
+
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
 import uk.gov.pay.directdebit.payments.dao.mapper.PaymentViewMapper;
@@ -11,7 +13,7 @@ import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
 public class PaymentViewDao {
     private final Jdbi jdbi;
     private final String QUERY_STRING = "SELECT ga.external_id as gateway_external_id, " +
-            "t.external_id AS payment_request_id, " +
+            "t.external_id AS transaction_external_id, " +
             "t.amount AS amount, " +
             "t.reference AS reference, " +
             "t.description AS description, " +
@@ -22,10 +24,18 @@ public class PaymentViewDao {
             "FROM transactions t " +
             "INNER JOIN mandates m ON t.mandate_id = m.id " +
             "INNER JOIN gateway_accounts ga ON ga.id = m.gateway_account_id " +
-            "LEFT JOIN payers pa ON t.mandate_id = pa.mandate_id " +
+            "INNER JOIN payers pa ON m.id = pa.mandate_id " +
             "WHERE ga.external_id = :gatewayAccountExternalId " +
             ":searchExtraFields " +
             "ORDER BY t.id DESC OFFSET :offset LIMIT :limit";
+
+    private final String COUNT_QUERY_STRING = "SELECT count(*) " +
+            "FROM transactions t " +
+            "INNER JOIN mandates m ON t.mandate_id = m.id " +
+            "INNER JOIN gateway_accounts ga ON ga.id = m.gateway_account_id " +
+            "INNER JOIN payers pa ON m.id = pa.mandate_id " +
+            "WHERE ga.external_id = :gatewayAccountExternalId " +
+            ":searchExtraFields ";
 
     @Inject
     public PaymentViewDao(Jdbi jdbi) {
@@ -40,6 +50,17 @@ public class PaymentViewDao {
             return query
                     .map(new PaymentViewMapper())
                     .list();
+        });
+    }
+    
+    public Long getPaymentViewCount(PaymentViewSearchParams searchParams) {
+        String searchExtraFields = searchParams.generateQuery();
+        return jdbi.withHandle(handle -> {
+            Query query = handle.createQuery(COUNT_QUERY_STRING.replace(":searchExtraFields", searchExtraFields));
+            searchParams.getQueryMap().forEach(query::bind);
+            return query
+                    .mapTo(Long.class)
+                    .findOnly();
         });
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentViewMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentViewMapper.java
@@ -12,7 +12,7 @@ import uk.gov.pay.directdebit.payments.model.PaymentView;
 public class PaymentViewMapper implements RowMapper<PaymentView> {
 
     private static final String GATEWAY_EXTERNAL_ACCOUNT_ID_COLUMN = "gateway_external_id";
-    private static final String PAYMENT_REQUEST_EXTERNAL_ID_COLUMN = "payment_request_id";
+    private static final String TRANSACTION_EXTERNAL_ID_COLUMN = "transaction_external_id";
     private static final String AMOUNT_COLUMN = "amount";
     private static final String REFERENCE_COLUMN = "reference";
     private static final String DESCRIPTION_COLUMN = "description";
@@ -25,7 +25,7 @@ public class PaymentViewMapper implements RowMapper<PaymentView> {
     public PaymentView map(ResultSet rs, StatementContext ctx) throws SQLException {
         return new PaymentView(
                 rs.getString(GATEWAY_EXTERNAL_ACCOUNT_ID_COLUMN),
-                rs.getString(PAYMENT_REQUEST_EXTERNAL_ID_COLUMN),
+                rs.getString(TRANSACTION_EXTERNAL_ID_COLUMN),
                 rs.getLong(AMOUNT_COLUMN),
                 rs.getString(REFERENCE_COLUMN),
                 rs.getString(DESCRIPTION_COLUMN),

--- a/src/main/java/uk/gov/pay/directdebit/payments/links/Link.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/links/Link.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.directdebit.payments.links;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public class Link {
+
+    private String href;
+    private String method;
+    private String rel;
+    
+    private Link(String href, String method, String rel) {
+        this.href = href;
+        this.method = method;
+        this.rel = rel;
+    }
+
+    public Link() {}
+
+    public String getHref() {
+        return href;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getRel() { return rel; }
+
+    public static Link ofValue(String href, String method, String rel) {
+        return new Link(href, method, rel);
+    }
+
+    @Override
+    public String toString() {
+        return "Link{" +
+                "rel='" + rel + '\'' +
+                ", href='" + href + '\'' +
+                ", method='" + method + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Link link = (Link) o;
+        return Objects.equals(href, link.href) &&
+                Objects.equals(method, link.method);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(href, method);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/ViewPaginationBuilder.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/ViewPaginationBuilder.java
@@ -1,0 +1,93 @@
+package uk.gov.pay.directdebit.payments.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.directdebit.payments.api.PaymentViewListResponse;
+import uk.gov.pay.directdebit.payments.links.Link;
+import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
+
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.List;
+
+public class ViewPaginationBuilder {
+
+    private static final String SELF_LINK = "self";
+    private static final String FIRST_LINK = "first_page";
+    private static final String LAST_LINK = "last_page";
+    private static final String PREV_LINK = "prev_page";
+    private static final String NEXT_LINK = "next_page";
+    private PaymentViewSearchParams searchParams;
+    private UriInfo uriInfo;
+    private List<PaymentViewListResponse> viewResponses;
+
+    private Long totalCount;
+    private Long selfPageNum;
+    @JsonProperty(SELF_LINK)
+    private Link selfLink;
+    @JsonProperty(FIRST_LINK)
+    private Link firstLink;
+    @JsonProperty(LAST_LINK)
+    private Link lastLink;
+    @JsonProperty(PREV_LINK)
+    private Link prevLink;
+    @JsonProperty(NEXT_LINK)
+    private Link nextLink;
+
+    public ViewPaginationBuilder(PaymentViewSearchParams searchParams, List<PaymentViewListResponse> chargeResponses, UriInfo uriInfo) {
+        this.searchParams = searchParams;
+        this.viewResponses = chargeResponses;
+        this.uriInfo = uriInfo;
+        selfPageNum = searchParams.getPage();
+    }
+
+    public ViewPaginationBuilder withTotalCount(Long total) {
+        this.totalCount = total;
+        return this;
+    }
+
+    public ViewPaginationBuilder buildResponse() {
+        Long size = searchParams.getDisplaySize();
+        long lastPage = totalCount > 0 ? (totalCount + size - 1) / size : 1;
+        buildLinks(lastPage);
+        
+        return this;
+    }
+
+    public Long getTotalCount() { return totalCount; }
+
+    public Long getSelfPageNum() { return selfPageNum; }
+
+    public Link getSelfLink() { return selfLink; }
+
+    public Link getFirstLink() { return firstLink; }
+
+    public Link getLastLink() { return lastLink; }
+
+    public Link getPrevLink() { return prevLink; }
+
+    public Link getNextLink() { return nextLink; }
+
+    private void buildLinks(long lastPage) {
+        selfLink = Link.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString(), "GET", SELF_LINK);
+        
+        searchParams.withPage(1L);
+        firstLink = Link.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString(), "GET", FIRST_LINK);
+
+        searchParams.withPage(lastPage);
+        lastLink = Link.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString(), "GET", LAST_LINK);
+
+        searchParams.withPage(selfPageNum - 1);
+        prevLink = selfPageNum == 1L ? null : Link.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString(), "GET", PREV_LINK);;
+
+        searchParams.withPage(selfPageNum + 1);
+        nextLink = selfPageNum == lastPage ? null : Link.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString(), "GET", LAST_LINK);;
+    }
+
+    private URI uriWithParams(String params) {
+        URI uri = uriInfo.getBaseUriBuilder()
+                .path(uriInfo.getPath())
+                .replaceQuery(params)
+                .build(searchParams.getGatewayExternalId());
+        return uri;
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
@@ -9,7 +9,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -23,6 +25,7 @@ public class PaymentViewResource {
     private static final String EMAIL_KEY = "email";
     private static final String REFERENCE_KEY = "reference";
     private static final String AMOUNT_KEY = "amount";
+    private static final String MANDATE_ID_KEY = "mandate_id";
     private final PaymentViewService paymentViewService;
 
     @Inject
@@ -31,7 +34,7 @@ public class PaymentViewResource {
     }
 
     @GET
-    @Path("/v1/api/accounts/{accountId}/payment-requests/view")
+    @Path("/v1/api/accounts/{accountId}/transactions/view")
     @Produces(APPLICATION_JSON)
     public Response getPaymentView(
             @PathParam("accountId") String accountExternalId,
@@ -41,17 +44,21 @@ public class PaymentViewResource {
             @QueryParam(TO_DATE_KEY) String toDate,
             @QueryParam(EMAIL_KEY) String email,
             @QueryParam(REFERENCE_KEY) String reference,
-            @QueryParam(AMOUNT_KEY) Long amount){
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(
-                accountExternalId,
-                pageNumber,
-                displaySize,
-                fromDate,
-                toDate,
-                email,
-                reference,
-                amount
-        );
-        return Response.ok().entity(paymentViewService.getPaymentViewResponse(searchParams)).build();
+            @QueryParam(AMOUNT_KEY) Long amount,
+            @QueryParam(MANDATE_ID_KEY) String mandateId,
+            @Context UriInfo uriInfo){
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(accountExternalId)
+                .withPage(pageNumber)
+                .withDisplaySize(displaySize)
+                .withFromDateString(fromDate)
+                .withToDateString(toDate)
+                .withEmail(email)
+                .withReference(reference)
+                .withAmount(amount)
+                .withMandateId(mandateId);
+        
+        return Response.ok().entity(paymentViewService
+                .withUriInfo(uriInfo)
+                .getPaymentViewResponse(searchParams)).build();
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -13,7 +13,9 @@ import org.junit.runner.RunWith;
 import uk.gov.pay.commons.testing.pact.providers.PayPactRunner;
 import uk.gov.pay.directdebit.junit.DropwizardAppWithPostgresRule;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
+import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 
 import java.util.Map;
 
@@ -47,5 +49,19 @@ public class PublicApiContractTest {
     public void aGatewayAccountWithExternalIdAndAMandateWithExternalIdExist(Map<String, String> params) {
         testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
         testMandate.withGatewayAccountFixture(testGatewayAccount).withExternalId(params.get("mandate_id")).insert(app.getTestContext().getJdbi());
+    }
+    
+    @State("three transaction records exist")
+    public void threeTransactionRecordsExist(Map<String, String> params) {
+        testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
+        MandateFixture testMandate = MandateFixture.aMandateFixture()
+                .withGatewayAccountFixture(testGatewayAccount)
+                .withExternalId(params.get("mandate_id"));
+        testMandate.insert(app.getTestContext().getJdbi());
+        PayerFixture testPayer = PayerFixture.aPayerFixture().withMandateId(testMandate.getId());
+        testPayer.insert(app.getTestContext().getJdbi());
+        for (int x = 0; x < 3; x++) {
+            TransactionFixture.aTransactionFixture().withMandateFixture(testMandate).insert(app.getTestContext().getJdbi());
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidatorTest.java
@@ -20,22 +20,23 @@ public class PaymentViewValidatorTest {
 
     @Test
     public void shouldReturnNoErrors_withMinimumParams() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account", 
-                null, null, null, null, null, null, null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account"); 
         validator.validateParams(searchParams);
     }
     
     @Test
     public void shouldReturnNoErrors_withValidPagination() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account",
-                2L, 3L, null, null, null, null, null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(2L)
+                .withDisplaySize(3L);
         validator.validateParams(searchParams);
     }
 
     @Test
     public void shouldReturnAnError_whenPageIsZero() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account", 
-                0L, 256L, null, null, null, null, null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(0L)
+                .withDisplaySize(300L);
         thrown.expect(NegativeSearchParamException.class);
         thrown.expectMessage("Query param 'page' should be a non zero positive integer");
         validator.validateParams(searchParams);
@@ -43,15 +44,16 @@ public class PaymentViewValidatorTest {
 
     @Test
     public void shouldResetDisplaySizeTo500() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account", 
-                2L, 600L, null, null, null, null, null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(2L)
+                .withDisplaySize(600L);
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getPaginationParams().getDisplaySize(), is(500L));
     }
 
     @Test
     public void shouldSetPaginationWithDefaultValues() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account", null, null, null, null,null, null, null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account"); 
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getPaginationParams().getDisplaySize(), is(500L));
         assertThat(searchParams.getPaginationParams().getPageNumber(), is(0L));
@@ -61,14 +63,11 @@ public class PaymentViewValidatorTest {
     public void shouldCorrectlyValidate_toAndFromDate() {
         String fromDate = "2018-05-03T15:00Z";
         String toDate = "2018-05-04T15:00Z";
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account",
-                3L, 
-                256L,
-                fromDate,
-                toDate,
-                null,
-                null,
-                null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(2L)
+                .withDisplaySize(42L)
+                .withFromDateString(fromDate)
+                .withToDateString(toDate);
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getSearchDateParams().getFromDate().toString(), is(fromDate));
         assertThat(searchParams.getSearchDateParams().getToDate().toString(), is(toDate));
@@ -77,14 +76,10 @@ public class PaymentViewValidatorTest {
     @Test 
     public void shouldLeaveToDateNull_whenMissing() {
         String fromDate = "2018-05-03T15:00Z";
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account",
-                3L,
-                256L,
-                fromDate,
-                null,
-                null,
-                null,
-                null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(2L)
+                .withDisplaySize(3L)
+                .withFromDateString(fromDate);
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getSearchDateParams().getFromDate().toString(), is(fromDate));
         assertThat(searchParams.getSearchDateParams().getToDate(), is(nullValue()));
@@ -93,14 +88,10 @@ public class PaymentViewValidatorTest {
     @Test
     public void shouldLeaveFromDateNull_whenMissing() {
         String toDate = "2018-05-04T15:00Z";
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account",
-                3L,
-                256L,
-                null,
-                toDate,
-                null,
-                null,
-                null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(2L)
+                .withDisplaySize(3L)
+                .withToDateString(toDate);
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getSearchDateParams().getFromDate(), is(nullValue()));
         assertThat(searchParams.getSearchDateParams().getToDate().toString(), is(toDate));
@@ -112,14 +103,11 @@ public class PaymentViewValidatorTest {
         String toDate = "2018-05-04T15:00Z";
         thrown.expect(InvalidDateException.class);
         thrown.expectMessage("from_date (2018-05-05T15:00Z) must be earlier then to_date (2018-05-04T15:00Z)");
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account",
-                3L,
-                256L,
-                fromDate,
-                toDate,
-                null,
-                null,
-                null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(2L)
+                .withDisplaySize(3L)
+                .withFromDateString(fromDate)
+                .withToDateString(toDate);
         validator.validateParams(searchParams);
     }
 
@@ -129,14 +117,11 @@ public class PaymentViewValidatorTest {
         String toDate = "2018-05-35T15:00Z";
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input toDate (2018-05-35T15:00Z) is wrong format");
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account",
-                3L,
-                256L,
-                fromDate,
-                toDate,
-                null,
-                null,
-                null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(3L)
+                .withDisplaySize(256L)
+                .withFromDateString(fromDate)
+                .withToDateString(toDate);
         validator.validateParams(searchParams);
     }
 
@@ -146,14 +131,11 @@ public class PaymentViewValidatorTest {
         String toDate = "2018-05-04T15:00Z";
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input fromDate (2018-05-03T15:00Z') is wrong format");
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account",
-                3L,
-                256L,
-                fromDate,
-                toDate,
-                null,
-                null,
-                null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(2L)
+                .withDisplaySize(3L)
+                .withFromDateString(fromDate)
+                .withToDateString(toDate);
         validator.validateParams(searchParams);
     }
 
@@ -163,14 +145,11 @@ public class PaymentViewValidatorTest {
         String toDate = "2018-05-04T15:00Z";
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input fromDate (%2018-05-03T15:00Z) is wrong format");
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account",
-                3L,
-                256L,
-                fromDate,
-                toDate,
-                null,
-                null,
-                null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+                .withPage(2L)
+                .withDisplaySize(3L)
+                .withFromDateString(fromDate)
+                .withToDateString(toDate);
         validator.validateParams(searchParams);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentView;
 import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
@@ -20,7 +21,9 @@ import uk.gov.pay.directdebit.payments.params.SearchDateParams;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
 import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -45,10 +48,10 @@ public class PaymentViewDaoIT {
 
     @Test
     public void shouldReturnAllPaymentViews()  {
-        GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
 
         for (int i = 0; i < 3; i++) {
-            MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+            MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
             aPayerFixture()
                     .withMandateId(mandateFixture.getId())
                     .withName("Joe Bog" + i)
@@ -61,18 +64,20 @@ public class PaymentViewDaoIT {
                     .withAmount(1000L + i)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId(),
-                0L, 100L, null, null, null, null, null, null, searchDateParams);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withPage(0L)
+                .withDisplaySize(100L)
+                .withSearchDateParams(searchDateParams);
         List<PaymentView> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(3));
     }
 
     @Test
     public void shouldReturnOnePaymentViewOnly() {
-        GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
 
         for (int i = 0; i < 3; i++) {
-            MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+            MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
             aPayerFixture()
                     .withMandateId(mandateFixture.getId())
                     .withName("Joe Bog" + i)
@@ -85,26 +90,27 @@ public class PaymentViewDaoIT {
                     .withAmount(1000L + i)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId(),
-                2L, 100L, null, null, null, null, null, null, searchDateParams);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withPage(2L)
+                .withDisplaySize(1L)
+                .withSearchDateParams(searchDateParams);
         List<PaymentView> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
     }
 
     @Test
     public void shouldReturnAnEmptyList_whenNoMatchingGatewayAccounts() throws Exception {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("invalid-external-id",
-                1L, 100L, null, null, null, null, null, null, searchDateParams);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("invalid-external-id");
         List<PaymentView> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.isEmpty(), is(true));
     }
 
     @Test
     public void shouldReturnTwoPaymentView_withFromDateSet() {
-        GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
 
         for (int i = 1; i < 4; i++) {
-            MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+            MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
             aPayerFixture()
                     .withMandateId(mandateFixture.getId())
                     .withName("Joe Bog" + i)
@@ -118,9 +124,11 @@ public class PaymentViewDaoIT {
                     .withAmount(1000L + i)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId(),
-                1L, 100L, zonedDateTime7DaysAgo.toString(), null, null, null, null, null,
-                new SearchDateParams(zonedDateTime7DaysAgo, zonedDateTimeNow));
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withPage(1L)
+                .withDisplaySize(100L)
+                .withFromDateString(zonedDateTime7DaysAgo.toString())
+                .withSearchDateParams(new SearchDateParams(zonedDateTime7DaysAgo, zonedDateTimeNow));
         List<PaymentView> paymentViewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(paymentViewList.size(), is(2));
         assertThat(paymentViewList.get(0).getCreatedDate().isAfter(zonedDateTime7DaysAgo), is(true));
@@ -131,10 +139,10 @@ public class PaymentViewDaoIT {
 
     @Test
     public void shouldReturn2PaymentView_withEmailSet() {
-        GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
         List<String> emailList = Arrays.asList("jane@example.com", "joe.bog@example.com", "jane.bog@example.com", "joe@example.com");
         for (int i = 0; i < 4; i++) {
-            MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+            MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
             aPayerFixture()
                     .withMandateId(mandateFixture.getId())
                     .withEmail(emailList.get(i))
@@ -144,8 +152,8 @@ public class PaymentViewDaoIT {
                     .withMandateFixture(mandateFixture)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId(),
-                0L, 100L, null, null, "bog", null, null, null, searchDateParams);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withEmail("bog");
         List<PaymentView> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(2));
         assertThat(viewList.get(0).getEmail().contains("bog"), is(true));
@@ -154,11 +162,11 @@ public class PaymentViewDaoIT {
 
     @Test
     public void shouldReturn2PaymentView_withReferenceSet() {
-        GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
 
         List<String> referenceList = Arrays.asList("MBKH45", "MBKI19", "MBKH46", "MBKI21");
         for (int i = 0; i < 4; i++) {
-            MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+            MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
             aPayerFixture()
                     .withMandateId(mandateFixture.getId())
                     .insert(testContext.getJdbi());
@@ -169,8 +177,8 @@ public class PaymentViewDaoIT {
                     .withAmount(((long) 200 + i))
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId(),
-                0L, 100L, null, null, null, "bkh", null, null, searchDateParams);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withReference("bkh");
         List<PaymentView> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(2));
         assertThat(viewList.get(0).getReference(), is(referenceList.get(2)));
@@ -178,11 +186,11 @@ public class PaymentViewDaoIT {
     }
 
     @Test
-    public void shouldReturn2PaymentView_withAmountSet() {
-        GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
+    public void shouldReturn1PaymentView_withAmountSet() {
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
 
         for (int i = 0; i < 4; i++) {
-            MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+            MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
             aPayerFixture()
                     .withMandateId(mandateFixture.getId())
                     .insert(testContext.getJdbi());
@@ -193,8 +201,9 @@ public class PaymentViewDaoIT {
                     .withAmount(((long) 200 + i))
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId(),
-                0L, 100L, null, null, null, null, 202L, null, searchDateParams);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withAmount(202L)
+                .withSearchDateParams(searchDateParams);
         List<PaymentView> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
         assertThat(viewList.get(0).getReference(), is("ref2"));
@@ -202,10 +211,13 @@ public class PaymentViewDaoIT {
 
     @Test
     public void shouldReturnOnePaymentViewWhenPaymentCreated() {
-        GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
 
         for (int i = 0; i < 3; i++) {
-            MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+            MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+            aPayerFixture()
+                    .withMandateId(mandateFixture.getId())
+                    .insert(testContext.getJdbi());
             aTransactionFixture()
                     .withId((long) i)
                     .withMandateFixture(mandateFixture)
@@ -214,9 +226,78 @@ public class PaymentViewDaoIT {
                     .withAmount(1000L + i)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId(),
-                2L, 100L, null, null, null, null, null, null, searchDateParams);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withPage(2L)
+                .withDisplaySize(100L)
+                .withSearchDateParams(searchDateParams);
         List<PaymentView> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
+    }
+    
+    @Test
+    public void shouldReturnCount_whenRecordsExist() {
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
+        MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+        aPayerFixture()
+                .withMandateId(mandateFixture.getId())
+                .insert(testContext.getJdbi());
+        for (int i = 0; i < 3; i++) {
+            aTransactionFixture()
+                    .withId((long) i)
+                    .withMandateFixture(mandateFixture)
+                    .withReference("important reference " + i)
+                    .withDescription("description " + i)
+                    .withAmount(1000L + i)
+                    .insert(testContext.getJdbi());
+        }
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withMandateId(mandateFixture.getExternalId());
+        Long count = paymentViewDao.getPaymentViewCount(searchParams);
+        assertThat(count, is(3L));
+    }
+    
+    @Test
+    public void shouldReturn3Records_withMatchingEmailsOnly() {
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
+                .withExternalId("gateway-external-id")
+                .insert(testContext.getJdbi());
+        String mandateExternalId = "a-mandate-external-id";
+        String anotherMandateExternalId = "another-external-id";
+        MandateFixture mandateFixture1 = aMandateFixture()
+                .withGatewayAccountFixture(gatewayAccountFixture)
+                .withExternalId(mandateExternalId)
+                .insert(testContext.getJdbi());
+        MandateFixture mandateFixture2 = aMandateFixture()
+                .withGatewayAccountFixture(gatewayAccountFixture)
+                .withExternalId(anotherMandateExternalId)
+                .insert(testContext.getJdbi());
+        PayerFixture payerFixture1 = aPayerFixture()
+                .withMandateId(mandateFixture1.getId())
+                .withEmail("j.citizen@mail.fake")
+                .insert(testContext.getJdbi());
+        aPayerFixture()
+                .withMandateId(mandateFixture2.getId())
+                .withEmail("j.doe@mail.fake")
+                .insert(testContext.getJdbi());
+        for (int i = 0; i < 6; i++) {
+            if (i%2 == 0) {
+                aTransactionFixture()
+                        .withMandateFixture(mandateFixture2)
+                        .insert(testContext.getJdbi());
+                continue;
+            }
+            aTransactionFixture()
+                    .withMandateFixture(mandateFixture1)
+                    .insert(testContext.getJdbi());
+        }
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withMandateId(mandateFixture1.getExternalId());
+        Long count = paymentViewDao.getPaymentViewCount(searchParams);
+        assertThat(count, is(3L));
+        List<PaymentView> paymentViews = paymentViewDao.searchPaymentView(searchParams);
+        assertThat(paymentViews.size(), is(3));
+        assertThat(paymentViews.get(0).getEmail().equals(payerFixture1.getEmail()), is(true));
+        assertThat(paymentViews.get(1).getEmail().equals(payerFixture1.getEmail()), is(true));
+        assertThat(paymentViews.get(2).getEmail().equals(payerFixture1.getEmail()), is(true));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParamsTest.java
@@ -18,8 +18,11 @@ public class PaymentViewSearchParamsTest {
     
     @Test
     public void shouldCreateQueryMap() {
-        searchParams = new PaymentViewSearchParams("account-id", 
-                2l, 600l, fromDate.toString(), toDate.toString(), null, null, null);
+        searchParams = new PaymentViewSearchParams("account-id")
+                                .withPage(2L)
+        .withDisplaySize(600L)
+        .withFromDateString(fromDate.toString())
+        .withToDateString(toDate.toString());        
         searchParams = new PaymentViewValidator().validateParams(searchParams);
         assertThat(searchParams.getQueryMap().get("gatewayAccountExternalId"), is("account-id"));
         assertThat(searchParams.getQueryMap().get("offset"), is(500L));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentViewServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentViewServiceTest.java
@@ -1,10 +1,5 @@
 package uk.gov.pay.directdebit.payments.services;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,17 +11,36 @@ import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountNotFoundException;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.api.PaymentViewListResponse;
 import uk.gov.pay.directdebit.payments.api.PaymentViewResponse;
 import uk.gov.pay.directdebit.payments.dao.PaymentViewDao;
-import uk.gov.pay.directdebit.payments.exception.RecordsNotFoundException;
+import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.PaymentView;
+import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
+import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTransactionFixture;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PaymentViewServiceTest {
@@ -39,7 +53,8 @@ public class PaymentViewServiceTest {
     private PaymentViewDao paymentViewDao;
     @Mock
     private GatewayAccountDao gatewayAccountDao;
-
+    @Mock
+    UriInfo mockUriInfo;
     private PaymentViewService paymentViewService;
     private GatewayAccount gatewayAccount;
 
@@ -58,17 +73,36 @@ public class PaymentViewServiceTest {
                     PaymentState.NEW);
             paymentViewList.add(paymentView);
         }
-        paymentViewService = new PaymentViewService(paymentViewDao, gatewayAccountDao);
         gatewayAccount = new GatewayAccount(1L, gatewayAccountExternalId, null, null, null, null, null);
+        when(mockUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://app.com"),
+                UriBuilder.fromUri("http://app.com"));
+        when(mockUriInfo.getPath()).thenReturn("/v1/api/accounts/" + gatewayAccount.getExternalId() + "/transactions/view");
+        try {
+            URI uri = new URI("http://app.com");
+            when(mockUriInfo.getBaseUri()).thenReturn(uri);
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+        paymentViewService = new PaymentViewService(paymentViewDao, gatewayAccountDao)
+                                    .withUriInfo(mockUriInfo);
     }
 
     @Test
     public void getPaymentViewList_withGatewayAccountIdAndOffsetAndLimit_shouldPopulateResponse() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId, 
-                1L, 100L, createdDate.toString(), createdDate.toString(), null, null, null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+            .withPage(1L)
+            .withDisplaySize(100L)
+            .withFromDateString(createdDate.toString())
+            .withToDateString(createdDate.toString());    
+        List<PaymentViewListResponse> listResponses = new ArrayList<>();
+        for (PaymentView paymentView : paymentViewList){
+            listResponses.add(new PaymentViewListResponse(paymentView.getTransactionExternalId(),
+                    paymentView.getAmount(), paymentView.getReference(), paymentView.getDescription(),
+                    paymentView.getCreatedDate().toString(), paymentView.getName(), paymentView.getEmail(), paymentView.getState().toExternal()));
+        }
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(gatewayAccount));
         when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);
-
+        when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(4L);
         PaymentViewResponse response = paymentViewService.getPaymentViewResponse(searchParams);
         assertThat(response.getPaymentViewResponses().get(3).getAmount(), is(1003L));
         assertThat(response.getPaymentViewResponses().get(1).getName(), is("John Doe1"));
@@ -77,23 +111,64 @@ public class PaymentViewServiceTest {
     }
 
     @Test
-    public void shouldThrowNoRecordsFoundException_whenPaymentViewListIsEmpty() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId,
-                10L, 100L, createdDate.toString(), createdDate.toString(), null, null, null);
-        thrown.expect(RecordsNotFoundException.class);
-        thrown.expectMessage("Found no records with page size 10 and display_size 100");
-        when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(gatewayAccount));
-        when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(new ArrayList<>());
-        paymentViewService.getPaymentViewResponse(searchParams);
-    }
-
-    @Test
     public void shouldThrowGatewayAccountNotFoundException_whenGatewayNotExists() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId,
-                10L, 100L, createdDate.toString(), createdDate.toString(), null, null, null);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+                .withPage(10L)
+                .withDisplaySize(100L)
+                .withFromDateString(createdDate.toString())
+                .withToDateString(createdDate.toString());
         thrown.expect(GatewayAccountNotFoundException.class);
         thrown.expectMessage("Unknown gateway account: " + gatewayAccountExternalId);
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.empty());
         paymentViewService.getPaymentViewResponse(searchParams);
+    }
+
+    @Test
+    public void shouldReturn20Records_whenPaginationSetToPage2AndDisplaySize20() {
+        ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC).minusDays(1L);
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().withExternalId(gatewayAccountExternalId);
+        MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture);
+        GatewayAccount testGatewayAccount = gatewayAccountFixture.toEntity();
+        Mandate mandate = mandateFixture.toEntity();
+        Payer payer = aPayerFixture().withMandateId(mandate.getId())
+                .withName("J. Doe")
+                .withEmail("j.doe@mail.fake")
+                .toEntity();
+        List<PaymentView> paymentViewList = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            Transaction transaction = aTransactionFixture()
+                    .withId((long) i)
+                    .withMandateFixture(mandateFixture)
+                    .withAmount(((long) 100 + i))
+                    .withReference("MBK" + i)
+                    .withDescription("Description" + i)
+                    .withCreatedDate(createdDate)
+                    .toEntity();
+            paymentViewList.add(new PaymentView(gatewayAccountExternalId, 
+                    transaction.getExternalId(),
+                    transaction.getAmount(), 
+                    transaction.getReference(), 
+                    transaction.getDescription(),
+                    transaction.getCreatedDate(), 
+                    payer.getName(), 
+                    payer.getEmail(),
+                    transaction.getState()));
+        }
+        when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(testGatewayAccount));
+        when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(50L);
+        when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+                .withPage(2L)
+                .withDisplaySize(20L);
+        PaymentViewResponse paymentViewResponse = paymentViewService.getPaymentViewResponse(searchParams);
+        assertThat(paymentViewResponse.getCount(), is(20L));
+        assertThat(paymentViewResponse.getPage(), is(2L));
+        assertThat(paymentViewResponse.getTotal(), is(50L));
+        assertThat(paymentViewResponse.getPaymentViewResponses().get(0).getLinks().get(0).getRel(), is("self"));
+        assertThat(paymentViewResponse.getPaginationBuilder().getFirstLink().getHref().contains("&page_number=1"), is(true));
+        assertThat(paymentViewResponse.getPaginationBuilder().getLastLink().getHref().contains("&page_number=3"), is(true));
+        assertThat(paymentViewResponse.getPaginationBuilder().getPrevLink().getHref().contains("&page_number=1"), is(true));
+        assertThat(paymentViewResponse.getPaginationBuilder().getNextLink().getHref().contains("&page_number=3"), is(true));
+        assertThat(paymentViewResponse.getPaginationBuilder().getSelfLink().getHref().contains("&page_number=2"), is(true));
     }
 }


### PR DESCRIPTION
Payment view should be able to be searched by a mandate id. Search response should also mirror to a logical extent that of connector search, eg paginations, total and count.

- add mandate_id and and query string generation to `PaymentViewSearchParams`
- refactor `PaymentViewSearchParams` to use `withXXXParam` instead of an unreadable constructor
- add `withUriInfo` to `PaymentViewService` to enable the service to generate links
- introduce `Link` class
- add feature to searching to include the total number of records for a given search
- refactor searching to include the number of records on the given page and the page number
- add `ViewPaginationBuilder` (to mirror connector's search pagination)
- add relevant Pact test
- add relevant tests
