### PR TITLE
BAU fix db script breakage

### DIFF
--- a/src/main/resources/migrations/00035_alter_table_events_add_external_id.sql
+++ b/src/main/resources/migrations/00035_alter_table_events_add_external_id.sql
@@ -1,1 +1,0 @@
-ALTER TABLE events ADD COLUMN external_id VARCHAR(26);

--- a/src/main/resources/migrations/00037_alter_table_events_add_external_id.sql
+++ b/src/main/resources/migrations/00037_alter_table_events_add_external_id.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table_events_add_external_id
+ALTER TABLE events DROP COLUMN IF EXISTS external_id;
+ALTER TABLE events ADD COLUMN external_id VARCHAR(26);
+
+--rollback ALTER TABLE events DROP COLUMN external_id;


### PR DESCRIPTION
## WHAT YOU DID
- add 'if not exists' to liquibase script
- rename script to follow logical numbering

## How to test
- run `msl -l up` locally on branch. make sure that `external_id` in `events` exists
- logs should show that the script ran but no action were taken

