### PR TITLE
Pp 3680 events pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,18 @@
         </dependency>
         <!-- testing -->
         <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path-assert</artifactId>
+            <version>2.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>
             <version>3.5.18</version>

--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.directdebit.events.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.directdebit.payments.links.PaginationLink;
+import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+
+public class DirectDebitEventsPagination {
+
+    @JsonProperty("self")
+    private PaginationLink selfLink;
+    @JsonProperty("first_page")
+    private PaginationLink firstLink;
+    @JsonProperty("last_page")
+    private PaginationLink lastLink;
+    @JsonProperty("prev_page")
+    private PaginationLink prevLink;
+    @JsonProperty("next_page")
+    private PaginationLink nextLink;
+
+    public DirectDebitEventsPagination(DirectDebitEventSearchParams searchParams, int total, UriInfo uriInfo) {
+        selfLink = PaginationLink.ofValue(uriWithParams(searchParams, uriInfo).toString());
+        firstLink = PaginationLink.ofValue(uriWithParams(searchParams.copy().page(1).build(), uriInfo).toString());
+        int lastPage = Math.round(total / searchParams.getPageSize());
+        lastLink = PaginationLink.ofValue(uriWithParams(searchParams.copy().page(lastPage).build(), uriInfo).toString());
+        Integer currentPage = searchParams.getPage();
+        prevLink = currentPage == 1 ? null : 
+                PaginationLink.ofValue(uriWithParams(searchParams.copy().page(currentPage - 1).build(), uriInfo).toString());
+        nextLink = currentPage == lastPage ? null : 
+                PaginationLink.ofValue(uriWithParams(searchParams.copy().page(currentPage + 1).build(), uriInfo).toString());
+    }
+
+    private URI uriWithParams(DirectDebitEventSearchParams params, UriInfo uriInfo) {
+        UriBuilder uriBuilder = uriInfo.getBaseUriBuilder().path(uriInfo.getPath());
+        params.getParamsAsMap().forEach((k, v) -> uriBuilder.queryParam(k, v));
+        return uriBuilder.build();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.events.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 import uk.gov.pay.directdebit.payments.links.PaginationLink;
 import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
 
@@ -11,15 +12,15 @@ import java.net.URI;
 
 public class DirectDebitEventsPagination {
 
-    @JsonProperty("self")
+    @JsonProperty("self") @Getter
     private PaginationLink selfLink;
-    @JsonProperty("first_page")
+    @JsonProperty("first_page") @Getter
     private PaginationLink firstLink;
-    @JsonProperty("last_page")
+    @JsonProperty("last_page") @Getter
     private PaginationLink lastLink;
-    @JsonProperty("prev_page")
+    @JsonProperty("prev_page") @Getter
     private PaginationLink prevLink;
-    @JsonProperty("next_page")
+    @JsonProperty("next_page") @Getter
     private PaginationLink nextLink;
 
     public DirectDebitEventsPagination(DirectDebitEventSearchParams searchParams, int total, UriInfo uriInfo) {
@@ -38,25 +39,5 @@ public class DirectDebitEventsPagination {
         UriBuilder uriBuilder = uriInfo.getBaseUriBuilder().path(uriInfo.getPath());
         params.getParamsAsMap().forEach((k, v) -> uriBuilder.queryParam(k, v));
         return uriBuilder.build();
-    }
-
-    public PaginationLink getSelfLink() {
-        return selfLink;
-    }
-
-    public PaginationLink getFirstLink() {
-        return firstLink;
-    }
-
-    public PaginationLink getLastLink() {
-        return lastLink;
-    }
-
-    public PaginationLink getPrevLink() {
-        return prevLink;
-    }
-
-    public PaginationLink getNextLink() {
-        return nextLink;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 
+
 public class DirectDebitEventsPagination {
 
     @JsonProperty("self")
@@ -37,5 +38,25 @@ public class DirectDebitEventsPagination {
         UriBuilder uriBuilder = uriInfo.getBaseUriBuilder().path(uriInfo.getPath());
         params.getParamsAsMap().forEach((k, v) -> uriBuilder.queryParam(k, v));
         return uriBuilder.build();
+    }
+
+    public PaginationLink getSelfLink() {
+        return selfLink;
+    }
+
+    public PaginationLink getFirstLink() {
+        return firstLink;
+    }
+
+    public PaginationLink getLastLink() {
+        return lastLink;
+    }
+
+    public PaginationLink getPrevLink() {
+        return prevLink;
+    }
+
+    public PaginationLink getNextLink() {
+        return nextLink;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
-import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
 
 import java.util.List;
 
@@ -22,11 +21,14 @@ public class DirectDebitEventsResponse {
     private final int total;
     @JsonProperty
     private final int count;
+    @JsonProperty("_links")
+    private DirectDebitEventsPagination pagination;
     
-    public DirectDebitEventsResponse(List<DirectDebitEvent> events, int page, int total) {
+    public DirectDebitEventsResponse(List<DirectDebitEvent> events, int page, int total, DirectDebitEventsPagination directDebitEventsPagination) {
         this.events = events;
         this.total = total;
         this.page = page;
         this.count = events.size();
+        this.pagination = directDebitEventsPagination;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsResponse.java
@@ -3,14 +3,12 @@ package uk.gov.pay.directdebit.events.api;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
-@AllArgsConstructor
 public class DirectDebitEventsResponse {
     
     @JsonProperty("results")

--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsResponse.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.directdebit.events.api;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
+import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@AllArgsConstructor
+public class DirectDebitEventsResponse {
+    
+    @JsonProperty("results")
+    private final List<DirectDebitEvent> events;
+    @JsonProperty
+    private final Integer page;
+    @JsonProperty
+    private final int total;
+    @JsonProperty
+    private final int count;
+    
+    public DirectDebitEventsResponse(List<DirectDebitEvent> events, int page, int total) {
+        this.events = events;
+        this.total = total;
+        this.page = page;
+        this.count = events.size();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
@@ -2,7 +2,6 @@ package uk.gov.pay.directdebit.events.resources;
 
 import uk.gov.pay.directdebit.events.api.DirectDebitEventsResponse;
 import uk.gov.pay.directdebit.events.service.DirectDebitEventsSearchService;
-import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
 
 import javax.inject.Inject;
@@ -10,9 +9,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
-
-import java.util.List;
+import javax.ws.rs.core.UriInfo;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -33,7 +32,8 @@ public class DirectDebitEventsResource {
                                @QueryParam("page_size") Integer pageSize,
                                @QueryParam("page") Integer page,
                                @QueryParam("mandate_id") Long mandateId,
-                               @QueryParam("transaction_id") Long transactionId) {
+                               @QueryParam("transaction_id") Long transactionId,
+                               @Context UriInfo uriInfo) {
 
         DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder()
                 .beforeDate(beforeDate)
@@ -44,7 +44,7 @@ public class DirectDebitEventsResource {
                 .page(page)
                 .build();
 
-        DirectDebitEventsResponse response = directDebitEventsSearchService.search(searchParams);
+        DirectDebitEventsResponse response = directDebitEventsSearchService.search(searchParams, uriInfo);
         
         return Response.ok(response).build();
     }

--- a/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.events.resources;
 
+import uk.gov.pay.directdebit.events.api.DirectDebitEventsResponse;
 import uk.gov.pay.directdebit.events.service.DirectDebitEventsSearchService;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
@@ -42,9 +43,9 @@ public class DirectDebitEventsResource {
                 .pageSize(pageSize)
                 .page(page)
                 .build();
+
+        DirectDebitEventsResponse response = directDebitEventsSearchService.search(searchParams);
         
-        List<DirectDebitEvent> events = directDebitEventsSearchService.search(searchParams);
-        
-        return Response.ok(events).build();
+        return Response.ok(response).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/service/DirectDebitEventsSearchService.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/service/DirectDebitEventsSearchService.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.events.service;
 
+import uk.gov.pay.directdebit.events.api.DirectDebitEventsResponse;
 import uk.gov.pay.directdebit.events.dao.DirectDebitEventSearchDao;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
@@ -16,7 +17,9 @@ public class DirectDebitEventsSearchService {
         this.dao = dao;
     }
 
-    public List<DirectDebitEvent> search(DirectDebitEventSearchParams searchParams) {
-        return dao.findEvents(searchParams);
+    public DirectDebitEventsResponse search(DirectDebitEventSearchParams searchParams) {
+        List<DirectDebitEvent> events = dao.findEvents(searchParams);
+        int total = dao.getTotalNumberOfEvents(searchParams);
+        return new DirectDebitEventsResponse(events, searchParams.getPage(), total);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/service/DirectDebitEventsSearchService.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/service/DirectDebitEventsSearchService.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.directdebit.events.service;
 
+import uk.gov.pay.directdebit.events.api.DirectDebitEventsPagination;
 import uk.gov.pay.directdebit.events.api.DirectDebitEventsResponse;
 import uk.gov.pay.directdebit.events.dao.DirectDebitEventSearchDao;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.UriInfo;
 import java.util.List;
 
 public class DirectDebitEventsSearchService {
@@ -17,9 +19,13 @@ public class DirectDebitEventsSearchService {
         this.dao = dao;
     }
 
-    public DirectDebitEventsResponse search(DirectDebitEventSearchParams searchParams) {
+    public DirectDebitEventsResponse search(DirectDebitEventSearchParams searchParams, UriInfo uriInfo) {
         List<DirectDebitEvent> events = dao.findEvents(searchParams);
         int total = dao.getTotalNumberOfEvents(searchParams);
-        return new DirectDebitEventsResponse(events, searchParams.getPage(), total);
+        return new DirectDebitEventsResponse(
+                events, 
+                searchParams.getPage(), 
+                total, 
+                new DirectDebitEventsPagination(searchParams, total, uriInfo));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
@@ -19,6 +19,7 @@ public class DirectDebitEventSearchParams {
     public static class DirectDebitEventSearchParamsBuilder {
         
         private Integer pageSize = 500;
+        private Integer page = 1;
         
         public DirectDebitEventSearchParamsBuilder beforeDate(String date) {
             if (date != null) {
@@ -30,6 +31,13 @@ public class DirectDebitEventSearchParams {
         public DirectDebitEventSearchParamsBuilder afterDate(String date) {
             if (date != null) {
                 this.afterDate = parseDate(date, "afterDate");    
+            }
+            return this;
+        }
+        
+        public DirectDebitEventSearchParamsBuilder page(Integer page) {
+            if (page != null) {
+                this.page = page;
             }
             return this;
         }

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
@@ -5,16 +5,44 @@ import lombok.Getter;
 import uk.gov.pay.directdebit.payments.exception.UnparsableDateException;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.Map;
 
 @Builder
 public class DirectDebitEventSearchParams {
-    @Getter private ZonedDateTime beforeDate;
-    @Getter private ZonedDateTime afterDate;
-    @Getter private Long mandateId;
-    @Getter private Long transactionId;
-    @Getter private Integer pageSize;
-    @Getter private Integer page;
+    @Getter private final ZonedDateTime beforeDate;
+    @Getter private final ZonedDateTime afterDate;
+    @Getter private final Long mandateId;
+    @Getter private final Long transactionId;
+    @Getter private final Integer pageSize;
+    @Getter private final Integer page;
+
+    public DirectDebitEventSearchParamsBuilder copy() {
+        return new DirectDebitEventSearchParamsBuilder().page(page).pageSize(pageSize).transactionId(transactionId).mandateId(mandateId).afterDate(afterDate).beforeDate(beforeDate);
+    }
+
+    public Map<String, String> getParamsAsMap() {
+        Map<String, String> params = new HashMap<>();
+        
+        if (beforeDate != null) 
+            params.put("before", beforeDate.format(DateTimeFormatter.ISO_INSTANT));
+        
+        if (afterDate != null)
+            params.put("after", afterDate.format(DateTimeFormatter.ISO_INSTANT));
+        
+        if (mandateId != null)
+            params.put("mandate_id", mandateId.toString());
+        
+        if (transactionId != null)
+            params.put("transaction_id", transactionId.toString());
+        
+        params.put("page_size", pageSize.toString());
+        params.put("page", page.toString());
+        
+        return params;
+    }
 
     public static class DirectDebitEventSearchParamsBuilder {
         
@@ -27,11 +55,21 @@ public class DirectDebitEventSearchParams {
             }
             return this;
         }
+
+        public DirectDebitEventSearchParamsBuilder beforeDate(ZonedDateTime date) {
+            this.beforeDate = date;
+            return this;
+        }
         
         public DirectDebitEventSearchParamsBuilder afterDate(String date) {
             if (date != null) {
                 this.afterDate = parseDate(date, "afterDate");    
             }
+            return this;
+        }
+
+        public DirectDebitEventSearchParamsBuilder afterDate(ZonedDateTime date) {
+            this.afterDate = date;    
             return this;
         }
         

--- a/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -35,23 +36,23 @@ public class DirectDebitEventsPaginationTest {
     public void testWithAllSearchParameters() {
         DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder()
                 .page(2)
-                .afterDate(ZonedDateTime.of(2018, 6, 29, 8, 0, 0, 0, ZoneId.systemDefault()))
-                .beforeDate(ZonedDateTime.of(2018, 6, 29, 9, 0, 0, 0, ZoneId.systemDefault()))
+                .afterDate(ZonedDateTime.of(2018, 6, 29, 8, 0, 0, 0, ZoneId.of("UTC")))
+                .beforeDate(ZonedDateTime.of(2018, 6, 29, 9, 0, 0, 0, ZoneId.of("UTC")))
                 .mandateId(1234L)
                 .transactionId(5678L)
                 .pageSize(10)
                 .build();
         DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 100, mockUriInfo);
         
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=2&page_size=10")
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=2&page_size=10")
                 , pagination.getSelfLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=3&page_size=10")
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=3&page_size=10")
                 , pagination.getNextLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=1&page_size=10")
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=1&page_size=10")
                 , pagination.getFirstLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=10&page_size=10")
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=10&page_size=10")
                 , pagination.getLastLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=1&page_size=10")
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=1&page_size=10")
                 , pagination.getPrevLink());
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
@@ -13,7 +13,6 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -25,10 +24,11 @@ public class DirectDebitEventsPaginationTest {
     
     @Mock
     private UriInfo mockUriInfo;
+    private final String testUrl = "http://test.test";
 
     @Before
     public void setup() {
-        when(mockUriInfo.getBaseUriBuilder()).thenAnswer((Answer<UriBuilder>) invocation -> UriBuilder.fromUri("http://test.com"));
+        when(mockUriInfo.getBaseUriBuilder()).thenAnswer((Answer<UriBuilder>) invocation -> UriBuilder.fromUri(testUrl));
         when(mockUriInfo.getPath()).thenReturn("/test/");
     }
 
@@ -44,15 +44,15 @@ public class DirectDebitEventsPaginationTest {
                 .build();
         DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 100, mockUriInfo);
         
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=2&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=2&page_size=10")
                 , pagination.getSelfLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=3&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=3&page_size=10")
                 , pagination.getNextLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=1&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=1&page_size=10")
                 , pagination.getFirstLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=10&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=10&page_size=10")
                 , pagination.getLastLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=1&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&before=2018-06-29T09%3A00%3A00Z&mandate_id=1234&after=2018-06-29T08%3A00%3A00Z&page=1&page_size=10")
                 , pagination.getPrevLink());
     }
 
@@ -66,15 +66,15 @@ public class DirectDebitEventsPaginationTest {
                 .build();
         DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 100, mockUriInfo);
 
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=3&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&mandate_id=1234&page=3&page_size=10")
                 , pagination.getSelfLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=4&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&mandate_id=1234&page=4&page_size=10")
                 , pagination.getNextLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=1&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&mandate_id=1234&page=1&page_size=10")
                 , pagination.getFirstLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=10&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&mandate_id=1234&page=10&page_size=10")
                 , pagination.getLastLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=2&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?transaction_id=5678&mandate_id=1234&page=2&page_size=10")
                 , pagination.getPrevLink());
     }
 
@@ -83,11 +83,10 @@ public class DirectDebitEventsPaginationTest {
         DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder().build();
         DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 5000, mockUriInfo);
 
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?page=1&page_size=500"), pagination.getSelfLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?page=2&page_size=500"), pagination.getNextLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?page=1&page_size=500"), pagination.getFirstLink());
-        assertEquals(PaginationLink.ofValue("http://test.com/test/?page=10&page_size=500"), pagination.getLastLink());
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=1&page_size=500"), pagination.getSelfLink());
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=2&page_size=500"), pagination.getNextLink());
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=1&page_size=500"), pagination.getFirstLink());
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=10&page_size=500"), pagination.getLastLink());
         assertNull(pagination.getPrevLink());
     }
-
 }

--- a/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
@@ -1,0 +1,92 @@
+package uk.gov.pay.directdebit.events.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import uk.gov.pay.directdebit.payments.links.PaginationLink;
+import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DirectDebitEventsPaginationTest {
+
+    
+    @Mock
+    private UriInfo mockUriInfo;
+
+    @Before
+    public void setup() {
+        when(mockUriInfo.getBaseUriBuilder()).thenAnswer((Answer<UriBuilder>) invocation -> UriBuilder.fromUri("http://test.com"));
+        when(mockUriInfo.getPath()).thenReturn("/test/");
+    }
+
+    @Test
+    public void testWithAllSearchParameters() {
+        DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder()
+                .page(2)
+                .afterDate(ZonedDateTime.of(2018, 6, 29, 8, 0, 0, 0, ZoneId.systemDefault()))
+                .beforeDate(ZonedDateTime.of(2018, 6, 29, 9, 0, 0, 0, ZoneId.systemDefault()))
+                .mandateId(1234L)
+                .transactionId(5678L)
+                .pageSize(10)
+                .build();
+        DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 100, mockUriInfo);
+        
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=2&page_size=10")
+                , pagination.getSelfLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=3&page_size=10")
+                , pagination.getNextLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=1&page_size=10")
+                , pagination.getFirstLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=10&page_size=10")
+                , pagination.getLastLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&before=2018-06-29T08%3A00%3A00Z&mandate_id=1234&after=2018-06-29T07%3A00%3A00Z&page=1&page_size=10")
+                , pagination.getPrevLink());
+    }
+
+    @Test
+    public void testWithSomeSearchParameters() {
+        DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder()
+                .page(3)
+                .mandateId(1234L)
+                .transactionId(5678L)
+                .pageSize(10)
+                .build();
+        DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 100, mockUriInfo);
+
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=3&page_size=10")
+                , pagination.getSelfLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=4&page_size=10")
+                , pagination.getNextLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=1&page_size=10")
+                , pagination.getFirstLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=10&page_size=10")
+                , pagination.getLastLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?transaction_id=5678&mandate_id=1234&page=2&page_size=10")
+                , pagination.getPrevLink());
+    }
+
+    @Test
+    public void testWithNoSearchParameters() {
+        DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder().build();
+        DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 5000, mockUriInfo);
+
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?page=1&page_size=500"), pagination.getSelfLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?page=2&page_size=500"), pagination.getNextLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?page=1&page_size=500"), pagination.getFirstLink());
+        assertEquals(PaginationLink.ofValue("http://test.com/test/?page=10&page_size=500"), pagination.getLastLink());
+        assertNull(pagination.getPrevLink());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsTest.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.directdebit.payments.resources;
+package uk.gov.pay.directdebit.events.resources;
 
 import com.jayway.jsonassert.JsonAssert;
 import junitparams.JUnitParamsRunner;

--- a/src/test/java/uk/gov/pay/directdebit/junit/PostgresTemplate.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/PostgresTemplate.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.junit;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import static java.lang.String.format;
 import static java.sql.DriverManager.getConnection;
 
 final class PostgresTemplate {
@@ -15,7 +16,11 @@ final class PostgresTemplate {
             terminateDbConnections(connection, config.getDatabaseName());
             connection.createStatement().execute("CREATE DATABASE " + TEMPLATE_NAME + " WITH TEMPLATE " + config.getDatabaseName() + " OWNER " + config.getUserName());
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            if (e.getMessage().equals(format("ERROR: database \"%s\" already exists", TEMPLATE_NAME))){
+                restorePostgres(databaseUrl, user, password);
+            } else {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/GetDirectDebitEventsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/GetDirectDebitEventsTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.payments.resources;
 
+import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,7 +64,8 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(1));
+                .body("count", is(1))
+                .body("results", hasSize(1));
     }
     
     @Test
@@ -107,12 +109,13 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(1))
-                .body("[0].mandate_id", is(Math.toIntExact(testMandate.getId())))
-                .body("[0].transaction_id", is(Math.toIntExact(testTransaction.getId())))
-                .body("[0].event_type", is(MANDATE.toString()))
-                .body("[0].event", is(PAYMENT_ACKNOWLEDGED_BY_PROVIDER.toString()))
-                .body("[0].event_date", is(directDebitEventFixture.getEventDate().format(DateTimeFormatter.ISO_INSTANT).toString()))
+                .body("results", hasSize(1))
+                .body("count", is(1))
+                .body("results[0].mandate_id", is(Math.toIntExact(testMandate.getId())))
+                .body("results[0].transaction_id", is(Math.toIntExact(testTransaction.getId())))
+                .body("results[0].event_type", is(MANDATE.toString()))
+                .body("results[0].event", is(PAYMENT_ACKNOWLEDGED_BY_PROVIDER.toString()))
+                .body("results[0].event_date", is(directDebitEventFixture.getEventDate().format(DateTimeFormatter.ISO_INSTANT).toString()))
         ;
     }
 
@@ -138,7 +141,8 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(0));
+                .body("count", is(0))
+                .body("results", hasSize(0));
     }
 
     @Test
@@ -160,7 +164,8 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(1));
+                .body("count", is(1))
+                .body("results", hasSize(1));
     }
 
     @Test
@@ -182,7 +187,8 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(1));
+                .body("count", is(1))
+                .body("results", hasSize(1));
     }
 
     @Test
@@ -203,7 +209,8 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(1));
+                .body("count", is(1))
+                .body("results", hasSize(1));
     }
 
     @Test
@@ -224,7 +231,8 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(1));
+                .body("count", is(1))
+                .body("results", hasSize(1));
     }
     
     @Test
@@ -247,7 +255,10 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(2));
+                .body("page", Is.is(1))
+                .body("total", Is.is(4))
+                .body("count", Is.is(2))
+                .body("results", hasSize(2));
     }
     
     @Test
@@ -272,8 +283,10 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(1))
-                .body("[0].id", is(1) );
+                .body("count", is(1))
+                .body("total", is(3))
+                .body("results", hasSize(1))
+                .body("results[0].id", is(1) );
     }
     
     @Test
@@ -297,6 +310,6 @@ public class GetDirectDebitEventsTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("$", hasSize(500));
+                .body("results", hasSize(500));
     }
 }


### PR DESCRIPTION
Improved the pagination for event search to include links to first, last, next, self and previous pages. This also introduces "count" as the number of results in the returned page and "total"  as the total number of results available for the parameters provided (e.g. across all pages).

This follows the pattern implemented for Payments search. 

@oswaldquek 