### PR TITLE
PP-3961 Add access_token and organisation columns to gateway_accounts

### DIFF
--- a/src/main/resources/migrations/00035_alter_table_gateway_accounts_add_access_token.sql
+++ b/src/main/resources/migrations/00035_alter_table_gateway_accounts_add_access_token.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table_gateway_accounts_add_access_token
+ALTER TABLE gateway_accounts ADD COLUMN access_token VARCHAR(255);
+ALTER TABLE gateway_accounts ADD UNIQUE (access_token);
+--rollback ALTER TABLE gateway_accounts DROP COLUMN access_token;

--- a/src/main/resources/migrations/00036_alter_table_gateway_accounts_add_organisation.sql
+++ b/src/main/resources/migrations/00036_alter_table_gateway_accounts_add_organisation.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table_gateway_accounts_add_organisation
+ALTER TABLE gateway_accounts ADD COLUMN organisation VARCHAR(255);
+ALTER TABLE gateway_accounts ADD UNIQUE (organisation);
+--rollback ALTER TABLE gateway_accounts DROP COLUMN organisation;


### PR DESCRIPTION
Add access_token and organisation columns to the Direct Debit connector gateway_accounts table (initially unpopulated).

- create 2 new alter table scripts to add the columns

## How to test
Run msl -l up locally and check logs and/or db that columns are present in the table
