### PR TITLE
bau: Run pact provider tests on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,6 @@ pipeline {
           def long stepBuildTime = System.currentTimeMillis()
 
           sh 'mvn clean verify'
-          runProviderContractTests()
           postSuccessfulMetrics("directdebit-connector.maven-build", stepBuildTime)
         }
       }
@@ -48,6 +47,7 @@ pipeline {
         branch 'master'
       }
       steps {
+        runProviderContractTests()
         sh 'mvn -Dmaven.test.skip=true clean package'
       }
     }


### PR DESCRIPTION
Because we weren't running pact provider tests on master branch, the 'Pact Tag' build
step wasn't tagging anything, as the commit on the master branch is different
to that of the PR (where provider tests were being run). A side effect of this
is that when checking publicapi is ok to deploy, the pact broker isn't checking
the compatibility between publicapi and direct-debit-connector.

@oswaldquek
