### PR TITLE
PP-3679 Change endpoint queryparam from mandate_id to agreement

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
@@ -18,6 +18,7 @@ public class PaymentViewSearchParams {
     private static final String AMOUNT_FIELD = "amount";
     private static final String MANDATE_EXTERNAL_ID_FIELD = "mandate_external_id";
     private static final String MANDATE_ID_KEY = "mandate_id";
+    private static final String MANDATE_ID_EXTERNAL_KEY = "agreement";
     private static final String FROM_DATE_KEY = "from_date";
     private static final String TO_DATE_KEY = "to_date";
     private final String gatewayExternalId;
@@ -171,29 +172,29 @@ public class PaymentViewSearchParams {
     }
     
     public String buildQueryParamString() {
-        StringBuilder sb = new StringBuilder("");
+        String query = "";
         if (isNotBlank(mandateId)) {
-            sb.append("&" + MANDATE_ID_KEY + "=" + mandateId);
+            query += "&" + MANDATE_ID_KEY + "=" + mandateId;
         }
         if (searchDateParams != null) {
             if (searchDateParams.getFromDate() != null) {
-                sb.append("&" + FROM_DATE_KEY + "=" + searchDateParams.getFromDate().toString());
+                query += "&" + FROM_DATE_KEY + "=" + searchDateParams.getFromDate().toString();
             }
             if (searchDateParams.getToDate() != null) {
-                sb.append("&" + TO_DATE_KEY + "=" + searchDateParams.getToDate().toString());
+                query += "&" + TO_DATE_KEY + "=" + searchDateParams.getToDate().toString();
             }
         }
         if (isNotBlank(email)) {
-            sb.append("&" + EMAIL_FIELD + "=" + email);
+            query += "&" + EMAIL_FIELD + "=" + email;
         }
         if (isNotBlank(reference)) {
-            sb.append("&" + REFERENCE_FIELD + "=" + reference);
+            query += "&" + REFERENCE_FIELD + "=" + reference;
         }
         if (amount != null) {
-            sb.append("&" + AMOUNT_FIELD + "=" + amount);
+            query += "&" + AMOUNT_FIELD + "=" + amount;
         }
-        sb.append(addPaginationParams());
-        return sb.toString();
+        query += addPaginationParams();
+        return query;
     }
     
     private String addPaginationParams() {

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
@@ -25,7 +25,7 @@ public class PaymentViewResource {
     private static final String EMAIL_KEY = "email";
     private static final String REFERENCE_KEY = "reference";
     private static final String AMOUNT_KEY = "amount";
-    private static final String MANDATE_ID_KEY = "mandate_id";
+    private static final String MANDATE_ID_EXTERNAL_KEY = "agreement";
     private final PaymentViewService paymentViewService;
 
     @Inject
@@ -45,7 +45,7 @@ public class PaymentViewResource {
             @QueryParam(EMAIL_KEY) String email,
             @QueryParam(REFERENCE_KEY) String reference,
             @QueryParam(AMOUNT_KEY) Long amount,
-            @QueryParam(MANDATE_ID_KEY) String mandateId,
+            @QueryParam(MANDATE_ID_EXTERNAL_KEY) String mandateId,
             @Context UriInfo uriInfo){
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(accountExternalId)
                 .withPage(pageNumber)

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -56,7 +56,7 @@ public class PublicApiContractTest {
         testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
         MandateFixture testMandate = MandateFixture.aMandateFixture()
                 .withGatewayAccountFixture(testGatewayAccount)
-                .withExternalId(params.get("mandate_id"));
+                .withExternalId(params.get("agreement"));
         testMandate.insert(app.getTestContext().getJdbi());
         PayerFixture testPayer = PayerFixture.aPayerFixture().withMandateId(testMandate.getId());
         testPayer.insert(app.getTestContext().getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceITest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceITest.java
@@ -363,7 +363,7 @@ public class PaymentViewResourceITest {
                     .withMandateFixture(mandateFixture1)
                     .insert(testContext.getJdbi());
         }
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?mandate_id=:mandateId"
+        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?agreement=:mandateId"
                 .replace("{accountId}", gatewayAccountFixture.getExternalId())
                 .replace(":mandateId", mandateFixture1.getExternalId());
         givenSetup()


### PR DESCRIPTION
this change is needed to hide mandate_id from public api

- change mandate_id to agreement on `PaymentViewResource` and `PaymentViewSearchParams.buildQueryParamString()`
- update relevant test
