### PR TITLE
PP-3928: Account list endpoint filter

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDao.java
@@ -1,7 +1,10 @@
 package uk.gov.pay.directdebit.gatewayaccounts.dao;
 
+import java.util.List;
+
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -27,4 +30,9 @@ public interface GatewayAccountDao {
             "VALUES (:externalId, :paymentProvider, :type, :serviceName, :description, :analyticsId)")
     @GetGeneratedKeys
     Long insert(@BindBean GatewayAccount gatewayAccount);
+
+    @SqlQuery("SELECT * FROM gateway_accounts WHERE external_id IN (<externalAccountIds>)")
+    List<GatewayAccount> find(
+      @BindList("externalAccountIds") List<String> externalAccountIds
+    );
 }

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountService.java
@@ -39,6 +39,10 @@ public class GatewayAccountService {
         return gatewayAccountDao.findAll();
     }
 
+    public List<GatewayAccount> getGatewayAccounts(List<String> externalAccountIds) {
+        return gatewayAccountDao.find(externalAccountIds);
+    }
+
     public GatewayAccount create(Map<String, String> createGatewayAccountRequest) {
         GatewayAccount gatewayAccount = gatewayAccountParser.parse(createGatewayAccountRequest);
         Long id = gatewayAccountDao.insert(gatewayAccount);

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java
@@ -121,6 +121,33 @@ public class GatewayAccountServiceTest {
     }
 
     @Test
+    public void shouldReturnAListOfGatewayAccountsSingle() {
+        GatewayAccount fixture = gatewayAccountFixture.toEntity();
+        List<String> ids = Arrays.asList(fixture.getExternalId());
+
+        when(mockedGatewayAccountDao.find(ids))
+          .thenReturn(Arrays.asList(fixture));
+
+        List<GatewayAccount> gatewayAccounts = service.getGatewayAccounts(ids);
+
+        assertThat(gatewayAccounts.size(), is(1));
+    }
+
+    @Test
+    public void shouldReturnAListOfGatewayAccountsMultiple() {
+        GatewayAccount fixture1 = gatewayAccountFixture.toEntity();
+        GatewayAccount fixture2 = gatewayAccountFixture.toEntity();
+        List<String> ids = Arrays.asList(fixture1.getExternalId(), fixture2.getExternalId());
+
+        when(mockedGatewayAccountDao.find(ids))
+          .thenReturn(Arrays.asList(fixture1, fixture2));
+
+        List<GatewayAccount> gatewayAccounts = service.getGatewayAccounts(ids);
+
+        assertThat(gatewayAccounts.size(), is(2));
+    }
+
+    @Test
     public void shouldStoreAGatewayAccount() {
         GatewayAccount parsedGatewayAccount = GatewayAccountFixture.aGatewayAccountFixture().toEntity();
         when(mockedGatewayAccountParser.parse(createTransactionRequest)).thenReturn(parsedGatewayAccount);

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/GatewayAccountDaoIT.java
@@ -17,6 +17,7 @@ import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -122,6 +123,86 @@ public class GatewayAccountDaoIT {
         assertThat(first.getDescription(), is(DESCRIPTION));
         assertThat(first.getAnalyticsId(), is(ANALYTICS_ID));
         assertThat(first.getType(), is(TYPE));
+
+        assertThat(second.getId(), is(notNullValue()));
+        assertThat(second.getExternalId(), is(externalId2));
+        assertThat(second.getPaymentProvider(), is(paymentProvider2));
+        assertThat(second.getServiceName(), is(serviceName2));
+        assertThat(second.getDescription(), is(description2));
+        assertThat(second.getAnalyticsId(), is(analyticsId2));
+        assertThat(second.getType(), is(TYPE));
+    }
+
+    @Test
+    public void shouldFindGatewayAccounts() {
+        testGatewayAccount.insert(testContext.getJdbi());
+
+        List<GatewayAccount> gatewayAccounts;
+        GatewayAccount first;
+        GatewayAccount second;
+
+        PaymentProvider paymentProvider  = PaymentProvider.GOCARDLESS;
+        String serviceName               = "aservice";
+        String externalId                = "single";
+        String description               = "tests pls";
+        String analyticsId               = "DD_234099_TOOLONGWONTREAD";
+
+        PaymentProvider paymentProvider2 = PaymentProvider.GOCARDLESS;
+        String serviceName2              = "aservice";
+        String externalId2               = "multiple";
+        String description2              = "tests pls";
+        String analyticsId2              = "DD_234199_TOOLONGWONTREAD";
+
+        GatewayAccountFixture
+          .aGatewayAccountFixture()
+          .withExternalId(externalId)
+          .withServiceName(serviceName)
+          .withDescription(description)
+          .withPaymentProvider(paymentProvider)
+          .withAnalyticsId(analyticsId)
+          .insert(testContext.getJdbi());
+
+        GatewayAccountFixture
+          .aGatewayAccountFixture()
+          .withExternalId(externalId2)
+          .withServiceName(serviceName2)
+          .withDescription(description2)
+          .withPaymentProvider(paymentProvider2)
+          .withAnalyticsId(analyticsId2)
+          .insert(testContext.getJdbi());
+
+        gatewayAccounts = gatewayAccountDao.find(
+          Arrays.asList(externalId)
+        );
+
+        assertThat(gatewayAccounts.size(), is(1));
+
+        first = gatewayAccounts.get(0);
+
+        assertThat(first.getId(),              is(notNullValue()));
+        assertThat(first.getExternalId(),      is(externalId));
+        assertThat(first.getPaymentProvider(), is(paymentProvider));
+        assertThat(first.getServiceName(),     is(serviceName));
+        assertThat(first.getDescription(),     is(description));
+        assertThat(first.getAnalyticsId(),     is(analyticsId));
+        assertThat(first.getType(),            is(TYPE));
+
+        gatewayAccounts = gatewayAccountDao.find(
+          Arrays.asList(externalId, externalId2)
+        );
+
+        assertThat(gatewayAccounts.size(), is(2));
+
+        first = gatewayAccounts.get(0);
+        second = gatewayAccounts.get(1);
+
+        assertThat(first.getId(),              is(notNullValue()));
+        assertThat(first.getExternalId(),      is(externalId));
+        assertThat(first.getPaymentProvider(), is(paymentProvider));
+        assertThat(first.getServiceName(),     is(serviceName));
+        assertThat(first.getDescription(),     is(description));
+        assertThat(first.getAnalyticsId(),     is(analyticsId));
+        assertThat(first.getType(),            is(TYPE));
 
         assertThat(second.getId(), is(notNullValue()));
         assertThat(second.getExternalId(), is(externalId2));

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -7,7 +7,7 @@ server:
       port: 0
 
 logging:
-    level: INFO
+    level: WARN
     appenders:
       - type: console
         threshold: ALL

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,7 @@
+<configuration debug="false">
+  <logger name="liquibase" level="WARN" />
+  <logger name="org.apache.http" level="WARN" />
+  <logger name="com.spotify" level="WARN" />
+  <logger name="uk.gov.pay." level="INFO" />
+  <root level="WARN"/>
+</configuration>


### PR DESCRIPTION
same as https://github.com/alphagov/pay-connector/pull/633
but for dd

basically

- [x] adds `externalAccountIds` query param to `/v1/api/accounts` so we don't get
them all

- [x] adds a clone of `/v1/api/accounts` but in the `frontend` namespace

- [x] tests

- [x] tests passing

- [x] bau reduce logging output for builds (no INFO except for uk.gov.pay) 

solo @tlwr