### PR TITLE
PP-3676 Remove asterisks from email payloads

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -15,7 +15,6 @@ import java.time.format.DateTimeFormatter;
 public class UserNotificationService {
 
     public static final String PLACEHOLDER_STATEMENT_NAME = "THE-CAKE-IS-A-LIE";
-    public static final String BANK_ACCOUNT_MASK_PREFIX = "******";
 
     private static final String DD_GUARANTEE_KEY = "dd guarantee link";
     private static final String MANDATE_REFERENCE_KEY = "mandate reference";
@@ -47,7 +46,7 @@ public class UserNotificationService {
         adminUsersClient.sendEmail(EmailTemplate.ON_DEMAND_MANDATE_CREATED, mandate,
                 ImmutableMap.<String, String>builder()
                         .put(MANDATE_REFERENCE_KEY, mandate.getMandateReference())
-                        .put(BANK_ACCOUNT_LAST_DIGITS_KEY, BANK_ACCOUNT_MASK_PREFIX + mandate.getPayer().getAccountNumberLastTwoDigits())
+                        .put(BANK_ACCOUNT_LAST_DIGITS_KEY, mandate.getPayer().getAccountNumberLastTwoDigits())
                         .put(STATEMENT_NAME_KEY, PLACEHOLDER_STATEMENT_NAME)
                         .put(DD_GUARANTEE_KEY, directDebitConfig.getLinks().getDirectDebitGuaranteeUrl())
                         .build()
@@ -77,7 +76,7 @@ public class UserNotificationService {
                         .put(AMOUNT_KEY, formatToPounds(transaction.getAmount()))
                         .put(COLLECTION_DATE_KEY, DATE_TIME_FORMATTER.format(earliestChargeDate))
                         .put(MANDATE_REFERENCE_KEY, transaction.getMandate().getMandateReference())
-                        .put(BANK_ACCOUNT_LAST_DIGITS_KEY, BANK_ACCOUNT_MASK_PREFIX + transaction.getMandate().getPayer().getAccountNumberLastTwoDigits())
+                        .put(BANK_ACCOUNT_LAST_DIGITS_KEY, transaction.getMandate().getPayer().getAccountNumberLastTwoDigits())
                         .put(STATEMENT_NAME_KEY, PLACEHOLDER_STATEMENT_NAME)
                         .put(DD_GUARANTEE_KEY, directDebitConfig.getLinks().getDirectDebitGuaranteeUrl())
                         .build());

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmMandateSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmMandateSetupResourceIT.java
@@ -73,6 +73,7 @@ public class ConfirmMandateSetupResourceIT {
         wireMockAdminUsers.start();
         gatewayAccountFixture.insert(testContext.getJdbi());
     }
+
     @Test
     public void confirm_shouldCreateAMandateAndUpdateCharge_ifMandateIsOneOff() {
         MandateFixture mandateFixture = MandateFixture.aMandateFixture()
@@ -87,7 +88,7 @@ public class ConfirmMandateSetupResourceIT {
                 .withState(PaymentState.NEW)
                 .insert(testContext.getJdbi());
 
-        String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length()-2);
+        String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length() - 2);
         String chargeDate = LocalDate.now().plusDays(4).format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
         String emailPayloadBody = "{\"address\": \"" + payerFixture.getEmail() + "\", " +
                 "\"gateway_account_external_id\": \"" + gatewayAccountFixture.getExternalId() + "\"," +
@@ -96,8 +97,8 @@ public class ConfirmMandateSetupResourceIT {
                 "{" +
                 "\"amount\": \"" + BigDecimal.valueOf(transactionFixture.getAmount(), 2).toString() + "\", " +
                 "\"mandate reference\": \"" + mandateFixture.getMandateReference() + "\", " +
-                "\"bank account last 2 digits\": \"******" +  lastTwoDigitsBankAccount + "\", " +
-                "\"collection date\": \"" +  chargeDate + "\", " +
+                "\"bank account last 2 digits\": \"" + lastTwoDigitsBankAccount + "\", " +
+                "\"collection date\": \"" + chargeDate + "\", " +
                 "\"SUN\": \"THE-CAKE-IS-A-LIE\", " +
                 "\"dd guarantee link\": \"http://Frontend/direct-debit-guarantee\"" +
                 "}" +
@@ -146,7 +147,7 @@ public class ConfirmMandateSetupResourceIT {
 //                "{" +
 //                "\"amount\": \"" + BigDecimal.valueOf(transactionFixture.getAmount(), 2).toString() + "\", " +
 //                "\"mandate reference\": \"" + mandateFixture.getMandateReference() + "\", " +
-//                "\"bank account last 2 digits\": \"******" +  lastTwoDigitsBankAccount + "\", " +
+//                "\"bank account last 2 digits\": \"" +  lastTwoDigitsBankAccount + "\", " +
 //                "\"collection date\": \"" +  chargeDate + "\", " +
 //                "\"SUN\": \"THE-CAKE-IS-A-LIE\", " +
 //                "\"dd guarantee link\": \"http://Frontend/direct-debit-guarantee\"" +
@@ -199,7 +200,7 @@ public class ConfirmMandateSetupResourceIT {
         stubCreateMandate(mandateFixture.getExternalId(), goCardlessCustomerFixture);
         stubCreatePayment(transactionFixture.getAmount(), "MD123", transactionFixture.getExternalId());
 
-        String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length()-2);
+        String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length() - 2);
         String emailPayloadBody = "{\"address\": \"" + payerFixture.getEmail() + "\", " +
                 "\"gateway_account_external_id\": \"" + gatewayAccountFixture.getExternalId() + "\"," +
                 "\"template\": \"ONE_OFF_PAYMENT_CONFIRMED\"," +
@@ -207,7 +208,7 @@ public class ConfirmMandateSetupResourceIT {
                 "{" +
                 "\"amount\": \"" + BigDecimal.valueOf(transactionFixture.getAmount(), 2).toString() + "\", " +
                 "\"mandate reference\": \"" + mandateFixture.getMandateReference() + "\", " +
-                "\"bank account last 2 digits\": \"******" +  lastTwoDigitsBankAccount + "\", " +
+                "\"bank account last 2 digits\": \"" + lastTwoDigitsBankAccount + "\", " +
                 "\"collection date\": \"2014-05-21\", " +
                 "\"SUN\": \"THE-CAKE-IS-A-LIE\", " +
                 "\"dd guarantee link\": \"http://Frontend/direct-debit-guarantee\"" +
@@ -215,7 +216,7 @@ public class ConfirmMandateSetupResourceIT {
                 "}";
 
         String confirmDetails =
-                "{\"sort_code\": \"" + payerFixture.getSortCode() + "\", " + 
+                "{\"sort_code\": \"" + payerFixture.getSortCode() + "\", " +
                         "\"account_number\": \"" + payerFixture.getAccountNumber() + "\", " +
                         "\"transaction_external_id\": \"" + transactionFixture.getExternalId() + "\"}";
 
@@ -270,7 +271,7 @@ public class ConfirmMandateSetupResourceIT {
 //                "{" +
 //                "\"amount\": \"" + BigDecimal.valueOf(transactionFixture.getAmount(), 2).toString() + "\", " +
 //                "\"mandate reference\": \"" + mandateFixture.getMandateReference() + "\", " +
-//                "\"bank account last 2 digits\": \"******" +  lastTwoDigitsBankAccount + "\", " +
+//                "\"bank account last 2 digits\": \"" +  lastTwoDigitsBankAccount + "\", " +
 //                "\"collection date\": \"2014-05-21\", " +
 //                "\"SUN\": \"THE-CAKE-IS-A-LIE\", " +
 //                "\"dd guarantee link\": \"http://Frontend/direct-debit-guarantee\"" +

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -72,7 +72,7 @@ public class UserNotificationServiceTest {
         userNotificationService = new UserNotificationService(mockAdminUsersClient, mockDirectDebitConfig);
         HashMap<String, String> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put("mandate reference", mandate.getMandateReference());
-        emailPersonalisation.put("bank account last 2 digits", UserNotificationService.BANK_ACCOUNT_MASK_PREFIX + mandate.getPayer().getAccountNumberLastTwoDigits());
+        emailPersonalisation.put("bank account last 2 digits", mandate.getPayer().getAccountNumberLastTwoDigits());
         emailPersonalisation.put("statement name", UserNotificationService.PLACEHOLDER_STATEMENT_NAME);
         emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
 
@@ -101,7 +101,7 @@ public class UserNotificationServiceTest {
         emailPersonalisation.put("amount", "123.45");
         emailPersonalisation.put("mandate reference", mandateFixture.getMandateReference());
         emailPersonalisation.put("collection date", "21/05/2018");
-        emailPersonalisation.put("bank account last 2 digits", UserNotificationService.BANK_ACCOUNT_MASK_PREFIX + payerFixture.getAccountNumberLastTwoDigits());
+        emailPersonalisation.put("bank account last 2 digits", payerFixture.getAccountNumberLastTwoDigits());
         emailPersonalisation.put("statement name", "THE-CAKE-IS-A-LIE");
         emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
 
@@ -118,7 +118,7 @@ public class UserNotificationServiceTest {
         emailPersonalisation.put("amount", "123.45");
         emailPersonalisation.put("mandate reference", mandateFixture.getMandateReference());
         emailPersonalisation.put("collection date", "21/05/2018");
-        emailPersonalisation.put("bank account last 2 digits", UserNotificationService.BANK_ACCOUNT_MASK_PREFIX + payerFixture.getAccountNumberLastTwoDigits());
+        emailPersonalisation.put("bank account last 2 digits", payerFixture.getAccountNumberLastTwoDigits());
         emailPersonalisation.put("statement name", "THE-CAKE-IS-A-LIE");
         emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
@@ -164,7 +164,7 @@ public class TransactionResourceIT {
                 "{" +
                 "\"amount\": \"" + BigDecimal.valueOf(AMOUNT, 2).toString() + "\", " +
                 "\"mandate reference\": \"" + mandateFixture.getMandateReference() + "\", " +
-                "\"bank account last 2 digits\": \"******" +  lastTwoDigitsBankAccount + "\", " +
+                "\"bank account last 2 digits\": \"" +  lastTwoDigitsBankAccount + "\", " +
                 "\"collection date\": \"" +  chargeDate + "\", " +
                 "\"statement name\": \"THE-CAKE-IS-A-LIE\", " +
                 "\"dd guarantee link\": \"http://Frontend/direct-debit-guarantee\"" +
@@ -231,7 +231,7 @@ public class TransactionResourceIT {
                 "{" +
                 "\"amount\": \"" + BigDecimal.valueOf(AMOUNT, 2).toString() + "\", " +
                 "\"mandate reference\": \"" + mandateFixture.getMandateReference() + "\", " +
-                "\"bank account last 2 digits\": \"******" +  lastTwoDigitsBankAccount + "\", " +
+                "\"bank account last 2 digits\": \"" +  lastTwoDigitsBankAccount + "\", " +
                 "\"collection date\": \"21/05/2014\", " +
                 "\"statement name\": \"THE-CAKE-IS-A-LIE\", " +
                 "\"dd guarantee link\": \"http://Frontend/direct-debit-guarantee\"" +


### PR DESCRIPTION
## WHAT

Our email provider fixed the bug where the asterisks were truncated to two `**` if they are defined in the email provider's template.
Now we can move them to the template definition.

We will clean-up the commented tests in the next PR as well

with @georgeracu
