### PR TITLE
PP-3942 Introduce SortCode object

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/ConfirmationDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/ConfirmationDetails.java
@@ -1,16 +1,17 @@
 package uk.gov.pay.directdebit.mandate.model;
 
+import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
 public class ConfirmationDetails {
     private Mandate mandate;
     private Transaction transaction;
     private String accountNumber;
-    private String sortCode;
+    private SortCode sortCode;
 
     public ConfirmationDetails(Mandate mandate,
             Transaction transaction, String accountNumber,
-            String sortCode) {
+            SortCode sortCode) {
         this.mandate = mandate;
         this.transaction = transaction;
         this.accountNumber = accountNumber;
@@ -29,7 +30,7 @@ public class ConfirmationDetails {
         return accountNumber;
     }
 
-    public String getSortCode() {
+    public SortCode getSortCode() {
         return sortCode;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -22,6 +22,7 @@ import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
+import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent;
 import uk.gov.pay.directdebit.payments.model.Token;
@@ -343,7 +344,7 @@ public class MandateService {
      * @param mandateExternalId
      */
     public ConfirmationDetails confirm(String mandateExternalId, Map<String, String> confirmDetailsRequest) {
-        String sortCode = confirmDetailsRequest.get("sort_code");
+        SortCode sortCode = SortCode.of(confirmDetailsRequest.get("sort_code"));
         String accountNumber = confirmDetailsRequest.get("account_number");
         Mandate mandate = confirmedDirectDebitDetailsFor(mandateExternalId);
         Transaction transaction = Optional

--- a/src/main/java/uk/gov/pay/directdebit/payers/api/PayerParser.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/PayerParser.java
@@ -1,8 +1,10 @@
 package uk.gov.pay.directdebit.payers.api;
 
-import java.util.Map;
 import org.mindrot.jbcrypt.BCrypt;
 import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payers.model.SortCode;
+
+import java.util.Map;
 
 public class PayerParser {
 
@@ -12,13 +14,13 @@ public class PayerParser {
 
     public Payer parse(Map<String, String> createPayerMap, Long mandateId) {
         String accountNumber = createPayerMap.get("account_number");
-        String sortCode = createPayerMap.get("sort_code");
+        SortCode sortCode = SortCode.of(createPayerMap.get("sort_code"));
         String bankName = createPayerMap.getOrDefault("bank_name", null);
         return new Payer(
                 mandateId,
                 createPayerMap.get("account_holder_name"),
                 createPayerMap.get("email"),
-                encrypt(sortCode),
+                encrypt(sortCode.toString()),
                 encrypt(accountNumber),
                 accountNumber.substring(accountNumber.length()-2),
                 bankName,

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetails.java
@@ -3,9 +3,9 @@ package uk.gov.pay.directdebit.payers.model;
 public class BankAccountDetails {
 
     private final String accountNumber;
-    private final String sortCode;
+    private final SortCode sortCode;
 
-    public BankAccountDetails(String accountNumber, String sortCode) {
+    public BankAccountDetails(String accountNumber, SortCode sortCode) {
         this.accountNumber = accountNumber;
         this.sortCode = sortCode;
     }
@@ -14,7 +14,7 @@ public class BankAccountDetails {
         return accountNumber;
     }
 
-    public String getSortCode() {
+    public SortCode getSortCode() {
         return sortCode;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetailsParser.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetailsParser.java
@@ -5,7 +5,7 @@ import java.util.Map;
 public class BankAccountDetailsParser {
     public BankAccountDetails parse(Map<String, String> bankAccountDetails) {
             String accountNumber = bankAccountDetails.get("account_number");
-            String sortCode = bankAccountDetails.get("sort_code");
+            SortCode sortCode = SortCode.of(bankAccountDetails.get("sort_code"));
             return new BankAccountDetails(accountNumber, sortCode);
         }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/SortCode.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/SortCode.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.directdebit.payers.model;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * A UK bank account sort code with no spaces or dashes e.g "123456"
+ * Guaranteed to be well-formed (six Arabic numerals) but not necessarily
+ * valid (in the sense of representing a real bank and branch)
+ */
+public class SortCode {
+
+    private static final Pattern SIX_ARABIC_NUMERALS = Pattern.compile("[0-9]{6}");
+
+    private final String sortCode;
+
+    private SortCode(String sortCode) throws IllegalArgumentException {
+        Objects.requireNonNull(sortCode);
+        if (!SIX_ARABIC_NUMERALS.matcher(sortCode).matches()) {
+            throw new IllegalArgumentException("Sort code must consist of exactly six Arabic numerals e.g. \"123456\"");
+        }
+        this.sortCode = sortCode;
+    }
+
+    public static SortCode of(String sortCode) throws IllegalArgumentException {
+        return new SortCode(sortCode);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == SortCode.class) {
+            SortCode that = (SortCode) other;
+            return this.sortCode.equals(that.sortCode);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return sortCode.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return sortCode;
+    }
+    
+}

--- a/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/resources/PayerResource.java
@@ -1,7 +1,17 @@
 package uk.gov.pay.directdebit.payers.resources;
 
-import java.net.URI;
-import java.util.Map;
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.common.util.URIBuilder;
+import uk.gov.pay.directdebit.common.validation.BankAccountDetailsValidator;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
+import uk.gov.pay.directdebit.payers.api.CreatePayerResponse;
+import uk.gov.pay.directdebit.payers.api.CreatePayerValidator;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProvider;
+import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
+
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -12,16 +22,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import org.slf4j.Logger;
-import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
-import uk.gov.pay.directdebit.common.util.URIBuilder;
-import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
-import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
-import uk.gov.pay.directdebit.payers.api.CreatePayerResponse;
-import uk.gov.pay.directdebit.payers.api.CreatePayerValidator;
-import uk.gov.pay.directdebit.payers.model.Payer;
-import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProvider;
-import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
+import java.net.URI;
+import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -30,6 +32,8 @@ public class PayerResource {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(PayerResource.class);
     private final PaymentProviderFactory paymentProviderFactory;
     private final CreatePayerValidator createPayerValidator = new CreatePayerValidator();
+    private final BankAccountDetailsValidator bankAccountDetailsValidator = new BankAccountDetailsValidator();
+
     @Inject
     public PayerResource(PaymentProviderFactory paymentProviderFactory) {
         this.paymentProviderFactory = paymentProviderFactory;
@@ -63,6 +67,7 @@ public class PayerResource {
             @PathParam("accountId") GatewayAccount gatewayAccount,
             @PathParam("mandateExternalId") String mandateExternalId,
             Map<String, String> bankAccountDetails) {
+        bankAccountDetailsValidator.validate(bankAccountDetails);
         LOGGER.info("Validating bank account details for mandate with id: {}", mandateExternalId);
         DirectDebitPaymentProvider payerService = paymentProviderFactory.getServiceFor(gatewayAccount.getPaymentProvider());
         BankAccountValidationResponse response = payerService.validate(mandateExternalId, bankAccountDetails);

--- a/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFacade.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFacade.java
@@ -4,8 +4,6 @@ import com.gocardless.resources.BankDetailsLookup;
 import com.gocardless.resources.Customer;
 import com.gocardless.resources.CustomerBankAccount;
 import com.gocardless.resources.Payment;
-import java.time.LocalDate;
-import javax.inject.Inject;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
@@ -13,7 +11,11 @@ import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
 import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.model.Transaction;
+
+import javax.inject.Inject;
+import java.time.LocalDate;
 
 import static com.gocardless.resources.BankDetailsLookup.AvailableDebitScheme.BACS;
 
@@ -34,7 +36,7 @@ public class GoCardlessClientFacade {
     }
 
     public GoCardlessCustomer createCustomerBankAccount(String mandateExternalId, GoCardlessCustomer customer,
-                                                        String accountHolderName, String sortCode, String accountNumber) {
+                                                        String accountHolderName, SortCode sortCode, String accountNumber) {
         CustomerBankAccount gcCustomerBankAccount = goCardlessClientWrapper.createCustomerBankAccount(mandateExternalId, customer,
                 accountHolderName, sortCode, accountNumber);
         customer.setCustomerBankAccountId(gcCustomerBankAccount.getId());

--- a/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
@@ -11,6 +11,7 @@ import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
 import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
 //thin abstraction over the client provided in the SDK
@@ -33,12 +34,12 @@ public class GoCardlessClientWrapper {
     }
 
     public CustomerBankAccount createCustomerBankAccount(String mandateExternalId, GoCardlessCustomer customer,
-                                                         String accountHolderName, String sortCode, String accountNumber){
+                                                         String accountHolderName, SortCode sortCode, String accountNumber){
         return goCardlessClient.customerBankAccounts()
                 .create()
                 .withAccountHolderName(accountHolderName)
                 .withAccountNumber(accountNumber)
-                .withBranchCode(sortCode)
+                .withBranchCode(sortCode.toString())
                 .withCountryCode("GB")
                 .withLinksCustomer(customer.getCustomerId())
                 .withIdempotencyKey(mandateExternalId)
@@ -66,7 +67,7 @@ public class GoCardlessClientWrapper {
     public BankDetailsLookup validate(BankAccountDetails bankAccountDetails) {
         return goCardlessClient.bankDetailsLookups().create()
                 .withAccountNumber(bankAccountDetails.getAccountNumber())
-                .withBranchCode(bankAccountDetails.getSortCode())
+                .withBranchCode(bankAccountDetails.getSortCode().toString())
                 .withCountryCode("GB")
                 .execute();
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
@@ -6,15 +6,29 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessMandateDao;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessPaymentDao;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
-import uk.gov.pay.directdebit.mandate.model.*;
+import uk.gov.pay.directdebit.mandate.model.ConfirmationDetails;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.mandate.services.MandateService;
 import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
 import uk.gov.pay.directdebit.payers.dao.GoCardlessCustomerDao;
-import uk.gov.pay.directdebit.payers.model.*;
+import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
+import uk.gov.pay.directdebit.payers.model.BankAccountDetailsParser;
+import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
+import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
+import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payers.services.PayerService;
 import uk.gov.pay.directdebit.payments.clients.GoCardlessClientFacade;
 import uk.gov.pay.directdebit.payments.dao.GoCardlessEventDao;
-import uk.gov.pay.directdebit.payments.exception.*;
+import uk.gov.pay.directdebit.payments.exception.CreateCustomerBankAccountFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreateCustomerFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreateMandateFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreatePaymentFailedException;
+import uk.gov.pay.directdebit.payments.exception.GoCardlessMandateNotFoundException;
+import uk.gov.pay.directdebit.payments.exception.GoCardlessPaymentNotFoundException;
 import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProvider;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.Transaction;
@@ -128,7 +142,8 @@ public class GoCardlessService implements DirectDebitPaymentProvider {
         }
     }
 
-    private void createCustomerBankAccount(String mandateExternalId, GoCardlessCustomer goCardlessCustomer, Payer payer, String sortCode, String accountNumber) {
+    private void createCustomerBankAccount(String mandateExternalId, GoCardlessCustomer goCardlessCustomer, Payer payer,
+                                           SortCode sortCode, String accountNumber) {
         try {
             LOGGER.info("Attempting to call gocardless to create a customer bank account, mandate id: {}", mandateExternalId);
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.directdebit.mandate.services;
 
 import com.google.common.collect.ImmutableMap;
-import org.hamcrest.Matchers;
-import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,6 +23,7 @@ import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
+import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
 import uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
@@ -178,7 +177,7 @@ public class MandateServiceTest {
 
         verify(mockedDirectDebitEventService).registerPayerEditedEventFor(mandate);
         verifyZeroInteractions(mockedMandateDao);
-        assertThat(mandate.getState(), Matchers.is(AWAITING_DIRECT_DEBIT_DETAILS));
+        assertThat(mandate.getState(), is(AWAITING_DIRECT_DEBIT_DETAILS));
     }
 
     @Test
@@ -191,7 +190,7 @@ public class MandateServiceTest {
                 .thenReturn(Optional.of(mandate));
         service.receiveDirectDebitDetailsFor(mandate.getExternalId());
         verify(mockedDirectDebitEventService).registerDirectDebitReceivedEventFor(mandate);
-        assertThat(mandate.getState(), Matchers.is(AWAITING_DIRECT_DEBIT_DETAILS));
+        assertThat(mandate.getState(), is(AWAITING_DIRECT_DEBIT_DETAILS));
     }
 
     @Test
@@ -400,10 +399,10 @@ public class MandateServiceTest {
         Mandate mandate = MandateFixture.aMandateFixture().withState(MandateState.AWAITING_DIRECT_DEBIT_DETAILS).withExternalId(mandateExternalId).toEntity();
         when(mockedMandateDao.findByExternalId(mandateExternalId)).thenReturn(Optional.of(mandate));
         ConfirmationDetails confirmationDetails = service.confirm(mandateExternalId, confirmMandateRequest);
-        assertThat(confirmationDetails.getMandate(), Is.is(mandate));
-        assertThat(confirmationDetails.getSortCode(), Is.is("123456"));
-        assertThat(confirmationDetails.getAccountNumber(), Is.is("12345678"));
-        assertThat(confirmationDetails.getTransaction(), Is.is(nullValue()));
+        assertThat(confirmationDetails.getMandate(), is(mandate));
+        assertThat(confirmationDetails.getSortCode(), is(SortCode.of("123456")));
+        assertThat(confirmationDetails.getAccountNumber(), is("12345678"));
+        assertThat(confirmationDetails.getTransaction(), is(nullValue()));
     }
 
     @Test
@@ -418,10 +417,10 @@ public class MandateServiceTest {
         when(mockedMandateDao.findByExternalId(mandateExternalId)).thenReturn(Optional.of(mandate));
         when(mockedTransactionService.findTransactionForExternalId(transactionExternaId)).thenReturn(transaction);
         ConfirmationDetails confirmationDetails = service.confirm(mandateExternalId, confirmMandateRequest);
-        assertThat(confirmationDetails.getMandate(), Is.is(mandate));
-        assertThat(confirmationDetails.getSortCode(), Is.is("123456"));
-        assertThat(confirmationDetails.getAccountNumber(), Is.is("12345678"));
-        assertThat(confirmationDetails.getTransaction(), Is.is(transaction));
+        assertThat(confirmationDetails.getMandate(), is(mandate));
+        assertThat(confirmationDetails.getSortCode(), is(SortCode.of("123456")));
+        assertThat(confirmationDetails.getAccountNumber(), is("12345678"));
+        assertThat(confirmationDetails.getTransaction(), is(transaction));
     }
 
     private Map<String, String> getMandateRequestPayload() {

--- a/src/test/java/uk/gov/pay/directdebit/payers/model/SortCodeTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/model/SortCodeTest.java
@@ -1,0 +1,110 @@
+package uk.gov.pay.directdebit.payers.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+public class SortCodeTest {
+
+    @Test
+    public void sortCodeWithExactlySixArabicNumeralsAccepted() {
+        SortCode.of("123456");
+    }
+
+    @Test
+    public void sortCodeWithLeadingZeroesAccepted() {
+        SortCode.of("073436");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sortCodeWithFewerThanSixDigitsNotAccepted() {
+        SortCode.of("12345");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sortCodeWithMoreThanSixDigitsNotAccepted() {
+        SortCode.of("1234567");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sortCodeWithNonArabicNumeralsNotAccepted() {
+        SortCode.of("12345١");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sortCodeWithDashesNotAccepted() {
+        SortCode.of("12-34-56");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sortCodeWithSpacesNotAccepted() {
+        SortCode.of("12 34 56");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sortCodeWithHexadecimalDigitsNotAccepted() {
+        SortCode.of("1234FF");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sortCodeWithLettersNotAccepted() {
+        SortCode.of("sextus");
+    }
+    
+    @Test
+    public void twoSortCodesWithTheSameDigitsAreEqual() {
+        SortCode sortCode1 = SortCode.of("123456");
+        SortCode sortCode2 = SortCode.of("123456");
+        
+        assertThat(sortCode1.equals(sortCode2), is(true));
+    }
+
+    @Test
+    public void twoSortCodesWithDifferentDigitsAreNotEqual() {
+        SortCode sortCode1 = SortCode.of("123456");
+        SortCode sortCode2 = SortCode.of("654321");
+
+        assertThat(sortCode1.equals(sortCode2), is(false));
+        assertThat(sortCode2.equals(sortCode1), is(false));
+    }
+
+    @Test
+    public void sortCodeIsNotEqualToTheStringificationOfItself() {
+        SortCode sortCode = SortCode.of("123456");
+
+        assertThat(sortCode.equals("123456"), is(false));
+    }
+
+    @Test
+    public void sortCodeIsNotEqualToNull() {
+        SortCode sortCode = SortCode.of("123456");
+
+        assertThat(sortCode.equals(null), is(false));
+    }
+    
+    @Test
+    public void twoSortCodesWithTheSameDigitsHaveTheSameHashCode() {
+        SortCode sortCode1 = SortCode.of("123456");
+        SortCode sortCode2 = SortCode.of("123456");
+
+        assertThat(sortCode1.hashCode(), is(sortCode2.hashCode()));
+    }
+
+    @Test
+    public void twoSortCodesWithDifferentDigitsHaveDifferentHashCodes() {
+        SortCode sortCode1 = SortCode.of("123456");
+        SortCode sortCode2 = SortCode.of("654321");
+
+        assertThat(sortCode1.hashCode(), not(sortCode2.hashCode()));
+    }
+
+    @Test
+    public void sortCodeToStringsToTheStringificationOfItself() {
+        SortCode sortCode = SortCode.of("123456");
+        
+        assertThat(sortCode.toString(), is("123456"));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFacadeTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFacadeTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
+import uk.gov.pay.directdebit.payers.model.SortCode;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,7 +27,7 @@ public class GoCardlessClientFacadeTest {
 
     private static final String BANK_NAME = "Awesome Bank";
 
-    private final BankAccountDetails bankAccountDetails = new BankAccountDetails("12345678", "123456");
+    private final BankAccountDetails bankAccountDetails = new BankAccountDetails("12345678", SortCode.of("123456"));
 
     @Mock
     private GoCardlessClientWrapper mockGoCardlessClientWrapper;

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/ConfirmationDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/ConfirmationDetailsFixture.java
@@ -3,12 +3,13 @@ package uk.gov.pay.directdebit.payments.fixtures;
 import org.apache.commons.lang.RandomStringUtils;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.ConfirmationDetails;
+import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
 public class ConfirmationDetailsFixture {
 
     private MandateFixture mandateFixture = MandateFixture.aMandateFixture();
-    private String sortCode = RandomStringUtils.randomNumeric(6);
+    private SortCode sortCode = SortCode.of(RandomStringUtils.randomNumeric(6));
     private String accountNumber = RandomStringUtils.randomNumeric(8);
     private TransactionFixture transactionFixture = null;
     
@@ -29,7 +30,7 @@ public class ConfirmationDetailsFixture {
         return this;
     }
     
-    public ConfirmationDetailsFixture withSortCode(String sortCode) {
+    public ConfirmationDetailsFixture withSortCode(SortCode sortCode) {
         this.sortCode = sortCode;
         return this;
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceOneOffTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceOneOffTest.java
@@ -16,7 +16,13 @@ import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
-import uk.gov.pay.directdebit.payments.exception.*;
+import uk.gov.pay.directdebit.payers.model.SortCode;
+import uk.gov.pay.directdebit.payments.exception.CreateCustomerBankAccountFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreateCustomerFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreateMandateFailedException;
+import uk.gov.pay.directdebit.payments.exception.CreatePaymentFailedException;
+import uk.gov.pay.directdebit.payments.exception.GoCardlessMandateNotFoundException;
+import uk.gov.pay.directdebit.payments.exception.GoCardlessPaymentNotFoundException;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.Transaction;
@@ -28,7 +34,9 @@ import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture.aGoCardlessEventFixture;
 
@@ -144,11 +152,11 @@ public class GoCardlessServiceOneOffTest extends GoCardlessServiceTest {
     @Test
     public void shouldValidateBankAccountDetails() {
         String accountNumber = "12345678";
-        String sortCode = "123456";
+        SortCode sortCode = SortCode.of("123456");
         BankAccountDetails bankAccountDetails = new BankAccountDetails(accountNumber, sortCode);
         Map<String, String> bankAccountDetailsRequest = ImmutableMap.of(
                 "account_number", accountNumber,
-                "sort_code", sortCode
+                "sort_code", sortCode.toString()
         );
         GoCardlessBankAccountLookup goCardlessBankAccountLookup = new GoCardlessBankAccountLookup("Great Bank of Cake", true);
         when(mockedBankAccountDetailsParser.parse(bankAccountDetailsRequest)).thenReturn(bankAccountDetails);
@@ -161,11 +169,11 @@ public class GoCardlessServiceOneOffTest extends GoCardlessServiceTest {
     @Test
     public void shouldValidateBankAccountDetails_ifGoCardlessReturnsInvalidLookup() {
         String accountNumber = "12345678";
-        String sortCode = "123467";
+        SortCode sortCode = SortCode.of("123467");
         BankAccountDetails bankAccountDetails = new BankAccountDetails(accountNumber, sortCode);
         Map<String, String> bankAccountDetailsRequest = ImmutableMap.of(
                 "account_number", accountNumber,
-                "sort_code", sortCode
+                "sort_code", sortCode.toString()
         );
         GoCardlessBankAccountLookup goCardlessBankAccountLookup = new GoCardlessBankAccountLookup(null, false);
         when(mockedBankAccountDetailsParser.parse(bankAccountDetailsRequest)).thenReturn(bankAccountDetails);
@@ -178,11 +186,11 @@ public class GoCardlessServiceOneOffTest extends GoCardlessServiceTest {
     @Test
     public void shouldValidateBankAccountDetails_ifExceptionIsThrownFromGC() {
         String accountNumber = "12345678";
-        String sortCode = "123467";
+        SortCode sortCode = SortCode.of("123467");
         BankAccountDetails bankAccountDetails = new BankAccountDetails(accountNumber, sortCode);
         Map<String, String> bankAccountDetailsRequest = ImmutableMap.of(
                 "account_number", accountNumber,
-                "sort_code", sortCode
+                "sort_code", sortCode.toString()
         );
         when(mockedBankAccountDetailsParser.parse(bankAccountDetailsRequest)).thenReturn(bankAccountDetails);
         when(mockedGoCardlessClientFacade.validate(bankAccountDetails)).thenThrow(new RuntimeException());

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.directdebit.payers.dao.GoCardlessCustomerDao;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetailsParser;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
+import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payers.services.PayerService;
 import uk.gov.pay.directdebit.payments.clients.GoCardlessClientFacade;
 import uk.gov.pay.directdebit.payments.dao.GoCardlessEventDao;
@@ -33,7 +34,7 @@ public abstract class GoCardlessServiceTest {
     static final String BANK_ACCOUNT_ID = "BA34983496";
     static final String MANDATE_ID = "sdkfhsdkjfhjdks";
     static final String TRANSACTION_ID = "sdkfhsd2jfhjdks";
-    static final String SORT_CODE = "123456";
+    static final SortCode SORT_CODE = SortCode.of("123456");
     static final String ACCOUNT_NUMBER = "12345678";
 
     @Rule
@@ -74,7 +75,7 @@ public abstract class GoCardlessServiceTest {
             .withExternalId(TRANSACTION_ID)
             .toEntity();
     Map<String, String> confirmDetails = ImmutableMap.of(
-            "sort_code", SORT_CODE,
+            "sort_code", SORT_CODE.toString(),
             "account_number", ACCOUNT_NUMBER,
             "transaction_external_id", TRANSACTION_ID
     );


### PR DESCRIPTION
The `SortCode` object represents a UK bank account sort code with no dashes or spaces e.g. `"123456"`. It performs a check when it’s constructed to ensure that it consists of exactly six Arabic numerals.

It’s safe to do this in most cases because `SortCode` objects are usually only ever created to represent data in requests and most of our resources ensure the sort codes match the correct format before the `SortCode` objects are created.

The exception was the bank account details validation resource, which performed no such checks. This has now been updated to check that the `sort_code` and `account_number` fields are present and that they are both numeric strings with appropriate lengths. While this change has may cause some behaviour changes, they won’t affect us in practice because only Direct Debit frontend calls this endpoint and it only sends well-formed input in the correct format (see commit bb8fe2d1b4aeec5a23bc1d18d788433767a79447 for details).

Note that there’s no guarantee that a `SortCode` object actually represents a real bank and branch, only that it’s exactly six Arabic numerals. 

The `sortCode` field in the `Payer` class remains a `String` rather than becoming a `SortCode` object because we hash the sort code before passing it to the `Payer` constructor (except in some tests), so it isn’t actually a sort code. This also means that `SortCode` objects are never persisted or depersisted: they are entirely ephemeral.