### PR TITLE
PP-3679 refactor to accept both agreement and agreement_id as queryparams part 1

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
@@ -25,7 +25,8 @@ public class PaymentViewResource {
     private static final String EMAIL_KEY = "email";
     private static final String REFERENCE_KEY = "reference";
     private static final String AMOUNT_KEY = "amount";
-    private static final String MANDATE_ID_EXTERNAL_KEY = "agreement";
+    private static final String MANDATE_ID_EXTERNAL_KEY = "agreement_id";
+    private static final String MANDATE_ID_BWC_EXTERNAL_KEY = "agreement";
     private final PaymentViewService paymentViewService;
 
     @Inject
@@ -46,7 +47,10 @@ public class PaymentViewResource {
             @QueryParam(REFERENCE_KEY) String reference,
             @QueryParam(AMOUNT_KEY) Long amount,
             @QueryParam(MANDATE_ID_EXTERNAL_KEY) String mandateId,
+            @QueryParam(MANDATE_ID_BWC_EXTERNAL_KEY) String mandateBWCId,
             @Context UriInfo uriInfo){
+        
+        String mandateIdToBeUsed = mandateBWCId == null ? mandateId : mandateBWCId;
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(accountExternalId)
                 .withPage(pageNumber)
                 .withDisplaySize(displaySize)
@@ -55,7 +59,7 @@ public class PaymentViewResource {
                 .withEmail(email)
                 .withReference(reference)
                 .withAmount(amount)
-                .withMandateId(mandateId);
+                .withMandateId(mandateIdToBeUsed);
         
         return Response.ok().entity(paymentViewService
                 .withUriInfo(uriInfo)

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -54,9 +54,17 @@ public class PublicApiContractTest {
     @State("three transaction records exist")
     public void threeTransactionRecordsExist(Map<String, String> params) {
         testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
+        String mandateId;
+        if (params.get("agreement") != null) {
+            mandateId = params.get("agreement");
+        } else if (params.get("agreement_id") != null) {
+            mandateId = params.get("agreement_id");
+        } else {
+            throw new RuntimeException("Cannot run `three transaction records exist` pact test, couldn't get agreement id from params");
+        }
         MandateFixture testMandate = MandateFixture.aMandateFixture()
                 .withGatewayAccountFixture(testGatewayAccount)
-                .withExternalId(params.get("agreement"));
+                .withExternalId(mandateId);
         testMandate.insert(app.getTestContext().getJdbi());
         PayerFixture testPayer = PayerFixture.aPayerFixture().withMandateId(testMandate.getId());
         testPayer.insert(app.getTestContext().getJdbi());


### PR DESCRIPTION

- refactor Pact test to try to use mandate_id by either agreement or agreement_id
- refactor PaymentViewResource to accept both agreement and agreement_id

