### PR TITLE
PP-3922 Add mandate reference to API response

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateResponse.java
@@ -35,11 +35,17 @@ public class CreateMandateResponse {
     @JsonProperty("service_reference")
     private String serviceReference;
 
+    @JsonProperty("mandate_reference")
+    private String mandateReference;
+
     public CreateMandateResponse(String mandateId,
-                                 MandateType mandateType, String returnUrl, String createdDate,
+                                 MandateType mandateType,
+                                 String returnUrl,
+                                 String createdDate,
                                  ExternalMandateState state,
                                  List<Map<String, Object>> dataLinks,
-                                 String serviceReference) {
+                                 String serviceReference,
+                                 String mandateReference) {
         this.dataLinks = dataLinks;
         this.mandateId = mandateId;
         this.mandateType = mandateType;
@@ -47,6 +53,7 @@ public class CreateMandateResponse {
         this.createdDate = createdDate;
         this.state = state;
         this.serviceReference = serviceReference;
+        this.mandateReference = mandateReference;
     }
 
     public String getMandateId() {
@@ -71,6 +78,10 @@ public class CreateMandateResponse {
 
     public String getServiceReference() {
         return serviceReference;
+    }
+
+    public String getMandateReference() {
+        return mandateReference;
     }
 
     public URI getLink(String rel) {

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/GetMandateResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/GetMandateResponse.java
@@ -3,9 +3,10 @@ package uk.gov.pay.directdebit.mandate.api;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.directdebit.mandate.model.MandateType;
+
 import java.util.List;
 import java.util.Map;
-import uk.gov.pay.directdebit.mandate.model.MandateType;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -17,25 +18,35 @@ public class GetMandateResponse {
 
     @JsonProperty("mandate_type")
     private MandateType mandateType;
-    
+
     @JsonProperty("return_url")
     private String returnUrl;
 
     @JsonProperty("links")
     private List<Map<String, Object>> dataLinks;
-    
+
     @JsonProperty
     private ExternalMandateState state;
 
+    @JsonProperty("service_reference")
+    private String serviceReference;
+
+    @JsonProperty("mandate_reference")
+    private String mandateReference;
+
     public GetMandateResponse(String mandateId,
-            MandateType mandateType, String returnUrl,
-            List<Map<String, Object>> dataLinks,
-            ExternalMandateState state) {
+                              MandateType mandateType, String returnUrl,
+                              List<Map<String, Object>> dataLinks,
+                              ExternalMandateState state,
+                              String serviceReference,
+                              String mandateReference) {
         this.mandateId = mandateId;
         this.mandateType = mandateType;
         this.returnUrl = returnUrl;
         this.dataLinks = dataLinks;
         this.state = state;
+        this.serviceReference = serviceReference;
+        this.mandateReference = mandateReference;
     }
 
     public String getReturnUrl() {
@@ -56,6 +67,14 @@ public class GetMandateResponse {
 
     public ExternalMandateState getState() {
         return state;
+    }
+
+    public String getServiceReference() {
+        return serviceReference;
+    }
+
+    public String getMandateReference() {
+        return mandateReference;
     }
 
     @Override
@@ -93,6 +112,7 @@ public class GetMandateResponse {
         result = 31 * result + state.hashCode();
         return result;
     }
+
 }
 
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -177,8 +177,9 @@ public class MandateService {
                 mandate.getType(),
                 mandate.getReturnUrl(),
                 dataLinks,
-                mandate.getState().toExternal()
-        );
+                mandate.getState().toExternal(),
+                mandate.getServiceReference(),
+                mandate.getMandateReference());
     }
 
     public CreateMandateResponse createMandateResponse(Map<String, String> mandateRequestMap, String accountExternalId, UriInfo uriInfo) {
@@ -193,8 +194,8 @@ public class MandateService {
                 mandate.getCreatedDate().toString(),
                 mandate.getState().toExternal(),
                 dataLinks,
-                mandate.getServiceReference()
-        );
+                mandate.getServiceReference(),
+                mandate.getMandateReference());
     }
 
     public Mandate findByExternalId(String externalId) {

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
@@ -39,7 +39,7 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
         this.gatewayAccountFixture = gatewayAccountFixture;
         return this;
     }
-    
+
     public MandateFixture withCreatedDate(ZonedDateTime createdDate) {
         this.createdDate = createdDate;
         return this;
@@ -85,6 +85,10 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
     public MandateFixture withMandateReference(String mandateReference) {
         this.mandateReference = mandateReference;
         return this;
+    }
+
+    public String getServiceReference() {
+        return serviceReference;
     }
 
     public MandateFixture withServiceReference(String serviceReference) {


### PR DESCRIPTION
## WHAT

- Added `mandate_reference` to response from `createMandate()` and `getMandate()` endpoints
- Added `service_reference` to response from `getMandate()` endpoints

with @danailminchev

