### PR TITLE
PP-3835 Do not allow creation of ONE_OFF mandate from create agreement endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -30,6 +30,8 @@ import uk.gov.pay.directdebit.common.exception.BadRequestExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.ConflictExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.InternalServerErrorExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.NotFoundExceptionMapper;
+import uk.gov.pay.directdebit.common.exception.PreconditionFailedException;
+import uk.gov.pay.directdebit.common.exception.PreconditionFailedExceptionMapper;
 import uk.gov.pay.directdebit.events.resources.DirectDebitEventsResource;
 import uk.gov.pay.directdebit.gatewayaccounts.GatewayAccountParamConverterProvider;
 import uk.gov.pay.directdebit.gatewayaccounts.resources.GatewayAccountResource;
@@ -109,6 +111,7 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
         environment.jersey().register(new NotFoundExceptionMapper());
         environment.jersey().register(new ConflictExceptionMapper());
         environment.jersey().register(new InternalServerErrorExceptionMapper());
+        environment.jersey().register(new PreconditionFailedExceptionMapper());
         setupSSL(configuration, socketFactory);
         initialiseMetrics(configuration, environment);
     }

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedException.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.directdebit.common.exception;
+
+public class PreconditionFailedException extends RuntimeException {
+
+    public PreconditionFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedExceptionMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.directdebit.common.exception;
+
+import com.google.common.collect.ImmutableMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class PreconditionFailedExceptionMapper implements ExceptionMapper<PreconditionFailedException> {
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(PreconditionFailedException.class);
+
+    @Override
+    public Response toResponse(PreconditionFailedException exception) {
+        LOGGER.error(exception.getMessage());
+        ImmutableMap<String, String> entity = ImmutableMap.of("message", exception.getMessage());
+        return Response.status(412).entity(entity).type(APPLICATION_JSON).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequestValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequestValidator.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.directdebit.mandate.api;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.function.Function;
+import uk.gov.pay.directdebit.common.validation.ApiValidation;
+import uk.gov.pay.directdebit.common.validation.FieldSize;
+import uk.gov.pay.directdebit.mandate.model.MandateType;
+
+public class CreateMandateRequestValidator extends ApiValidation {
+
+    private final static String AGREEMENT_TYPE_KEY = "agreement_type";
+    private final static String RETURN_URL_KEY = "return_url";
+    private final static String REFERENCE_KEY = "service_reference";
+
+    private final static Map<String, Function<String, Boolean>> validators =
+            ImmutableMap.<String, Function<String, Boolean>>builder()
+                    .put(AGREEMENT_TYPE_KEY, ApiValidation::isNotNullOrEmpty)
+                    .put(RETURN_URL_KEY, ApiValidation::isNotNullOrEmpty)
+                    .put(REFERENCE_KEY, ApiValidation::isNotNullOrEmpty)
+                    .build();
+
+    private final static String[] requiredFields = {AGREEMENT_TYPE_KEY, RETURN_URL_KEY};
+
+    private final static Map<String, FieldSize> fieldSizes =
+            ImmutableMap.<String, FieldSize>builder()
+                    .put(REFERENCE_KEY, new FieldSize(0, 255))
+                    .build();
+
+    public CreateMandateRequestValidator() {
+        super(requiredFields, fieldSizes, validators);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateType.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateType.java
@@ -1,6 +1,21 @@
 package uk.gov.pay.directdebit.mandate.model;
 
+import org.slf4j.Logger;
+import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+
 public enum MandateType {
     ONE_OFF,
-    ON_DEMAND
+    ON_DEMAND;
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(MandateType.class);
+
+    public static MandateType fromString(String type) {
+        for (MandateType typeEnum : values()) {
+            if (typeEnum.toString().equalsIgnoreCase(type)) {
+                return typeEnum;
+            }
+        }
+        LOGGER.error("Invalid mandate type: {}", type);
+        return null;
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/resources/MandateResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/resources/MandateResource.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.UriInfo;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.api.CreateMandateRequestValidator;
 import uk.gov.pay.directdebit.mandate.api.CreateMandateResponse;
 import uk.gov.pay.directdebit.mandate.api.DirectDebitInfoFrontendResponse;
 import uk.gov.pay.directdebit.mandate.api.GetMandateResponse;
@@ -26,7 +27,7 @@ import static javax.ws.rs.core.Response.created;
 public class MandateResource {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(MandateResource.class);
     private final MandateService mandateService;
-    
+    private final CreateMandateRequestValidator createMandateRequestValidator = new CreateMandateRequestValidator();
     @Inject
     public MandateResource(MandateService mandateService) {
         this.mandateService = mandateService;
@@ -38,7 +39,8 @@ public class MandateResource {
     @Produces(APPLICATION_JSON)
     public Response createMandate(@PathParam("accountId") GatewayAccount gatewayAccount, Map<String, String> createMandateRequest, @Context UriInfo uriInfo) {
         LOGGER.info("Received create mandate request with gateway account external id - {}", gatewayAccount.getExternalId());
-        CreateMandateResponse createMandateResponse = mandateService.createMandateResponse(createMandateRequest, gatewayAccount.getExternalId(), uriInfo);
+        createMandateRequestValidator.validate(createMandateRequest);
+        CreateMandateResponse createMandateResponse = mandateService.createMandate(createMandateRequest, gatewayAccount.getExternalId(), uriInfo);
         return created(createMandateResponse.getLink("self")).entity(createMandateResponse).build();
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/InvalidMandateTypeException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/InvalidMandateTypeException.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.directdebit.payments.exception;
+
+import uk.gov.pay.directdebit.common.exception.PreconditionFailedException;
+import uk.gov.pay.directdebit.mandate.model.MandateType;
+
+import static java.lang.String.format;
+
+public class InvalidMandateTypeException extends PreconditionFailedException {
+
+    public InvalidMandateTypeException(MandateType mandateType) {
+        super(format("Invalid operation on mandate of type %s", mandateType.toString()));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/TransactionResource.java
@@ -65,9 +65,8 @@ public class TransactionResource {
     public Response createOneOffPayment(@PathParam("accountId") String accountExternalId, Map<String, String> transactionRequest, @Context UriInfo uriInfo) {
         LOGGER.info("Received new one-off payment request");
         transactionRequestValidator.validate(transactionRequest);
-        transactionRequest.put("agreement_type", MandateType.ONE_OFF.toString());
         Mandate mandate = mandateService
-                .createMandate(transactionRequest, accountExternalId);
+                .createMandate(transactionRequest, accountExternalId, MandateType.ONE_OFF);
         Transaction transaction = transactionService.createTransaction(transactionRequest, mandate, accountExternalId);
         TransactionResponse response = transactionService.createPaymentResponseWithAllLinks(transaction, accountExternalId, uriInfo);
         return created(response.getLink("self")).entity(response).build();
@@ -79,6 +78,7 @@ public class TransactionResource {
     public Response collectPaymentFromMandate(@PathParam("accountId") GatewayAccount gatewayAccount, Map<String, String> collectPaymentRequest, @Context UriInfo uriInfo) {
         LOGGER.info("Received collect payment from mandate request");
         collectPaymentRequestValidator.validate(collectPaymentRequest);
+        
         DirectDebitPaymentProvider service = paymentProviderFactory.getServiceFor(gatewayAccount.getPaymentProvider());
         Transaction transaction = service.collect(gatewayAccount, collectPaymentRequest);
         CollectPaymentResponse response = transactionService.collectPaymentResponseWithSelfLink(transaction, gatewayAccount.getExternalId(), uriInfo);

--- a/src/test/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequestValidatorTest.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.directdebit.mandate.api;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.directdebit.common.exception.validation.InvalidFieldsException;
+import uk.gov.pay.directdebit.common.exception.validation.InvalidSizeFieldsException;
+import uk.gov.pay.directdebit.common.exception.validation.MissingMandatoryFieldsException;
+
+public class CreateMandateRequestValidatorTest {
+
+        private CreateMandateRequestValidator createMandateRequestValidator = new CreateMandateRequestValidator();
+
+        @Rule
+        public ExpectedException thrown = ExpectedException.none();
+
+        @Test
+        public void shouldNotThrowExceptionIfRequestIsValid() {
+            Map<String, String> request = ImmutableMap.of(
+                    "agreement_type", "ON_DEMAND",
+                    "return_url", "https://blabla.test",
+                    "service_reference", "blablabla"
+            );
+            createMandateRequestValidator.validate(request);
+        }
+        
+        @Test
+        public void shouldThrowIfMissingRequiredFields() {
+            Map<String, String> request = ImmutableMap.of(
+                    "agreement_type", "ON_DEMAND",
+                    "service_reference", "blablabla"
+            );
+            thrown.expect(MissingMandatoryFieldsException.class);
+            thrown.expectMessage("Field(s) missing: [return_url]");
+            thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
+            createMandateRequestValidator.validate(request);
+        }
+        
+        @Test
+        public void shouldThrowIfFieldsAreInvalid() {
+            Map<String, String> request = ImmutableMap.of(
+                    "agreement_type", "",
+                    "return_url", "blabla.test",
+                    "service_reference", "blablabla"
+            );
+            thrown.expect(InvalidFieldsException.class);
+            thrown.expectMessage("Field(s) are invalid: [agreement_type]");
+            thrown.reportMissingExceptionWithMessage("InvalidFieldsException expected");
+            createMandateRequestValidator.validate(request);
+        }
+
+    @Test
+    public void shouldThrowIfFieldsHaveTheWrongSize() {
+        Map<String, String> request = ImmutableMap.of(
+                "agreement_type", "ONE_OFF",
+                "return_url", "https://blabla.test",
+                "service_reference", RandomStringUtils.randomAlphanumeric(256)
+        );
+        thrown.expect(InvalidSizeFieldsException.class);
+        thrown.expectMessage("The size of a field(s) is invalid: [service_reference]");
+        thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
+        createMandateRequestValidator.validate(request);
+    }
+    }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import javax.ws.rs.core.Response.Status;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -150,6 +151,29 @@ public class MandateResourceIT {
                 }}));
     }
 
+    @Test
+    public void shouldNotCreateAOneOffMandate() throws Exception {
+        String accountExternalId = testGatewayAccount.getExternalId();
+        String agreementType = MandateType.ONE_OFF.toString();
+        String returnUrl = "http://example.com/success-page/";
+        String postBody = new ObjectMapper().writeValueAsString(ImmutableMap.builder()
+                .put("agreement_type", agreementType)
+                .put("return_url", returnUrl)
+                .put("service_reference", "test-service-reference")
+                .build());
+
+        String requestPath = "/v1/api/accounts/{accountId}/mandates"
+                .replace("{accountId}", accountExternalId);
+
+        givenSetup()
+                .body(postBody)
+                .post(requestPath)
+                .then()
+                .statusCode(Status.PRECONDITION_FAILED.getStatusCode())
+                .contentType(JSON)
+                .body("message", is("Invalid operation on mandate of type ONE_OFF"));
+    }
+    
     @Test
     public void shouldRetrieveAMandate_FromFrontendEndpoint_WhenATransactionHasBeenCreated() {
         String accountExternalId = testGatewayAccount.getExternalId();

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -438,6 +438,6 @@ public class MandateServiceTest {
         when(mockedGatewayAccountDao.findByExternalId(anyString())).thenReturn(Optional.of(gatewayAccount));
         when(mockedMandateDao.insert(any(Mandate.class))).thenReturn(1L);
 
-        return service.createMandate(getMandateRequestPayload(), gatewayAccount.getExternalId());
+        return service.createMandate(getMandateRequestPayload(), gatewayAccount.getExternalId(), MandateType.ON_DEMAND);
     }
 }


### PR DESCRIPTION
## WHAT
 - We have already the create payment endpoint which creates a one-off mandate and
   a payment.
   We do not want to allow creation of one-off mandates from the create agreement
   endpoint as this will be used for recurring payments.

