### PR TITLE
PP-3942 Introduce AccountNumber

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/ConfirmationDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/ConfirmationDetails.java
@@ -1,16 +1,17 @@
 package uk.gov.pay.directdebit.mandate.model;
 
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
 public class ConfirmationDetails {
     private Mandate mandate;
     private Transaction transaction;
-    private String accountNumber;
+    private AccountNumber accountNumber;
     private SortCode sortCode;
 
     public ConfirmationDetails(Mandate mandate,
-            Transaction transaction, String accountNumber,
+            Transaction transaction, AccountNumber accountNumber,
             SortCode sortCode) {
         this.mandate = mandate;
         this.transaction = transaction;
@@ -26,7 +27,7 @@ public class ConfirmationDetails {
         return mandate;
     }
 
-    public String getAccountNumber() {
+    public AccountNumber getAccountNumber() {
         return accountNumber;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -22,6 +22,7 @@ import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent;
@@ -345,7 +346,7 @@ public class MandateService {
      */
     public ConfirmationDetails confirm(String mandateExternalId, Map<String, String> confirmDetailsRequest) {
         SortCode sortCode = SortCode.of(confirmDetailsRequest.get("sort_code"));
-        String accountNumber = confirmDetailsRequest.get("account_number");
+        AccountNumber accountNumber = AccountNumber.of(confirmDetailsRequest.get("account_number"));
         Mandate mandate = confirmedDirectDebitDetailsFor(mandateExternalId);
         Transaction transaction = Optional
                 .ofNullable(confirmDetailsRequest.get("transaction_external_id"))

--- a/src/main/java/uk/gov/pay/directdebit/payers/api/PayerParser.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/PayerParser.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.payers.api;
 
 import org.mindrot.jbcrypt.BCrypt;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payers.model.SortCode;
 
@@ -13,7 +14,7 @@ public class PayerParser {
     }
 
     public Payer parse(Map<String, String> createPayerMap, Long mandateId) {
-        String accountNumber = createPayerMap.get("account_number");
+        AccountNumber accountNumber = AccountNumber.of(createPayerMap.get("account_number"));
         SortCode sortCode = SortCode.of(createPayerMap.get("sort_code"));
         String bankName = createPayerMap.getOrDefault("bank_name", null);
         return new Payer(
@@ -21,8 +22,8 @@ public class PayerParser {
                 createPayerMap.get("account_holder_name"),
                 createPayerMap.get("email"),
                 encrypt(sortCode.toString()),
-                encrypt(accountNumber),
-                accountNumber.substring(accountNumber.length()-2),
+                encrypt(accountNumber.toString()),
+                accountNumber.getLastTwoDigits(),
                 bankName,
                 Boolean.parseBoolean(createPayerMap.get("requires_authorisation")));
     }

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/AccountNumber.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/AccountNumber.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.directdebit.payers.model;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * A UK bank account number with no dashes or spaces e.g "12345678"
+ * Guaranteed to be well-formed (six to eight Arabic numerals
+ * inclusive) but not necessarily valid (in the sense of representing
+ * a real bank account)
+ */
+public class AccountNumber {
+
+    private static final Pattern SIX_TO_EIGHT_ARABIC_NUMERALS = Pattern.compile("[0-9]{6,8}");
+
+    private final String accountNumber;
+
+    private AccountNumber(String accountNumber) throws IllegalArgumentException {
+        Objects.requireNonNull(accountNumber);
+        if (!SIX_TO_EIGHT_ARABIC_NUMERALS.matcher(accountNumber).matches()) {
+            throw new IllegalArgumentException("Account number must consist of six to eight Arabic numerals inclusive e.g. \"12345678\"");
+        }
+        this.accountNumber = accountNumber;
+    }
+
+    public static AccountNumber of(String accountNumber) throws IllegalArgumentException {
+        return new AccountNumber(accountNumber);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == AccountNumber.class) {
+            AccountNumber that = (AccountNumber) other;
+            return this.accountNumber.equals(that.accountNumber);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return accountNumber.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return accountNumber;
+    }
+
+    public String getLastTwoDigits() {
+        return accountNumber.substring(accountNumber.length() - 2);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetails.java
@@ -2,15 +2,15 @@ package uk.gov.pay.directdebit.payers.model;
 
 public class BankAccountDetails {
 
-    private final String accountNumber;
+    private final AccountNumber accountNumber;
     private final SortCode sortCode;
 
-    public BankAccountDetails(String accountNumber, SortCode sortCode) {
+    public BankAccountDetails(AccountNumber accountNumber, SortCode sortCode) {
         this.accountNumber = accountNumber;
         this.sortCode = sortCode;
     }
 
-    public String getAccountNumber() {
+    public AccountNumber getAccountNumber() {
         return accountNumber;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetailsParser.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetailsParser.java
@@ -3,9 +3,10 @@ package uk.gov.pay.directdebit.payers.model;
 import java.util.Map;
 
 public class BankAccountDetailsParser {
+
     public BankAccountDetails parse(Map<String, String> bankAccountDetails) {
-            String accountNumber = bankAccountDetails.get("account_number");
-            SortCode sortCode = SortCode.of(bankAccountDetails.get("sort_code"));
-            return new BankAccountDetails(accountNumber, sortCode);
-        }
+        AccountNumber accountNumber = AccountNumber.of(bankAccountDetails.get("account_number"));
+        SortCode sortCode = SortCode.of(bankAccountDetails.get("sort_code"));
+        return new BankAccountDetails(accountNumber, sortCode); 
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFacade.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFacade.java
@@ -7,6 +7,7 @@ import com.gocardless.resources.Payment;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
@@ -36,7 +37,7 @@ public class GoCardlessClientFacade {
     }
 
     public GoCardlessCustomer createCustomerBankAccount(String mandateExternalId, GoCardlessCustomer customer,
-                                                        String accountHolderName, SortCode sortCode, String accountNumber) {
+                                                        String accountHolderName, SortCode sortCode, AccountNumber accountNumber) {
         CustomerBankAccount gcCustomerBankAccount = goCardlessClientWrapper.createCustomerBankAccount(mandateExternalId, customer,
                 accountHolderName, sortCode, accountNumber);
         customer.setCustomerBankAccountId(gcCustomerBankAccount.getId());

--- a/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientWrapper.java
@@ -8,6 +8,7 @@ import com.gocardless.resources.Mandate;
 import com.gocardless.resources.Payment;
 import com.gocardless.services.PaymentService;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
 import uk.gov.pay.directdebit.payers.model.Payer;
@@ -34,11 +35,11 @@ public class GoCardlessClientWrapper {
     }
 
     public CustomerBankAccount createCustomerBankAccount(String mandateExternalId, GoCardlessCustomer customer,
-                                                         String accountHolderName, SortCode sortCode, String accountNumber){
+                                                         String accountHolderName, SortCode sortCode, AccountNumber accountNumber){
         return goCardlessClient.customerBankAccounts()
                 .create()
                 .withAccountHolderName(accountHolderName)
-                .withAccountNumber(accountNumber)
+                .withAccountNumber(accountNumber.toString())
                 .withBranchCode(sortCode.toString())
                 .withCountryCode("GB")
                 .withLinksCustomer(customer.getCustomerId())
@@ -66,7 +67,7 @@ public class GoCardlessClientWrapper {
 
     public BankDetailsLookup validate(BankAccountDetails bankAccountDetails) {
         return goCardlessClient.bankDetailsLookups().create()
-                .withAccountNumber(bankAccountDetails.getAccountNumber())
+                .withAccountNumber(bankAccountDetails.getAccountNumber().toString())
                 .withBranchCode(bankAccountDetails.getSortCode().toString())
                 .withCountryCode("GB")
                 .execute();

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessService.java
@@ -14,6 +14,7 @@ import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.mandate.services.MandateService;
 import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
 import uk.gov.pay.directdebit.payers.dao.GoCardlessCustomerDao;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetailsParser;
 import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
@@ -143,7 +144,7 @@ public class GoCardlessService implements DirectDebitPaymentProvider {
     }
 
     private void createCustomerBankAccount(String mandateExternalId, GoCardlessCustomer goCardlessCustomer, Payer payer,
-                                           SortCode sortCode, String accountNumber) {
+                                           SortCode sortCode, AccountNumber accountNumber) {
         try {
             LOGGER.info("Attempting to call gocardless to create a customer bank account, mandate id: {}", mandateExternalId);
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
 import uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture;
@@ -401,7 +402,7 @@ public class MandateServiceTest {
         ConfirmationDetails confirmationDetails = service.confirm(mandateExternalId, confirmMandateRequest);
         assertThat(confirmationDetails.getMandate(), is(mandate));
         assertThat(confirmationDetails.getSortCode(), is(SortCode.of("123456")));
-        assertThat(confirmationDetails.getAccountNumber(), is("12345678"));
+        assertThat(confirmationDetails.getAccountNumber(), is(AccountNumber.of("12345678")));
         assertThat(confirmationDetails.getTransaction(), is(nullValue()));
     }
 
@@ -419,7 +420,7 @@ public class MandateServiceTest {
         ConfirmationDetails confirmationDetails = service.confirm(mandateExternalId, confirmMandateRequest);
         assertThat(confirmationDetails.getMandate(), is(mandate));
         assertThat(confirmationDetails.getSortCode(), is(SortCode.of("123456")));
-        assertThat(confirmationDetails.getAccountNumber(), is("12345678"));
+        assertThat(confirmationDetails.getAccountNumber(), is(AccountNumber.of("12345678")));
         assertThat(confirmationDetails.getTransaction(), is(transaction));
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payers/model/AccountNumberTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/model/AccountNumberTest.java
@@ -1,0 +1,157 @@
+package uk.gov.pay.directdebit.payers.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+public class AccountNumberTest {
+
+    @Test
+    public void accountNumberWithExactlySixArabicNumeralsAccepted() {
+        AccountNumber.of("123456");
+    }
+
+    @Test
+    public void accountNumberWithExactlySevenArabicNumeralsAccepted() {
+        AccountNumber.of("1234567");
+    }
+
+    @Test
+    public void accountNumberWithExactlyEightArabicNumeralsAccepted() {
+        AccountNumber.of("12345678");
+    }
+
+    @Test
+    public void accountNumberWithLeadingZeroesAccepted() {
+        AccountNumber.of("00123456");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void accountNumberWithFewerThanSixDigitsNotAccepted() {
+        AccountNumber.of("12345");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void accountNumberWithMoreThanEightDigitsNotAccepted() {
+        AccountNumber.of("123456789");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void accountNumberWithNonArabicNumeralsNotAccepted() {
+        AccountNumber.of("1234567١");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void accountNumberWithDashesNotAccepted() {
+        AccountNumber.of("12-34-56-78");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void accountNumberWithSpacesNotAccepted() {
+        AccountNumber.of("12 34 56 78");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void accountNumberWithHexadecimalDigitsNotAccepted() {
+        AccountNumber.of("123456FF");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void accountNumberWithLettersNotAccepted() {
+        AccountNumber.of("eatcake");
+    }
+
+    @Test
+    public void twoAccountNumbersWithTheSameDigitsAreEqual() {
+        AccountNumber accountNumber1 = AccountNumber.of("12345678");
+        AccountNumber accountNumber2 = AccountNumber.of("12345678");
+
+        assertThat(accountNumber1.equals(accountNumber2), is(true));
+    }
+
+    @Test
+    public void twoAccountNumbersWithDifferentDigitsAreNotEqual() {
+        AccountNumber accountNumber1 = AccountNumber.of("12345678");
+        AccountNumber accountNumber2 = AccountNumber.of("87654321");
+
+        assertThat(accountNumber1.equals(accountNumber2), is(false));
+        assertThat(accountNumber2.equals(accountNumber1), is(false));
+    }
+
+    @Test
+    public void twoAccountNumbersThatHaveTheSameNumericalValueButAreNotTheSameAreNotEqual() {
+        AccountNumber accountNumber1 = AccountNumber.of("1234567");
+        AccountNumber accountNumber2 = AccountNumber.of("01234567");
+
+        assertThat(accountNumber1.equals(accountNumber2), is(false));
+        assertThat(accountNumber2.equals(accountNumber1), is(false));
+    }
+
+    @Test
+    public void accountNumberIsNotEqualToTheStringificationOfItself() {
+        AccountNumber accountNumber = AccountNumber.of("12345678");
+
+        assertThat(accountNumber.equals("12345678"), is(false));
+    }
+
+    @Test
+    public void accountNumberIsNotEqualToNull() {
+        AccountNumber accountNumber = AccountNumber.of("12345678");
+
+        assertThat(accountNumber.equals(null), is(false));
+    }
+
+    @Test
+    public void twoAccountNumbersWithTheSameDigitsHaveTheSameHashCode() {
+        AccountNumber accountNumber1 = AccountNumber.of("12345678");
+        AccountNumber accountNumber2 = AccountNumber.of("12345678");
+
+        assertThat(accountNumber1.hashCode(), is(accountNumber2.hashCode()));
+    }
+
+    @Test
+    public void twoAccountNumbersWithDifferentDigitsHaveDifferentHashCodes() {
+        AccountNumber accountNumber1 = AccountNumber.of("12345678");
+        AccountNumber accountNumber2 = AccountNumber.of("87654321");
+
+        assertThat(accountNumber1.hashCode(), not(accountNumber2.hashCode()));
+    }
+
+    @Test
+    public void accountNumberToStringsToTheStringificationOfItself() {
+        AccountNumber accountNumber = AccountNumber.of("12345678");
+
+        assertThat(accountNumber.toString(), is("12345678"));
+    }
+    
+    @Test
+    public void getLastTwoDigitsReturnsLastTwoDigitsOfSixDigitAccountNumber() {
+        AccountNumber accountNumber = AccountNumber.of("123456");
+        
+        assertThat(accountNumber.getLastTwoDigits(), is("56"));
+    }
+
+    @Test
+    public void getLastTwoDigitsReturnsLastTwoDigitsOfSevenDigitAccountNumber() {
+        AccountNumber accountNumber = AccountNumber.of("1234567");
+
+        assertThat(accountNumber.getLastTwoDigits(), is("67"));
+    }
+
+    @Test
+    public void getLastTwoDigitsReturnsLastTwoDigitsOfEightDigitAccountNumber() {
+        AccountNumber accountNumber = AccountNumber.of("12345678");
+
+        assertThat(accountNumber.getLastTwoDigits(), is("78"));
+    }
+
+    @Test
+    public void getLastTwoDigitsReturnsLastTwoDigitsEvenIfThePenultimateOneIsZero() {
+        AccountNumber accountNumber = AccountNumber.of("12345609");
+
+        assertThat(accountNumber.getLastTwoDigits(), is("09"));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFacadeTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFacadeTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
 import uk.gov.pay.directdebit.payers.model.SortCode;
@@ -27,7 +28,7 @@ public class GoCardlessClientFacadeTest {
 
     private static final String BANK_NAME = "Awesome Bank";
 
-    private final BankAccountDetails bankAccountDetails = new BankAccountDetails("12345678", SortCode.of("123456"));
+    private final BankAccountDetails bankAccountDetails = new BankAccountDetails(AccountNumber.of("12345678"), SortCode.of("123456"));
 
     @Mock
     private GoCardlessClientWrapper mockGoCardlessClientWrapper;

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/ConfirmationDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/ConfirmationDetailsFixture.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.payments.fixtures;
 import org.apache.commons.lang.RandomStringUtils;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.ConfirmationDetails;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 
@@ -10,7 +11,7 @@ public class ConfirmationDetailsFixture {
 
     private MandateFixture mandateFixture = MandateFixture.aMandateFixture();
     private SortCode sortCode = SortCode.of(RandomStringUtils.randomNumeric(6));
-    private String accountNumber = RandomStringUtils.randomNumeric(8);
+    private AccountNumber accountNumber = AccountNumber.of(RandomStringUtils.randomNumeric(8));
     private TransactionFixture transactionFixture = null;
     
     private ConfirmationDetailsFixture() { }
@@ -35,7 +36,7 @@ public class ConfirmationDetailsFixture {
         return this;
     }
 
-    public ConfirmationDetailsFixture withAccountNumber(String accountNumber) {
+    public ConfirmationDetailsFixture withAccountNumber(AccountNumber accountNumber) {
         this.accountNumber = accountNumber;
         return this;
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceOneOffTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceOneOffTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
@@ -151,11 +152,11 @@ public class GoCardlessServiceOneOffTest extends GoCardlessServiceTest {
 
     @Test
     public void shouldValidateBankAccountDetails() {
-        String accountNumber = "12345678";
+        AccountNumber accountNumber = AccountNumber.of("12345678");
         SortCode sortCode = SortCode.of("123456");
         BankAccountDetails bankAccountDetails = new BankAccountDetails(accountNumber, sortCode);
         Map<String, String> bankAccountDetailsRequest = ImmutableMap.of(
-                "account_number", accountNumber,
+                "account_number", accountNumber.toString(),
                 "sort_code", sortCode.toString()
         );
         GoCardlessBankAccountLookup goCardlessBankAccountLookup = new GoCardlessBankAccountLookup("Great Bank of Cake", true);
@@ -168,11 +169,11 @@ public class GoCardlessServiceOneOffTest extends GoCardlessServiceTest {
 
     @Test
     public void shouldValidateBankAccountDetails_ifGoCardlessReturnsInvalidLookup() {
-        String accountNumber = "12345678";
+        AccountNumber accountNumber = AccountNumber.of("12345678");
         SortCode sortCode = SortCode.of("123467");
         BankAccountDetails bankAccountDetails = new BankAccountDetails(accountNumber, sortCode);
         Map<String, String> bankAccountDetailsRequest = ImmutableMap.of(
-                "account_number", accountNumber,
+                "account_number", accountNumber.toString(),
                 "sort_code", sortCode.toString()
         );
         GoCardlessBankAccountLookup goCardlessBankAccountLookup = new GoCardlessBankAccountLookup(null, false);
@@ -185,11 +186,11 @@ public class GoCardlessServiceOneOffTest extends GoCardlessServiceTest {
 
     @Test
     public void shouldValidateBankAccountDetails_ifExceptionIsThrownFromGC() {
-        String accountNumber = "12345678";
+        AccountNumber accountNumber = AccountNumber.of("12345678");
         SortCode sortCode = SortCode.of("123467");
         BankAccountDetails bankAccountDetails = new BankAccountDetails(accountNumber, sortCode);
         Map<String, String> bankAccountDetailsRequest = ImmutableMap.of(
-                "account_number", accountNumber,
+                "account_number", accountNumber.toString(),
                 "sort_code", sortCode.toString()
         );
         when(mockedBankAccountDetailsParser.parse(bankAccountDetailsRequest)).thenReturn(bankAccountDetails);

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
 import uk.gov.pay.directdebit.mandate.services.MandateService;
 import uk.gov.pay.directdebit.payers.dao.GoCardlessCustomerDao;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
+import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetailsParser;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
 import uk.gov.pay.directdebit.payers.model.SortCode;
@@ -35,7 +36,7 @@ public abstract class GoCardlessServiceTest {
     static final String MANDATE_ID = "sdkfhsdkjfhjdks";
     static final String TRANSACTION_ID = "sdkfhsd2jfhjdks";
     static final SortCode SORT_CODE = SortCode.of("123456");
-    static final String ACCOUNT_NUMBER = "12345678";
+    static final AccountNumber ACCOUNT_NUMBER = AccountNumber.of("12345678");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -76,7 +77,7 @@ public abstract class GoCardlessServiceTest {
             .toEntity();
     Map<String, String> confirmDetails = ImmutableMap.of(
             "sort_code", SORT_CODE.toString(),
-            "account_number", ACCOUNT_NUMBER,
+            "account_number", ACCOUNT_NUMBER.toString(),
             "transaction_external_id", TRANSACTION_ID
     );
     GoCardlessPayment goCardlessPayment = aGoCardlessPaymentFixture().withTransactionId(transaction.getId()).toEntity();


### PR DESCRIPTION
The `AccountNumber` object represents a UK bank account number with no dashes or spaces e.g. `"12345678"`. It performs a check when it’s constructed to ensure that it consists of six to eight Arabic numerals inclusive. It’s safe to do this because `AccountNumber` objects are only ever created to represent data in requests and our resources ensure the account numbers match the correct format before the `AccountNumber` objects are created.

Note that there’s no guarantee that an `AccountNumber` object actually represents a real bank account.

The `accountNumber` field in the `Payer` class remains a `String` rather than becoming an `AccountNumber` object because we hash the account number before passing it to the `Payer` constructor (except in some tests), so it isn’t actually an account number. This also means that `AccountNumber` objects are never persisted or depersisted: they are entirely ephemeral.