### PR TITLE
PP 3680 search events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
         </dependency>

--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -30,6 +30,7 @@ import uk.gov.pay.directdebit.common.exception.BadRequestExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.ConflictExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.InternalServerErrorExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.NotFoundExceptionMapper;
+import uk.gov.pay.directdebit.events.resources.DirectDebitEventsResource;
 import uk.gov.pay.directdebit.gatewayaccounts.GatewayAccountParamConverterProvider;
 import uk.gov.pay.directdebit.gatewayaccounts.resources.GatewayAccountResource;
 import uk.gov.pay.directdebit.healthcheck.resources.HealthCheckResource;
@@ -39,7 +40,6 @@ import uk.gov.pay.directdebit.payers.resources.PayerResource;
 import uk.gov.pay.directdebit.payments.resources.PaymentViewResource;
 import uk.gov.pay.directdebit.payments.resources.TransactionResource;
 import uk.gov.pay.directdebit.tasks.resources.ExpireResource;
-import uk.gov.pay.directdebit.tasks.services.ExpireService;
 import uk.gov.pay.directdebit.tokens.resources.SecurityTokensResource;
 import uk.gov.pay.directdebit.webhook.gocardless.exception.InvalidWebhookExceptionMapper;
 import uk.gov.pay.directdebit.webhook.gocardless.resources.WebhookGoCardlessResource;
@@ -101,6 +101,7 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
         environment.jersey().register(injector.getInstance(PaymentViewResource.class));
         environment.jersey().register(injector.getInstance(MandateResource.class));
         environment.jersey().register(injector.getInstance(ExpireResource.class));
+        environment.jersey().register(injector.getInstance(DirectDebitEventsResource.class));
 
 
         environment.jersey().register(new InvalidWebhookExceptionMapper());

--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
@@ -10,6 +10,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import javax.net.ssl.SSLSocketFactory;
 import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.directdebit.events.dao.DirectDebitEventSearchDao;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessMandateDao;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessPaymentDao;
@@ -151,5 +152,11 @@ public class DirectDebitModule extends AbstractModule {
     @Singleton
     public PaymentViewDao providePaymentViewDao() {
         return new PaymentViewDao(jdbi);
+    }
+
+    @Provides
+    @Singleton
+    public DirectDebitEventSearchDao provideDirectDebitEventSearchDao() {
+        return new DirectDebitEventSearchDao(jdbi);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/dao/DirectDebitEventSearchDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/DirectDebitEventSearchDao.java
@@ -1,0 +1,84 @@
+package uk.gov.pay.directdebit.events.dao;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import lombok.AllArgsConstructor;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
+import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
+
+import javax.inject.Inject;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.nonNull;
+
+public class DirectDebitEventSearchDao {
+
+    private static final String QUERY = "SELECT * from EVENTS e WHERE :searchFields";
+    
+    private final Jdbi jdbi;
+
+    @Inject
+    public DirectDebitEventSearchDao(Jdbi jdbi) {
+        this.jdbi = jdbi;
+    }
+    
+    public List<DirectDebitEvent> findEvents(DirectDebitEventSearchParams searchParams) {
+        QueryStringAndQueryMap queryStringAndQueryMap = generateQuery(searchParams);
+        return jdbi.withHandle(handle -> {
+            Query query = handle.createQuery(QUERY.replace(":searchFields", queryStringAndQueryMap.queryString));
+            queryStringAndQueryMap.queryMap.forEach(query::bind);
+            return query.map(new DirectDebitEventsMapper()).list();
+        });
+    }
+
+    private QueryStringAndQueryMap generateQuery(DirectDebitEventSearchParams searchParams) {
+        List<String> searchStrings = Lists.newArrayList();
+        Map<String, Object> queryMap = Maps.newHashMap();
+        if (nonNull(searchParams.getMandateId())) {
+            searchStrings.add("e.mandate_id = :mandate_id");
+            queryMap.put("mandate_id", searchParams.getMandateId());
+        }
+        if (nonNull(searchParams.getTransactionId())) {
+            searchStrings.add("e.transaction_id = :transaction_id");
+            queryMap.put("transaction_id", searchParams.getTransactionId());
+        }
+        if (nonNull(searchParams.getBeforeDate())) {
+            searchStrings.add("e.event_date < :before_date");
+            queryMap.put("before_date", searchParams.getBeforeDate());
+        }
+        if (nonNull(searchParams.getAfterDate())) {
+            searchStrings.add("e.event_date > :after_date");
+            queryMap.put("after_date", searchParams.getAfterDate());
+        }
+        return new QueryStringAndQueryMap(searchStrings.stream().collect(Collectors.joining(" AND ")), queryMap);
+    }
+
+    private class DirectDebitEventsMapper implements RowMapper<DirectDebitEvent> {
+        @Override
+        public DirectDebitEvent map(ResultSet rs, StatementContext ctx) throws SQLException {
+            return new DirectDebitEvent(
+                    rs.getLong("id"),
+                    rs.getLong("mandate_id"),
+                    rs.getLong("transaction_id"),
+                    DirectDebitEvent.Type.valueOf(rs.getString("event_type")),
+                    DirectDebitEvent.SupportedEvent.valueOf(rs.getString("event")),
+                    ZonedDateTime.ofInstant(rs.getTimestamp("event_date").toInstant(), ZoneOffset.UTC));
+        }
+    }
+
+    @AllArgsConstructor
+    private class QueryStringAndQueryMap {
+        public final String queryString; 
+        public final Map<String, Object> queryMap;
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
@@ -29,8 +29,8 @@ public class DirectDebitEventsResource {
     @Produces(APPLICATION_JSON)
     public Response findEvents(@QueryParam("before") String beforeDate,
                                @QueryParam("after") String afterDate,
-                               @QueryParam("page_size") String pageSize,
-                               @QueryParam("page") String page,
+                               @QueryParam("page_size") Integer pageSize,
+                               @QueryParam("page") Integer page,
                                @QueryParam("mandate_id") Long mandateId,
                                @QueryParam("transaction_id") Long transactionId) {
 
@@ -39,6 +39,8 @@ public class DirectDebitEventsResource {
                 .afterDate(afterDate)
                 .mandateId(mandateId)
                 .transactionId(transactionId)
+                .pageSize(pageSize)
+                .page(page)
                 .build();
         
         List<DirectDebitEvent> events = directDebitEventsSearchService.search(searchParams);

--- a/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.directdebit.events.resources;
+
+import uk.gov.pay.directdebit.events.service.DirectDebitEventsSearchService;
+import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
+import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/v1/events")
+public class DirectDebitEventsResource {
+    
+    private final DirectDebitEventsSearchService directDebitEventsSearchService;
+
+    @Inject
+    public DirectDebitEventsResource(DirectDebitEventsSearchService directDebitEventsSearchService) {
+        this.directDebitEventsSearchService = directDebitEventsSearchService;
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Response findEvents(@QueryParam("before") String beforeDate,
+                               @QueryParam("after") String afterDate,
+                               @QueryParam("page_size") String pageSize,
+                               @QueryParam("page") String page,
+                               @QueryParam("mandate_id") Long mandateId,
+                               @QueryParam("transaction_id") Long transactionId) {
+
+        DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder()
+                .beforeDate(beforeDate)
+                .afterDate(afterDate)
+                .mandateId(mandateId)
+                .transactionId(transactionId)
+                .build();
+        
+        List<DirectDebitEvent> events = directDebitEventsSearchService.search(searchParams);
+        
+        return Response.ok(events).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/events/service/DirectDebitEventsSearchService.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/service/DirectDebitEventsSearchService.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.directdebit.events.service;
+
+import uk.gov.pay.directdebit.events.dao.DirectDebitEventSearchDao;
+import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
+import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
+
+import javax.inject.Inject;
+import java.util.List;
+
+public class DirectDebitEventsSearchService {
+    
+    private final DirectDebitEventSearchDao dao;
+
+    @Inject
+    public DirectDebitEventsSearchService(DirectDebitEventSearchDao dao) {
+        this.dao = dao;
+    }
+
+    public List<DirectDebitEvent> search(DirectDebitEventSearchParams searchParams) {
+        return dao.findEvents(searchParams);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/DirectDebitEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/DirectDebitEventDao.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.payments.dao;
 
-import java.util.Optional;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
@@ -9,6 +8,8 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.payments.dao.mapper.EventMapper;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
+
+import java.util.Optional;
 
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type;

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/CustomDateSerializer.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/CustomDateSerializer.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.directdebit.payments.model;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class CustomDateSerializer extends StdSerializer<ZonedDateTime> {
+
+    public CustomDateSerializer() {
+        this(null);
+    }
+    
+    protected CustomDateSerializer(Class<ZonedDateTime> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider sp) throws IOException {
+        gen.writeString(value.format(DateTimeFormatter.ISO_INSTANT));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
@@ -41,7 +41,7 @@ import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.PAYER;
 public class DirectDebitEvent {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(DirectDebitEvent.class);
 
-    @JsonProperty
+    @JsonProperty("id")
     private Long id;
     
     @JsonProperty("mandate_id")

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
@@ -1,6 +1,11 @@
 package uk.gov.pay.directdebit.payments.model;
 
 import java.time.ZonedDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.payments.exception.UnsupportedDirectDebitEventException;
@@ -29,14 +34,28 @@ import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.CHARGE
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.MANDATE;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.PAYER;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@Data
 public class DirectDebitEvent {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(DirectDebitEvent.class);
 
+    @JsonProperty
     private Long id;
+    
+    @JsonProperty("mandate_id")
     private Long mandateId;
+
+    @JsonProperty("transaction_id")
     private Long transactionId;
+
+    @JsonProperty("event_type")
     private Type eventType;
+
+    @JsonProperty
     private SupportedEvent event;
+
+    @JsonProperty("event_date")
     private ZonedDateTime eventDate;
 
     public DirectDebitEvent(Long id, Long mandateId, Long transactionId, Type eventType, SupportedEvent event, ZonedDateTime eventDate) {
@@ -136,55 +155,7 @@ public class DirectDebitEvent {
     public static DirectDebitEvent paymentExpired(Long mandateId, Long transactionId) {
         return new DirectDebitEvent(mandateId, transactionId, CHARGE, PAYMENT_EXPIRED_BY_SYSTEM);
     }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Long getMandateId() {
-        return mandateId;
-    }
-
-    public void setMandateId(Long mandateId) {
-        this.mandateId = mandateId;
-    }
-
-    public Long getTransactionId() {
-        return transactionId;
-    }
-
-    public void setTransactionId(Long transactionId) {
-        this.transactionId = transactionId;
-    }
-
-    public Type getEventType() {
-        return eventType;
-    }
-
-    public void setEventType(Type eventType) {
-        this.eventType = eventType;
-    }
-
-    public SupportedEvent getEvent() {
-        return event;
-    }
-
-    public void setEvent(SupportedEvent event) {
-        this.event = event;
-    }
-
-    public ZonedDateTime getEventDate() {
-        return eventDate;
-    }
-
-    public void setEventDate(ZonedDateTime eventDate) {
-        this.eventDate = eventDate;
-    }
-
+    
     public enum Type {
         PAYER, CHARGE, MANDATE
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
@@ -5,6 +5,7 @@ import java.time.ZonedDateTime;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Data;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
@@ -56,6 +57,7 @@ public class DirectDebitEvent {
     private SupportedEvent event;
 
     @JsonProperty("event_date")
+    @JsonSerialize(using = CustomDateSerializer.class)
     private ZonedDateTime eventDate;
 
     public DirectDebitEvent(Long id, Long mandateId, Long transactionId, Type eventType, SupportedEvent event, ZonedDateTime eventDate) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
@@ -17,19 +17,30 @@ public class DirectDebitEventSearchParams {
     @Getter private Integer page;
 
     public static class DirectDebitEventSearchParamsBuilder {
+        
+        private Integer pageSize = 500;
+        
         public DirectDebitEventSearchParamsBuilder beforeDate(String date) {
             if (date != null) {
                 this.beforeDate = parseDate(date, "beforeDate");    
             }
             return this;
         }
-
+        
         public DirectDebitEventSearchParamsBuilder afterDate(String date) {
             if (date != null) {
                 this.afterDate = parseDate(date, "afterDate");    
             }
             return this;
         }
+
+        public DirectDebitEventSearchParamsBuilder pageSize(Integer pageSize) {
+            if (pageSize != null && pageSize < 500) {
+                this.pageSize = pageSize;
+            }
+            return this;
+        }
+
 
         private ZonedDateTime parseDate(String date, String fieldName) {
             ZonedDateTime dateTime;

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.directdebit.payments.params;
+
+import lombok.Builder;
+import lombok.Getter;
+import uk.gov.pay.directdebit.payments.exception.UnparsableDateException;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+
+@Builder
+public class DirectDebitEventSearchParams {
+    @Getter private ZonedDateTime beforeDate;
+    @Getter private ZonedDateTime afterDate;
+    @Getter private Long mandateId;
+    @Getter private Long transactionId;
+ 
+    public static class DirectDebitEventSearchParamsBuilder {
+        public DirectDebitEventSearchParamsBuilder beforeDate(String date) {
+            this.beforeDate = parseDate(date, "beforeDate");
+            return this;
+        }
+
+        public DirectDebitEventSearchParamsBuilder afterDate(String date) {
+            this.afterDate = parseDate(date, "afterDate");
+            return this;
+        }
+
+        private ZonedDateTime parseDate(String date, String fieldName) {
+            ZonedDateTime dateTime;
+            try {
+                dateTime = ZonedDateTime.parse(date);
+            } catch (DateTimeParseException e) {
+                throw new UnparsableDateException(fieldName, date);
+            }
+            return dateTime;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
@@ -13,15 +13,21 @@ public class DirectDebitEventSearchParams {
     @Getter private ZonedDateTime afterDate;
     @Getter private Long mandateId;
     @Getter private Long transactionId;
- 
+    @Getter private Integer pageSize;
+    @Getter private Integer page;
+
     public static class DirectDebitEventSearchParamsBuilder {
         public DirectDebitEventSearchParamsBuilder beforeDate(String date) {
-            this.beforeDate = parseDate(date, "beforeDate");
+            if (date != null) {
+                this.beforeDate = parseDate(date, "beforeDate");    
+            }
             return this;
         }
 
         public DirectDebitEventSearchParamsBuilder afterDate(String date) {
-            this.afterDate = parseDate(date, "afterDate");
+            if (date != null) {
+                this.afterDate = parseDate(date, "afterDate");    
+            }
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/GetDirectDebitEventsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/GetDirectDebitEventsTest.java
@@ -251,14 +251,11 @@ public class GetDirectDebitEventsTest {
     }
     
     @Test
-    public void shouldReturnBadRequestIfPageIsSetAndPageSizeIsNotSet() {
-        
-    }
-    
-    @Test
     public void shouldReturnThirdEventWherePageSizeIsTwoAndPageIsTwo() {
+        
         for (int i = 1; i < 4; i++) {
             aDirectDebitEventFixture()
+                    .withId(Long.valueOf(i))
                     .withMandateId(testMandate.getId())
                     .withTransactionId(testTransaction.getId())
                     .withEventType(MANDATE)
@@ -267,7 +264,7 @@ public class GetDirectDebitEventsTest {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = format("/v1/events?transaction_id=%s&page_size=2&page=2", testTransaction.getId());
+        String requestPath = format("/v1/events?page_size=2&page=2");
 
         given().port(testContext.getPort())
                 .contentType(JSON)
@@ -275,11 +272,31 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(1));
+                .body("$", hasSize(1))
+                .body("[0].id", is(1) );
     }
     
     @Test
     public void shouldReturnFiveHundredEventsWhenPageSizeIsFiveHundredAndOne() {
-        
+        for (int i = 1; i < 503; i++) {
+            aDirectDebitEventFixture()
+                    .withId(Long.valueOf(i))
+                    .withMandateId(testMandate.getId())
+                    .withTransactionId(testTransaction.getId())
+                    .withEventType(MANDATE)
+                    .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                    .withEventDate(ZonedDateTime.now())
+                    .insert(testContext.getJdbi());
+        }
+
+        String requestPath = format("/v1/events?page_size=501");
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("$", hasSize(500));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/GetDirectDebitEventsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/GetDirectDebitEventsTest.java
@@ -1,0 +1,121 @@
+package uk.gov.pay.directdebit.payments.resources;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.junit.DropwizardConfig;
+import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
+import uk.gov.pay.directdebit.junit.DropwizardTestContext;
+import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture;
+import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
+import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+
+import javax.ws.rs.core.Response;
+import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture.aDirectDebitEventFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_ACKNOWLEDGED_BY_PROVIDER;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.MANDATE;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
+public class GetDirectDebitEventsTest {
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    private MandateFixture testMandate;
+    private TransactionFixture testTransaction;
+
+    @Before
+    public void setUp() {
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
+        this.testMandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
+        this.testTransaction = TransactionFixture.aTransactionFixture().withMandateFixture(testMandate).insert(testContext.getJdbi());
+    }
+
+    @Test
+    public void shouldReturnNoEventsForNoSearchParameters() {
+        
+    }
+    
+    @Test
+    public void shouldThrow422IfDatesAreNotValid() {
+        
+    }
+    
+    @Test
+    public void shouldReturnAnEventWithAllSearchParameters() {
+        aDirectDebitEventFixture()
+                .withMandateId(testMandate.getId())
+                .withTransactionId(testTransaction.getId())
+                .withEventType(MANDATE)
+                .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                .withEventDate(ZonedDateTime.now())
+                .insert(testContext.getJdbi());
+        
+        String requestPath = format("/v1/events?before=%s&after=%s&page_size=100&page=1&mandate_id=%s&transaction_id=%s",
+                ZonedDateTime.now().plusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
+                ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
+                testMandate.getId().toString(),
+                testTransaction.getId().toString());
+        
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("results", hasSize(1));
+    }
+
+    @Test
+    public void shouldReturnNoEventsForNonExistentDates() {
+
+    }
+
+    @Test
+    public void shouldReturnAnEventForBeforeParameter() {
+
+    }
+
+    @Test
+    public void shouldReturnAnEventForAfterParameter() {
+
+    }
+
+    @Test
+    public void shouldReturnAnEventForMandateIdParameter() {
+
+    }
+
+    @Test
+    public void shouldReturnAnEventForTransactionIdParameter() {
+
+    }
+    
+    @Test
+    public void shouldReturnTwoEventsWherePageSizeIsSetToTwo() {
+        
+    }
+    
+    @Test
+    public void shouldReturnThirdEventWherePageSizeIsTwoAndPageIsTwo() {
+        
+    }
+    
+    @Test
+    public void shouldReturnFiveHundredEventsWhenPageSizeIsFiveHundredAndOne() {
+        
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/GetDirectDebitEventsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/GetDirectDebitEventsTest.java
@@ -14,7 +14,6 @@ import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 
 import javax.ws.rs.core.Response;
-import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -22,6 +21,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture.aDirectDebitEventFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_ACKNOWLEDGED_BY_PROVIDER;
@@ -36,26 +36,17 @@ public class GetDirectDebitEventsTest {
 
     private MandateFixture testMandate;
     private TransactionFixture testTransaction;
+    private GatewayAccountFixture gatewayAccountFixture;
 
     @Before
     public void setUp() {
-        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
+        gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
         this.testMandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
         this.testTransaction = TransactionFixture.aTransactionFixture().withMandateFixture(testMandate).insert(testContext.getJdbi());
     }
 
     @Test
-    public void shouldReturnNoEventsForNoSearchParameters() {
-        
-    }
-    
-    @Test
-    public void shouldThrow422IfDatesAreNotValid() {
-        
-    }
-    
-    @Test
-    public void shouldReturnAnEventWithAllSearchParameters() {
+    public void shouldReturnAllEventsForNoSearchParameters() {
         aDirectDebitEventFixture()
                 .withMandateId(testMandate.getId())
                 .withTransactionId(testTransaction.getId())
@@ -64,6 +55,46 @@ public class GetDirectDebitEventsTest {
                 .withEventDate(ZonedDateTime.now())
                 .insert(testContext.getJdbi());
         
+        String requestPath = "/v1/events";
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("$", hasSize(1));
+    }
+    
+    @Test
+    public void shouldReturnBadRequestIfDatesAreNotValid() {
+        aDirectDebitEventFixture()
+                .withMandateId(testMandate.getId())
+                .withTransactionId(testTransaction.getId())
+                .withEventType(MANDATE)
+                .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                .withEventDate(ZonedDateTime.now())
+                .insert(testContext.getJdbi());
+
+        String requestPath = format("/v1/events?before=%s", "invalid_format");
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+    
+    @Test
+    public void shouldReturnAnEventWithAllSearchParameters() {
+        DirectDebitEventFixture directDebitEventFixture = aDirectDebitEventFixture()
+                .withMandateId(testMandate.getId())
+                .withTransactionId(testTransaction.getId())
+                .withEventType(MANDATE)
+                .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                .withEventDate(ZonedDateTime.now())
+                .insert(testContext.getJdbi());
+
         String requestPath = format("/v1/events?before=%s&after=%s&page_size=100&page=1&mandate_id=%s&transaction_id=%s",
                 ZonedDateTime.now().plusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
                 ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
@@ -76,42 +107,175 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("results", hasSize(1));
+                .body("$", hasSize(1))
+                .body("[0].mandate_id", is(Math.toIntExact(testMandate.getId())))
+                .body("[0].transaction_id", is(Math.toIntExact(testTransaction.getId())))
+                .body("[0].event_type", is(MANDATE.toString()))
+                .body("[0].event", is(PAYMENT_ACKNOWLEDGED_BY_PROVIDER.toString()))
+                .body("[0].event_date", is(directDebitEventFixture.getEventDate().format(DateTimeFormatter.ISO_INSTANT).toString()))
+        ;
     }
 
     @Test
     public void shouldReturnNoEventsForNonExistentDates() {
+        aDirectDebitEventFixture()
+                .withMandateId(testMandate.getId())
+                .withTransactionId(testTransaction.getId())
+                .withEventType(MANDATE)
+                .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                .withEventDate(ZonedDateTime.now())
+                .insert(testContext.getJdbi());
 
+        String requestPath = format("/v1/events?before=%s&after=%s&page_size=100&page=1&mandate_id=%s&transaction_id=%s",
+                ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
+                ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
+                testMandate.getId().toString(),
+                testTransaction.getId().toString());
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("$", hasSize(0));
     }
 
     @Test
     public void shouldReturnAnEventForBeforeParameter() {
+        aDirectDebitEventFixture()
+                .withMandateId(testMandate.getId())
+                .withTransactionId(testTransaction.getId())
+                .withEventType(MANDATE)
+                .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                .withEventDate(ZonedDateTime.now())
+                .insert(testContext.getJdbi());
 
+        String requestPath = format("/v1/events?before=%s",
+                ZonedDateTime.now().plusMinutes(5).format(DateTimeFormatter.ISO_INSTANT));
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("$", hasSize(1));
     }
 
     @Test
     public void shouldReturnAnEventForAfterParameter() {
+        aDirectDebitEventFixture()
+                .withMandateId(testMandate.getId())
+                .withTransactionId(testTransaction.getId())
+                .withEventType(MANDATE)
+                .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                .withEventDate(ZonedDateTime.now())
+                .insert(testContext.getJdbi());
 
+        String requestPath = format("/v1/events?after=%s",
+                ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT));
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("$", hasSize(1));
     }
 
     @Test
     public void shouldReturnAnEventForMandateIdParameter() {
+        aDirectDebitEventFixture()
+                .withMandateId(testMandate.getId())
+                .withTransactionId(testTransaction.getId())
+                .withEventType(MANDATE)
+                .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                .withEventDate(ZonedDateTime.now())
+                .insert(testContext.getJdbi());
 
+        String requestPath = format("/v1/events?mandate_id=%s", testMandate.getId());
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("$", hasSize(1));
     }
 
     @Test
     public void shouldReturnAnEventForTransactionIdParameter() {
+        aDirectDebitEventFixture()
+                .withMandateId(testMandate.getId())
+                .withTransactionId(testTransaction.getId())
+                .withEventType(MANDATE)
+                .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                .withEventDate(ZonedDateTime.now())
+                .insert(testContext.getJdbi());
 
+        String requestPath = format("/v1/events?transaction_id=%s", testTransaction.getId());
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("$", hasSize(1));
     }
     
     @Test
     public void shouldReturnTwoEventsWherePageSizeIsSetToTwo() {
+        for (int i = 0; i < 4; i++) {
+            aDirectDebitEventFixture()
+                    .withMandateId(testMandate.getId())
+                    .withTransactionId(testTransaction.getId())
+                    .withEventType(MANDATE)
+                    .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                    .withEventDate(ZonedDateTime.now())
+                    .insert(testContext.getJdbi());
+        }
+
+        String requestPath = format("/v1/events?transaction_id=%s&page_size=2", testTransaction.getId());
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("$", hasSize(2));
+    }
+    
+    @Test
+    public void shouldReturnBadRequestIfPageIsSetAndPageSizeIsNotSet() {
         
     }
     
     @Test
     public void shouldReturnThirdEventWherePageSizeIsTwoAndPageIsTwo() {
-        
+        for (int i = 1; i < 4; i++) {
+            aDirectDebitEventFixture()
+                    .withMandateId(testMandate.getId())
+                    .withTransactionId(testTransaction.getId())
+                    .withEventType(MANDATE)
+                    .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
+                    .withEventDate(ZonedDateTime.now())
+                    .insert(testContext.getJdbi());
+        }
+
+        String requestPath = format("/v1/events?transaction_id=%s&page_size=2&page=2", testTransaction.getId());
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .get(requestPath)
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("$", hasSize(1));
     }
     
     @Test


### PR DESCRIPTION
This adds a new resource to search for events by mandate id, transaction id, before date and after date. Also accepts page size and page number parameters. All parameters are optional and the default page size is 500 (this is also the maximum page size).

Pagenation is done using OFFSET and LIMIT as part of the db query as per existing patterns found in DD Connector.

@oswaldquek 