### PR TITLE
BAU: Make tests which use DB work with docker for mac

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/junit/PostgresTestContainer.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/PostgresTestContainer.java
@@ -37,16 +37,20 @@ final class PostgresTestContainer {
 
     private volatile boolean stopped = false;
 
-    PostgresTestContainer(DockerClient docker, String host, String dockerImage) throws Exception {
-        Class.forName("org.postgresql.Driver");
+    PostgresTestContainer(DockerClient docker, String dockerImage) throws Exception {
+        loadPostgresDriver();
         this.dockerImage = dockerImage;
         failsafeDockerPull(docker, this.dockerImage);
         this.docker = docker;
         this.containerId = createContainer(docker);
         docker.startContainer(containerId);
-        this.postgresUri = "jdbc:postgresql://" + host + ":" + getContainerPortBy(docker, containerId) + "/";
+        this.postgresUri = "jdbc:postgresql://" + docker.getHost() + ":" + getContainerPortBy(docker, containerId) + "/";
         registerShutdownHook();
         waitForPostgresToStart();
+    }
+
+    private void loadPostgresDriver() throws ClassNotFoundException {
+        Class.forName("org.postgresql.Driver");
     }
 
     String getPostgresDbUri() {

--- a/src/test/java/uk/gov/pay/directdebit/junit/PostgresTestDocker.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/PostgresTestDocker.java
@@ -16,43 +16,19 @@ import static uk.gov.pay.directdebit.junit.PostgresTestContainer.DB_USERNAME;
 final class PostgresTestDocker {
 
     static final String DB_NAME = "directdebit_connector_tests";
-    private static final String DOCKER_HOST = "DOCKER_HOST";
-    private static final String DOCKER_CERT_PATH = "DOCKER_CERT_PATH";
-    private static final String HOST = dockerHostLocalAware();
     private static PostgresTestContainer container;
 
     static void getOrCreate(String image) {
         try {
             if (container == null) {
-                container = new PostgresTestContainer(DefaultDockerClient.fromEnv().build(), HOST, image);
+                container = new PostgresTestContainer(DefaultDockerClient.fromEnv().build(), image);
                 createDatabase();
             }
         } catch (Exception e) {
             throw new PostgresTestDockerException(e);
         }
     }
-
-    private static URI getDockerHostUri() throws URISyntaxException {
-        final String dockerHost = Optional.ofNullable(System.getenv(DOCKER_HOST)).
-                orElseThrow(() -> new PostgresTestDockerException(DOCKER_HOST + " environment variable not set. It has to be set to the docker daemon location."));
-        return new URI(dockerHost);
-    }
-
-    private static String dockerHostLocalAware() {
-        try {
-            URI dockerHostURI = getDockerHostUri();
-            final boolean isDockerDaemonLocal = "unix".equals(dockerHostURI.getScheme());
-            if (isDockerDaemonLocal) {
-                return "localhost";
-            } else {
-                assertNotNull(DOCKER_CERT_PATH + " environment variable not set.", System.getenv(DOCKER_CERT_PATH));
-                return dockerHostURI.getHost();
-            }
-        } catch (URISyntaxException e) {
-            throw new PostgresTestDockerException(e);
-        }
-    }
-
+    
     private static void createDatabase() {
         try (Connection connection = getConnection(container.getPostgresDbUri(), DB_USERNAME, DB_PASSWORD)) {
             connection.createStatement().execute("CREATE DATABASE " + DB_NAME + " WITH owner=" + DB_USERNAME + " TEMPLATE postgres");


### PR DESCRIPTION
Docker for mac is connected to over a unix socket rather than TCP. The postgres setup code
attempts to calculate the hostname of the postgres server. Rather than doing that, we can use
the docker class itself, which knows the hostname that it's running on. This means we can delete
a bunch of code.

## How to test

I've only tested this on docker-for-mac so I'd appreciate if someone could test it on a docker-toolbox setup as well.

To use with docker for mac, you need to ensure that there are no `DOCKER_*` env vars set in your run configuration, and also that intellij is not propagating the env vars through from its environment.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
