### PR TITLE
This change adds the capability to expire mandates to the ExpireResourse

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.mandate.dao;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -10,7 +11,10 @@ import uk.gov.pay.directdebit.mandate.dao.mapper.MandateMapper;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @RegisterRowMapper(MandateMapper.class)
 public interface MandateDao {
@@ -78,6 +82,9 @@ public interface MandateDao {
 
     @SqlQuery(query + "WHERE m.external_id = :externalId")
     Optional<Mandate> findByExternalId(@Bind("externalId") String externalId);
+
+    @SqlQuery(query + "WHERE m.state IN (<states>) AND m.created_date < :maxDateTime")
+    List<Mandate> findAllMandatesBySetOfStatesAndMaxCreationTime(@BindList("states") Set<MandateState> states, @Bind("maxDateTime")ZonedDateTime maxDateTime);
     
     @SqlUpdate("UPDATE mandates m SET state = :state WHERE m.id = :id")
     int updateState(@Bind("id") Long id, @Bind("state") MandateState mandateState);

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateState.java
@@ -19,7 +19,8 @@ public enum MandateState implements DirectDebitState {
     PENDING(EXTERNAL_PENDING),
     ACTIVE(EXTERNAL_ACTIVE),
     FAILED(EXTERNAL_INACTIVE),
-    CANCELLED(EXTERNAL_INACTIVE);
+    CANCELLED(EXTERNAL_INACTIVE),
+    EXPIRED(EXTERNAL_INACTIVE);
 
     private ExternalMandateState externalState;
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateStatesGraph.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateStatesGraph.java
@@ -6,9 +6,25 @@ import com.google.common.graph.ValueGraphBuilder;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.model.DirectDebitStatesGraph;
 
-import static uk.gov.pay.directdebit.mandate.model.MandateState.*;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.ACTIVE;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.AWAITING_DIRECT_DEBIT_DETAILS;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.CANCELLED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.EXPIRED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.FAILED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.PENDING;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.USER_CANCEL_NOT_ELIGIBLE;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.*;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_CANCELLED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_EXPIRED_BY_SYSTEM;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_FAILED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_PENDING;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_CANCELLED_BY_USER;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.TOKEN_EXCHANGED;
 
 public class MandateStatesGraph extends DirectDebitStatesGraph<MandateState> {
     
@@ -33,6 +49,10 @@ public class MandateStatesGraph extends DirectDebitStatesGraph<MandateState> {
         graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, SUBMITTED, DIRECT_DEBIT_DETAILS_CONFIRMED);
         graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, CANCELLED, PAYMENT_CANCELLED_BY_USER);
         graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, USER_CANCEL_NOT_ELIGIBLE, PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE);
+        
+        graph.putEdgeValue(CREATED, EXPIRED, MANDATE_EXPIRED_BY_SYSTEM);
+        graph.putEdgeValue(AWAITING_DIRECT_DEBIT_DETAILS, EXPIRED, MANDATE_EXPIRED_BY_SYSTEM);
+        graph.putEdgeValue(SUBMITTED, EXPIRED, MANDATE_EXPIRED_BY_SYSTEM);
 
         graph.putEdgeValue(SUBMITTED, PENDING, MANDATE_PENDING);
         graph.putEdgeValue(PENDING, ACTIVE, MANDATE_ACTIVE);

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.inject.Inject;
 import javax.ws.rs.core.UriInfo;
 
@@ -199,6 +200,10 @@ public class MandateService {
                 .findById(id)
                 .orElseThrow(() -> new MandateNotFoundException(id.toString()));
     }
+    
+    public List<Mandate> findAllMandatesBySetOfStatesAndMaxCreationTime(Set<MandateState> states, ZonedDateTime maxCreationTime) {
+        return mandateDao.findAllMandatesBySetOfStatesAndMaxCreationTime(states, maxCreationTime);
+    }
 
     public DirectDebitEvent mandateFailedFor(Mandate mandate) {
         Mandate newMandate = updateStateFor(mandate, MANDATE_FAILED);
@@ -225,7 +230,12 @@ public class MandateService {
         updateStateFor(mandate, MANDATE_ACTIVE);
         return directDebitEventService.registerMandateActiveEventFor(mandate);
     }
-
+    
+    public DirectDebitEvent mandateExpiredFor(Mandate mandate) {
+        Mandate updatedMandate = updateStateFor(mandate, SupportedEvent.MANDATE_EXPIRED_BY_SYSTEM);
+        return directDebitEventService.registerMandateExpiredEventFor(updatedMandate);
+    }
+    
     public Mandate receiveDirectDebitDetailsFor(String mandateExternalId) {
         Mandate mandate = findByExternalId(mandateExternalId);
         directDebitEventService.registerDirectDebitReceivedEventFor(mandate);

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
@@ -10,6 +10,7 @@ import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEv
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_ACTIVE;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_CANCELLED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_EXPIRED_BY_SYSTEM;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAID;
@@ -81,6 +82,10 @@ public class DirectDebitEvent {
 
     public static DirectDebitEvent mandateCancelled(Long mandateId) {
         return new DirectDebitEvent(mandateId, null, MANDATE, MANDATE_CANCELLED);
+    }
+    
+    public static DirectDebitEvent mandateExpiredBySystem(Long mandateId) {
+        return new DirectDebitEvent(mandateId, null, MANDATE, MANDATE_EXPIRED_BY_SYSTEM);
     }
     
     public static DirectDebitEvent mandateActive(Long mandateId) {
@@ -195,6 +200,7 @@ public class DirectDebitEvent {
         MANDATE_ACTIVE,
         MANDATE_FAILED,
         MANDATE_CANCELLED,
+        MANDATE_EXPIRED_BY_SYSTEM,
         PAYMENT_SUBMITTED_TO_PROVIDER,
         PAYMENT_CANCELLED_BY_USER,
         PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE,

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraph.java
@@ -5,7 +5,12 @@ import com.google.common.graph.MutableValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
 
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.*;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAID_OUT;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_CANCELLED_BY_USER;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_EXPIRED_BY_SYSTEM;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_FAILED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_SUBMITTED_TO_PROVIDER;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.CANCELLED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.EXPIRED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.FAILED;

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventService.java
@@ -70,6 +70,12 @@ public class DirectDebitEventService {
         return insertEventFor(mandate, directDebitEvent);
     }
 
+    public DirectDebitEvent registerMandateExpiredEventFor(Mandate mandate) {
+        DirectDebitEvent directDebitEvent = mandateExpiredBySystem(mandate.getId());
+        return insertEventFor(mandate, directDebitEvent);
+    }
+
+
     public DirectDebitEvent registerPaymentFailedEventFor(Transaction transaction) {
         Mandate mandate = transaction.getMandate();
         DirectDebitEvent directDebitEvent = paymentFailed(mandate.getId(), transaction.getId());

--- a/src/main/java/uk/gov/pay/directdebit/tasks/resources/ExpireResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/tasks/resources/ExpireResource.java
@@ -14,7 +14,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
 public class ExpireResource {
-
+    
     private final ExpireService expireService;
     
     @Inject
@@ -27,7 +27,8 @@ public class ExpireResource {
     @Produces(APPLICATION_JSON)
     public Response expirePaymentsAndMandates() {
         int numberOfExpiredPayments = expireService.expirePayments();
-        ResourceResponse resourceResponse =  new ResourceResponse(numberOfExpiredPayments);
+        int numberOfExpiredMandates = expireService.expireMandates();
+        ResourceResponse resourceResponse =  new ResourceResponse(numberOfExpiredPayments, numberOfExpiredMandates);
         return Response.ok(resourceResponse).build();
     }
     
@@ -36,9 +37,13 @@ public class ExpireResource {
         
         @JsonProperty
         private final int numberOfExpiredPayments;
+        
+        @JsonProperty
+        private final int numberOfExpiredMandates;
 
-        ResourceResponse(int numberOfExpiredPayments) {
+        ResourceResponse(int numberOfExpiredPayments, int numberOfExpiredMandates) {
             this.numberOfExpiredPayments = numberOfExpiredPayments;
+            this.numberOfExpiredMandates = numberOfExpiredMandates;
         }
     }
     

--- a/src/main/java/uk/gov/pay/directdebit/tasks/services/ExpireService.java
+++ b/src/main/java/uk/gov/pay/directdebit/tasks/services/ExpireService.java
@@ -2,6 +2,10 @@ package uk.gov.pay.directdebit.tasks.services;
 
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
+import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
+import uk.gov.pay.directdebit.mandate.services.MandateService;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.PaymentStatesGraph;
 import uk.gov.pay.directdebit.payments.model.Transaction;
@@ -16,16 +20,23 @@ public class ExpireService {
 
     private TransactionService transactionService;
     private PaymentStatesGraph paymentStatesGraph;
+    private MandateStatesGraph mandateStatesGraph;
     private static final Logger LOGGER = PayLoggerFactory.getLogger(ExpireService.class);
     private final long MIN_EXPIRY_AGE_MINUTES = 90l;
     private final PaymentState PAYMENT_EXPIRY_CUTOFF_STATUS = PaymentState.PENDING;
-    
+    private final MandateState MANDATE_EXPIRY_CUTOFF_STATUS = MandateState.PENDING;
+    private MandateService mandateService;
+
+
     @Inject
-    public ExpireService(TransactionService transactionService, PaymentStatesGraph paymentStatesGraph) {
+    ExpireService(TransactionService transactionService, MandateStatesGraph mandateStatesGraph,
+                         PaymentStatesGraph paymentStatesGraph, MandateService mandateService) {
         this.transactionService = transactionService;
         this.paymentStatesGraph = paymentStatesGraph;
+        this.mandateService = mandateService;
+        this.mandateStatesGraph = mandateStatesGraph;
     }
-    
+
     public int expirePayments() {
         LOGGER.info("Starting expire payments process.");
         List<Transaction> paymentsToExpire = getPaymentsForExpiration();
@@ -40,5 +51,21 @@ public class ExpireService {
         Set<PaymentState> states = paymentStatesGraph.getPriorStates(PAYMENT_EXPIRY_CUTOFF_STATUS);
         ZonedDateTime cutOffTime = ZonedDateTime.now().minusMinutes(MIN_EXPIRY_AGE_MINUTES);
         return transactionService.findAllPaymentsBySetOfStatesAndCreationTime(states, cutOffTime);
+    }
+
+    public int expireMandates() {
+        LOGGER.info("Starting expire mandates process.");
+        List<Mandate> mandatesToExpire = getMandatesForExpiration();
+        for (Mandate mandate : mandatesToExpire) {
+            mandateService.mandateExpiredFor(mandate);
+            LOGGER.info("Expired mandate " + mandate.getId());
+        }
+        return mandatesToExpire.size();
+    }
+
+    private List<Mandate> getMandatesForExpiration() {
+        Set<MandateState> states = mandateStatesGraph.getPriorStates(MANDATE_EXPIRY_CUTOFF_STATUS);
+        ZonedDateTime cutOffTime = ZonedDateTime.now().minusMinutes(MIN_EXPIRY_AGE_MINUTES);
+        return mandateService.findAllMandatesBySetOfStatesAndMaxCreationTime(states, cutOffTime);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -215,7 +215,7 @@ public class MandateDaoIT {
     }
 
     @Test
-    public void findAllMandatesBySetOfStatesAndMaxCreationTime_shouldNotFindMandate_WrongState() {
+    public void shouldNotFindMandateInWrongState() {
         MandateFixture.aMandateFixture()
                 .withState(MandateState.PENDING)
                 .withGatewayAccountFixture(gatewayAccountFixture)
@@ -229,7 +229,7 @@ public class MandateDaoIT {
     }
 
     @Test
-    public void findAllMandatesBySetOfStatesAndMaxCreationTime_shouldNotFindMandate_WrongCreationTime() {
+    public void shouldNotFindMandateWrongCreationTime() {
         MandateFixture.aMandateFixture()
                 .withState(MandateState.CREATED)
                 .withGatewayAccountFixture(gatewayAccountFixture)
@@ -243,7 +243,7 @@ public class MandateDaoIT {
     }
 
     @Test
-    public void findAllMandatesBySetOfStatesAndMaxCreationTime_shouldFindThreeMandates() {
+    public void shouldFindThreeMandates() {
         MandateFixture.aMandateFixture()
                 .withState(MandateState.AWAITING_DIRECT_DEBIT_DETAILS)
                 .withGatewayAccountFixture(gatewayAccountFixture)

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
@@ -39,6 +39,11 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
         this.gatewayAccountFixture = gatewayAccountFixture;
         return this;
     }
+    
+    public MandateFixture withCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
 
     public MandateFixture withPayerFixture(
             PayerFixture payerFixture) {

--- a/src/test/java/uk/gov/pay/directdebit/mandate/model/MandateStatesGraphTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/model/MandateStatesGraphTest.java
@@ -57,7 +57,11 @@ public class MandateStatesGraphTest {
 
     @Test
     public void priorStates() {
-        assertThat(mandateStatesGraph.getPriorStates(MandateState.PENDING), is(new HashSet(Arrays.asList(MandateState.SUBMITTED, MandateState.CREATED, MandateState.AWAITING_DIRECT_DEBIT_DETAILS))));
+        assertThat(mandateStatesGraph.getPriorStates(MandateState.PENDING), 
+                is(new HashSet<>(Arrays.asList(
+                        MandateState.CREATED,
+                        MandateState.SUBMITTED,
+                        MandateState.AWAITING_DIRECT_DEBIT_DETAILS))));
     }
     
     

--- a/src/test/java/uk/gov/pay/directdebit/tasks/services/ExpireServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/tasks/services/ExpireServiceTest.java
@@ -7,12 +7,18 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
+import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
+import uk.gov.pay.directdebit.mandate.services.MandateService;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.PaymentStatesGraph;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -28,16 +34,22 @@ public class ExpireServiceTest {
 
     @DropwizardTestContext
     private TestContext testContext;
+
     private PaymentStatesGraph paymentStatesGraph = new PaymentStatesGraph();
+    private MandateStatesGraph mandateStatesGraph = new MandateStatesGraph();
     
     @Mock
     private TransactionService transactionService;
     
+    @Mock
+    private MandateService mandateService;
+    
+    @Mock
     private ExpireService expireService;
     
     @Before
     public void setup() {
-        expireService = new ExpireService(transactionService, paymentStatesGraph);
+        expireService = new ExpireService(transactionService, mandateStatesGraph, paymentStatesGraph, mandateService);
     }
     
     
@@ -53,10 +65,28 @@ public class ExpireServiceTest {
     }
 
     @Test
+    public void expireMandates_shouldCallMandateServiceWithPriorStatesToPending() {
+        Mandate mandate = MandateFixture.aMandateFixture().withState(MandateState.CREATED).toEntity();
+        when(mandateService
+                .findAllMandatesBySetOfStatesAndMaxCreationTime(eq(mandateStatesGraph.getPriorStates(MandateState.PENDING)), any()))
+                .thenReturn(Collections.singletonList(mandate));
+        int numberOfExpiredMandates = expireService.expireMandates();
+        assertEquals(1, numberOfExpiredMandates);
+    }
+
+    @Test
     public void shouldGetCorrectPaymentsStatesPriorToPending() {
         Set<PaymentState> paymentStates = paymentStatesGraph.getPriorStates(PaymentState.PENDING);
         Set<PaymentState> expectedPaymentStates = new HashSet<>(Collections.singletonList(PaymentState.NEW));
         assertEquals(expectedPaymentStates, paymentStates);
     }
 
+    @Test
+    public void shouldGetCorrectMandateStatesPriorToPending() {
+        Set<MandateState> paymentStates = mandateStatesGraph.getPriorStates(MandateState.PENDING);
+        Set<MandateState> expectedPaymentStates = new HashSet<>(Arrays.asList(MandateState.CREATED, 
+                                                                              MandateState.AWAITING_DIRECT_DEBIT_DETAILS,
+                                                                              MandateState.SUBMITTED));
+        assertEquals(expectedPaymentStates, paymentStates);
+    }
 }


### PR DESCRIPTION
… end-point (see PP-3647 and pull request #176 which created this service with the initial payment expiry functionality).

Following the implementation of the existing payment expiry logic it:
 - finds all mandates in a state prior to PENDING and created more than 90 minutes ago. Note that eligible states are determined from the MandateStatesGraph.getPriorStates which was
 introduced in the previous PR for payments (see above)..
 - Updates the status of each mandate to EXPIRED and creates an event MANDATE_EXPIRED_BY_SYSTEM.
 - Adds the number of expired mandates the response.

The existing implementation and merged PR for expiring payments can be viewed at:
https://github.com/alphagov/pay-direct-debit-connector/pull/176

@mrlumbu 