### PR TITLE
PP-3679 Remove agreement from search params

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -90,7 +90,7 @@ GET /v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?r
 | `page`                    | - | To get the results from the specified page number, should be a non zero +ve number (optional, defaults to 1)|
 | `display_size`            | - | Number of records to be returned per page, should be a non zero +ve number (optional, defaults to 500)|
 | `email`                   | - | Email of the payment user to search for          |
-| `agreement`               | - | Agreement external id |
+| `agreement_id`            | - | Mandate external id |
 
 ### Response example
 ```

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
@@ -18,15 +18,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 @Path("/")
 public class PaymentViewResource {
 
-    private static final String PAGE_KEY = "page";
-    private static final String DISPLAY_SIZE_KEY = "display_size";
-    private static final String FROM_DATE_KEY = "from_date";
-    private static final String TO_DATE_KEY = "to_date";
-    private static final String EMAIL_KEY = "email";
-    private static final String REFERENCE_KEY = "reference";
-    private static final String AMOUNT_KEY = "amount";
-    private static final String MANDATE_ID_EXTERNAL_KEY = "agreement_id";
-    private static final String MANDATE_ID_BWC_EXTERNAL_KEY = "agreement";
     private final PaymentViewService paymentViewService;
 
     @Inject
@@ -39,18 +30,16 @@ public class PaymentViewResource {
     @Produces(APPLICATION_JSON)
     public Response getPaymentView(
             @PathParam("accountId") String accountExternalId,
-            @QueryParam(PAGE_KEY) Long pageNumber,
-            @QueryParam(DISPLAY_SIZE_KEY) Long displaySize,
-            @QueryParam(FROM_DATE_KEY) String fromDate,
-            @QueryParam(TO_DATE_KEY) String toDate,
-            @QueryParam(EMAIL_KEY) String email,
-            @QueryParam(REFERENCE_KEY) String reference,
-            @QueryParam(AMOUNT_KEY) Long amount,
-            @QueryParam(MANDATE_ID_EXTERNAL_KEY) String mandateId,
-            @QueryParam(MANDATE_ID_BWC_EXTERNAL_KEY) String mandateBWCId,
+            @QueryParam("page") Long pageNumber,
+            @QueryParam("display_size") Long displaySize,
+            @QueryParam("from_date") String fromDate,
+            @QueryParam("to_date") String toDate,
+            @QueryParam("email") String email,
+            @QueryParam("reference") String reference,
+            @QueryParam("amount") Long amount,
+            @QueryParam("agreement_id") String mandateId,
             @Context UriInfo uriInfo){
         
-        String mandateIdToBeUsed = mandateBWCId == null ? mandateId : mandateBWCId;
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(accountExternalId)
                 .withPage(pageNumber)
                 .withDisplaySize(displaySize)
@@ -59,7 +48,7 @@ public class PaymentViewResource {
                 .withEmail(email)
                 .withReference(reference)
                 .withAmount(amount)
-                .withMandateId(mandateIdToBeUsed);
+                .withMandateId(mandateId);
         
         return Response.ok().entity(paymentViewService
                 .withUriInfo(uriInfo)

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -54,17 +54,9 @@ public class PublicApiContractTest {
     @State("three transaction records exist")
     public void threeTransactionRecordsExist(Map<String, String> params) {
         testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
-        String mandateId;
-        if (params.get("agreement") != null) {
-            mandateId = params.get("agreement");
-        } else if (params.get("agreement_id") != null) {
-            mandateId = params.get("agreement_id");
-        } else {
-            throw new RuntimeException("Cannot run `three transaction records exist` pact test, couldn't get agreement id from params");
-        }
         MandateFixture testMandate = MandateFixture.aMandateFixture()
                 .withGatewayAccountFixture(testGatewayAccount)
-                .withExternalId(mandateId);
+                .withExternalId(params.get("agreement_id"));
         testMandate.insert(app.getTestContext().getJdbi());
         PayerFixture testPayer = PayerFixture.aPayerFixture().withMandateId(testMandate.getId());
         testPayer.insert(app.getTestContext().getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceITest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceITest.java
@@ -359,7 +359,7 @@ public class PaymentViewResourceITest {
                     .withMandateFixture(mandateFixture1)
                     .insert(testContext.getJdbi());
         }
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?agreement=:mandateId"
+        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?agreement_id=:mandateId"
                 .replace("{accountId}", gatewayAccountFixture.getExternalId())
                 .replace(":mandateId", mandateFixture1.getExternalId());
         givenSetup()


### PR DESCRIPTION
- remove backwards compability 'mandate' from search queryparams
- update relevant tests/api docs
- refactor `PaymentViewService` to use String literals instead of constants

