### PR TITLE
PP-3646 Implement `state` search and fix pagination

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -84,7 +84,7 @@ GET /v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?r
 | Field                     | required | Description                               |
 | ------------------------  |:--------:| ----------------------------------------- |
 | `reference`               | - | There (partial or full) reference issued by the government service for this payment. |
-| `status`                  | - | The transaction of this payment |
+| `state`                   | - | The current state of the payment |
 | `from_date`               | - | The initial date for search payments |
 | `to_date`                 | - | The end date for search payments|
 | `page`                    | - | To get the results from the specified page number, should be a non zero +ve number (optional, defaults to 1)|
@@ -121,19 +121,19 @@ GET /v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?r
     ],
     "_links": {
         "next_page": {
-            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page_number=3&display_size=100"
+            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page=3&display_size=100"
         },
         "self": {
-            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page_number=2&display_size=100"
+            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page=2&display_size=100"
         },
         "prev_page": {
-            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page_number=1&display_size=100"
+            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page=1&display_size=100"
         },
         "last_page": {
-            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page_number=3&display_size=100"
+            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page=3&display_size=100"
         },
         "first_page": {
-            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page_number=1&display_size=100"
+            "href": "https://direct-debit-connector.example.com/v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?reference=MBK&page=1&display_size=100"
         }
     }
 }
@@ -147,7 +147,7 @@ GET /v1/api/accounts/DIRECT_DEBIT:r6oe9rd7mm1u9r43bi6u1p0qd9/transactions/view?r
 | `page`                                | Yes            | Page number of the current recordset                              |
 | `results`                             | Yes            | List of payments                                                  |
 | `results[i].amount`                   | Yes            | The amount of this payment in pence                               |
-| `results[i].state`                    | Yes            | The current external status of the payment                        |
+| `results[i].state`                    | Yes            | The current state of the payment                        |
 | `results[i].description`              | Yes            | The payment description                                           |
 | `results[i].reference`                | Yes            | There reference issued by the government service for this payment |
 | `results[i].email`                    | Yes            | The email address of the user of this payment                     |

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidator.java
@@ -32,7 +32,8 @@ public class PaymentViewValidator {
                 .withAmount(searchParams.getAmount())
                 .withMandateId(searchParams.getMandateId())
                 .withPaginationParams(paginationParams)
-                .withSearchDateParams(searchDateParams);
+                .withSearchDateParams(searchDateParams)
+                .withState(searchParams.getState());
     }
 
     private PaginationParams validatePagination(PaymentViewSearchParams searchParams) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
@@ -30,7 +30,7 @@ public class PaymentViewDao {
             ":searchExtraFields " +
             "ORDER BY t.id DESC OFFSET :offset LIMIT :limit";
 
-    private final String COUNT_QUERY_STRING = "SELECT count(*) " +
+    private final String COUNT_QUERY_STRING = "SELECT count(t.id) " +
             "FROM transactions t " +
             "INNER JOIN mandates m ON t.mandate_id = m.id " +
             "INNER JOIN gateway_accounts ga ON ga.id = m.gateway_account_id " +

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentState.java
@@ -27,4 +27,8 @@ public enum PaymentState implements DirectDebitState {
     public ExternalPaymentState toExternal() {
         return externalState;
     }
+
+    public String toSingleQuoteString() {
+        return "'" + this + "'";
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/ViewPaginationBuilder.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/ViewPaginationBuilder.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.payments.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.directdebit.payments.api.PaymentViewResultResponse;
 import uk.gov.pay.directdebit.payments.links.PaginationLink;
@@ -10,6 +11,9 @@ import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
 public class ViewPaginationBuilder {
 
     private static final String SELF_LINK = "self";
@@ -80,10 +84,13 @@ public class ViewPaginationBuilder {
         lastLink = PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString());
 
         searchParams.withPage(selfPageNum - 1);
-        prevLink = selfPageNum == 1L ? null : PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString());;
+        prevLink = selfPageNum == 1L ? null : 
+                selfPageNum > lastPage ? 
+                        PaginationLink.ofValue(uriWithParams(searchParams.withPage(lastPage).buildQueryParamString()).toString()) :
+                        PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString());
 
         searchParams.withPage(selfPageNum + 1);
-        nextLink = selfPageNum == lastPage ? null : PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString());;
+        nextLink = selfPageNum >= lastPage ? null : PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString()).toString());;
     }
 
     private URI uriWithParams(String params) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/ViewPaginationBuilder.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/ViewPaginationBuilder.java
@@ -3,13 +3,11 @@ package uk.gov.pay.directdebit.payments.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.pay.directdebit.payments.api.PaymentViewResultResponse;
 import uk.gov.pay.directdebit.payments.links.PaginationLink;
 import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
 
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -23,7 +21,6 @@ public class ViewPaginationBuilder {
     private static final String NEXT_LINK = "next_page";
     private PaymentViewSearchParams searchParams;
     private UriInfo uriInfo;
-    private List<PaymentViewResultResponse> viewResponses;
 
     @JsonIgnore
     private Long totalCount;
@@ -40,9 +37,8 @@ public class ViewPaginationBuilder {
     @JsonProperty(NEXT_LINK)
     private PaginationLink nextLink;
 
-    public ViewPaginationBuilder(PaymentViewSearchParams searchParams, List<PaymentViewResultResponse> chargeResponses, UriInfo uriInfo) {
+    public ViewPaginationBuilder(PaymentViewSearchParams searchParams, UriInfo uriInfo) {
         this.searchParams = searchParams;
-        this.viewResponses = chargeResponses;
         this.uriInfo = uriInfo;
         selfPageNum = searchParams.getPage();
     }
@@ -59,10 +55,6 @@ public class ViewPaginationBuilder {
         
         return this;
     }
-
-    public Long getTotalCount() { return totalCount; }
-
-    public Long getSelfPageNum() { return selfPageNum; }
 
     public PaginationLink getSelfLink() { return selfLink; }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
@@ -1,10 +1,19 @@
 package uk.gov.pay.directdebit.payments.params;
 
+import uk.gov.pay.directdebit.payments.api.ExternalPaymentState;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.CANCELLED;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.EXPIRED;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.FAILED;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.NEW;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.PENDING;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.SUCCESS;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.USER_CANCEL_NOT_ELIGIBLE;
 
 public class PaymentViewSearchParams {
 
@@ -17,9 +26,10 @@ public class PaymentViewSearchParams {
     private static final String REFERENCE_FIELD = "reference";
     private static final String AMOUNT_FIELD = "amount";
     private static final String MANDATE_ID_INTERNAL_KEY = "mandate_id";
-    private static final String MANDATE_ID_EXTERNAL_KEY = "agreement";
+    private static final String MANDATE_ID_EXTERNAL_KEY = "agreement_id";
     private static final String FROM_DATE_KEY = "from_date";
     private static final String TO_DATE_KEY = "to_date";
+    private static final String STATE_FIELD = "state";
     private final String gatewayExternalId;
     private Long page;
     private Long displaySize;
@@ -29,15 +39,32 @@ public class PaymentViewSearchParams {
     private String reference;
     private Long amount;
     private String mandateId;
+    private String state;
     private SearchDateParams searchDateParams;
     private PaginationParams paginationParams;
     private Map<String, Object> queryMap;
-    
+
+    private static Map<String, String> externalPaymentToInternalStateQueryMap = new HashMap<>(4);
+
+    static {
+        String andStateCondition = " AND t.state = '%s'";
+        // see uk.gov.pay.directdebit.payments.model.PaymentState for mappings
+        externalPaymentToInternalStateQueryMap
+                .put(ExternalPaymentState.EXTERNAL_STARTED.getState(), format(andStateCondition, NEW));
+        externalPaymentToInternalStateQueryMap
+                .put(ExternalPaymentState.EXTERNAL_PENDING.getState(), format(andStateCondition, PENDING));
+        externalPaymentToInternalStateQueryMap
+                .put(ExternalPaymentState.EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE.getState(), format(andStateCondition, USER_CANCEL_NOT_ELIGIBLE));
+        externalPaymentToInternalStateQueryMap
+                .put(ExternalPaymentState.EXTERNAL_SUCCESS.getState(), format(andStateCondition, SUCCESS));
+        externalPaymentToInternalStateQueryMap
+                .put(ExternalPaymentState.EXTERNAL_FAILED.getState(), format("AND t.state IN('%s', '%s', '%s')", FAILED, CANCELLED, EXPIRED));
+    }
+
     public PaymentViewSearchParams(String gatewayExternalId) {
-        
         this.gatewayExternalId = gatewayExternalId;
     }
-    
+
     public PaymentViewSearchParams withDisplaySize(Long displaySize) {
         this.displaySize = displaySize;
         return this;
@@ -47,7 +74,7 @@ public class PaymentViewSearchParams {
         this.fromDateString = fromDateString;
         return this;
     }
-    
+
     public PaymentViewSearchParams withAmount(Long amount) {
         this.amount = amount;
         return this;
@@ -70,6 +97,11 @@ public class PaymentViewSearchParams {
 
     public PaymentViewSearchParams withMandateId(String mandateId) {
         this.mandateId = mandateId;
+        return this;
+    }
+
+    public PaymentViewSearchParams withState(String state) {
+        this.state = state;
         return this;
     }
 
@@ -101,6 +133,8 @@ public class PaymentViewSearchParams {
 
     public String getMandateId() { return mandateId; }
 
+    public String getState() { return state; }
+
     public PaginationParams getPaginationParams() {
         if (paginationParams == null) {
             return new PaginationParams(page, displaySize);
@@ -116,7 +150,7 @@ public class PaymentViewSearchParams {
     }
 
     public String generateQuery() {
-        StringBuilder sb = new StringBuilder("");
+        StringBuilder sb = new StringBuilder();
         if (isNotBlank(mandateId)) {
             sb.append(" AND m.external_id = :" + MANDATE_ID_INTERNAL_KEY);
         }
@@ -136,6 +170,9 @@ public class PaymentViewSearchParams {
         }
         if (amount != null) {
             sb.append(" AND t.amount = :" + AMOUNT_FIELD);
+        }
+        if (isNotBlank(state) && externalPaymentToInternalStateQueryMap.containsKey(state)) {
+            sb.append(externalPaymentToInternalStateQueryMap.get(state));
         }
         return sb.toString();
     }
@@ -169,7 +206,7 @@ public class PaymentViewSearchParams {
         }
         return queryMap;
     }
-    
+
     public String buildQueryParamString() {
         String query = "";
         if (isNotBlank(mandateId)) {
@@ -192,12 +229,15 @@ public class PaymentViewSearchParams {
         if (amount != null) {
             query += "&" + AMOUNT_FIELD + "=" + amount;
         }
+        if (isNotBlank(state)) {
+            query += "&" + STATE_FIELD + "=" + state;
+        }
         query += addPaginationParams();
-        return query;
+        return query.substring(1);
     }
-    
+
     private String addPaginationParams() {
-        String queryParams = format("&page_number=%s", page);
+        String queryParams = format("&page=%s", page);
         queryParams += format("&display_size=%s", displaySize);
         return queryParams;
     }
@@ -205,4 +245,5 @@ public class PaymentViewSearchParams {
     private String likeClause(String rawUserInputText) {
         return "%" + rawUserInputText + "%";
     }
+
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
@@ -47,18 +47,17 @@ public class PaymentViewSearchParams {
     private static Map<String, String> externalPaymentToInternalStateQueryMap = new HashMap<>(4);
 
     static {
-        String andStateCondition = " AND t.state = '%s'";
         // see uk.gov.pay.directdebit.payments.model.PaymentState for mappings
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_STARTED.getState(), format(andStateCondition, NEW));
+                .put(ExternalPaymentState.EXTERNAL_STARTED.getState(), NEW.toSingleQuoteString());
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_PENDING.getState(), format(andStateCondition, PENDING));
+                .put(ExternalPaymentState.EXTERNAL_PENDING.getState(), PENDING.toSingleQuoteString());
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE.getState(), format(andStateCondition, USER_CANCEL_NOT_ELIGIBLE));
+                .put(ExternalPaymentState.EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE.getState(), USER_CANCEL_NOT_ELIGIBLE.toSingleQuoteString());
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_SUCCESS.getState(), format(andStateCondition, SUCCESS));
+                .put(ExternalPaymentState.EXTERNAL_SUCCESS.getState(), SUCCESS.toSingleQuoteString());
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_FAILED.getState(), format("AND t.state IN('%s', '%s', '%s')", FAILED, CANCELLED, EXPIRED));
+                .put(ExternalPaymentState.EXTERNAL_FAILED.getState(), FAILED.toSingleQuoteString() + ", " + CANCELLED.toSingleQuoteString() + ", " + EXPIRED.toSingleQuoteString());
     }
 
     public PaymentViewSearchParams(String gatewayExternalId) {
@@ -172,7 +171,7 @@ public class PaymentViewSearchParams {
             sb.append(" AND t.amount = :" + AMOUNT_FIELD);
         }
         if (isNotBlank(state) && externalPaymentToInternalStateQueryMap.containsKey(state)) {
-            sb.append(externalPaymentToInternalStateQueryMap.get(state));
+            sb.append(format(" AND t.state IN(%s)", externalPaymentToInternalStateQueryMap.get(state)));
         }
         return sb.toString();
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
@@ -40,8 +40,9 @@ public class PaymentViewResource {
             @QueryParam("reference") String reference,
             @QueryParam("amount") Long amount,
             @QueryParam("agreement_id") String mandateId,
-            @Context UriInfo uriInfo){
-        
+            @QueryParam("state") String state,
+            @Context UriInfo uriInfo) {
+
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(accountExternalId)
                 .withPage(pageNumber)
                 .withDisplaySize(displaySize)
@@ -50,8 +51,8 @@ public class PaymentViewResource {
                 .withEmail(email)
                 .withReference(reference)
                 .withAmount(amount)
-                .withMandateId(mandateId);
-        
+                .withMandateId(mandateId)
+                .withState(state);
         return Response.ok().entity(paymentViewService
                 .withUriInfo(uriInfo)
                 .getPaymentViewResponse(searchParams)).build();

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentViewService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentViewService.java
@@ -2,8 +2,8 @@ package uk.gov.pay.directdebit.payments.services;
 
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountNotFoundException;
-import uk.gov.pay.directdebit.payments.api.PaymentViewResultResponse;
 import uk.gov.pay.directdebit.payments.api.PaymentViewResponse;
+import uk.gov.pay.directdebit.payments.api.PaymentViewResultResponse;
 import uk.gov.pay.directdebit.payments.api.PaymentViewValidator;
 import uk.gov.pay.directdebit.payments.dao.PaymentViewDao;
 import uk.gov.pay.directdebit.payments.links.Link;
@@ -42,7 +42,7 @@ public class PaymentViewService {
                         viewListResponse =
                                 getPaymentViewResultResponse(validatedSearchParams, gatewayAccount.getExternalId());
                     }
-                    ViewPaginationBuilder paginationBuilder = new ViewPaginationBuilder(validatedSearchParams, viewListResponse, uriInfo);
+                    ViewPaginationBuilder paginationBuilder = new ViewPaginationBuilder(validatedSearchParams, uriInfo);
                     return new PaymentViewResponse(validatedSearchParams.getGatewayExternalId(),
                             total,
                             validatedSearchParams.getPage(),

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/ViewPaginationBuilderTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/ViewPaginationBuilderTest.java
@@ -1,0 +1,93 @@
+package uk.gov.pay.directdebit.payments.model;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ViewPaginationBuilderTest {
+
+    @Mock
+    private UriInfo mockedUriInfo;
+
+    private final String gatewayAccountExternalId = "a-gateway-account-external-id";
+
+    @Before
+    public void setUp() throws URISyntaxException {
+        URI uri = new URI("http://example.org");
+        when(mockedUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(uri), UriBuilder.fromUri(uri));
+        when(mockedUriInfo.getPath()).thenReturn("/v1/api/accounts/" + gatewayAccountExternalId + "/transactions/view");
+    }
+
+    @Test
+    public void shouldNotShowPrevLinkAndFirstLinkIsEqualToLastLink_whenOnlyOnePage() {
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+                .withPage(1L)
+                .withDisplaySize(500L);
+        ViewPaginationBuilder builder = new ViewPaginationBuilder(searchParams, mockedUriInfo)
+                .withTotalCount(120L);
+        builder = builder.buildResponse();
+        assertThat(builder.getPrevLink(), is(nullValue()));
+        assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
+        assertThat(builder.getLastLink().getHref().contains("?page=1&display_size=500"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("?page=1&display_size=500"), is(true));
+        assertThat(builder.getNextLink(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldShowPrevLinkAndFirstLinkAndLastLinkAsPage1_whenCurrentPageIsBiggerThanLastPage() {
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+                .withPage(777L)
+                .withDisplaySize(500L);
+        ViewPaginationBuilder builder = new ViewPaginationBuilder(searchParams, mockedUriInfo)
+                .withTotalCount(120L);
+        builder = builder.buildResponse();
+        assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=500"), is(true));
+        assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
+        assertThat(builder.getLastLink().getHref().contains("?page=1&display_size=500"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("?page=777&display_size=500"), is(true));
+    }
+
+    @Test
+    public void shouldShowPrevLinkAndFirstLinkAsEqualsAndLastLinkAndNextLinkAsEquals() {
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+                .withPage(2L)
+                .withDisplaySize(50L);
+        ViewPaginationBuilder builder = new ViewPaginationBuilder(searchParams, mockedUriInfo)
+                .withTotalCount(120L);
+        builder = builder.buildResponse();
+        assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=50"), is(true));
+        assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=50"), is(true));
+        assertThat(builder.getLastLink().getHref().contains("?page=3&display_size=50"), is(true));
+        assertThat(builder.getNextLink().getHref().contains("?page=3&display_size=50"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("?page=2&display_size=50"), is(true));
+    }
+
+    @Test
+    public void shouldShowAllLinksCorrectly_whenMultiplePagesExists() {
+        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+                .withPage(3L)
+                .withDisplaySize(10L);
+        ViewPaginationBuilder builder = new ViewPaginationBuilder(searchParams, mockedUriInfo)
+                .withTotalCount(120L);
+        builder = builder.buildResponse();
+        assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=10"), is(true));
+        assertThat(builder.getLastLink().getHref().contains("?page=12&display_size=10"), is(true));
+        assertThat(builder.getPrevLink().getHref().contains("?page=2&display_size=10"), is(true));
+        assertThat(builder.getNextLink().getHref().contains("?page=4&display_size=10"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("?page=3&display_size=10"), is(true));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID

- add sql generation for `state` using mapping from `ExternalPaymentState`
- handle external states from resource level downwards
- fix pagination (it's page and not page_number)
- fix bug in calculating next/last/prev page
- update docs
- add/update relevant tests
- fix pagination url (no & after ?)
- added unit tests for `ViewPaginationBuilder`
- refactor `ViewPaginationBuilder` (remove unnecessary list of PaymentViewResultResponse

with @SandorArpa
