### PR TITLE
PP-3962 Read in gateway account access token and organisation

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/mapper/GatewayAccountMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/mapper/GatewayAccountMapper.java
@@ -4,6 +4,8 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderOrganisationIdentifier;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -17,10 +19,12 @@ public class GatewayAccountMapper implements RowMapper<GatewayAccount> {
     private static final String TYPE_COLUMN = "type";
     private static final String DESCRIPTION_COLUMN = "description";
     private static final String ANALYTICS_ID_COLUMN = "analytics_id";
+    private static final String ACCESS_TOKEN = "access_token";
+    private static final String ORGANISATION = "organisation";
 
     @Override
     public GatewayAccount map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
-        return new GatewayAccount(
+        GatewayAccount gatewayAccount = new GatewayAccount(
                 resultSet.getLong(ID_COLUMN),
                 resultSet.getString(EXTERNAL_ID_COLUMN),
                 PaymentProvider.fromString(resultSet.getString(PAYMENT_PROVIDER_COLUMN)),
@@ -29,5 +33,17 @@ public class GatewayAccountMapper implements RowMapper<GatewayAccount> {
                 resultSet.getString(DESCRIPTION_COLUMN),
                 resultSet.getString(ANALYTICS_ID_COLUMN)
         );
+        
+        String accessToken = resultSet.getString(ACCESS_TOKEN);
+        if (accessToken != null) {
+            gatewayAccount.setAccessToken(PaymentProviderAccessToken.of(accessToken));
+        }
+        
+        String organisation = resultSet.getString(ORGANISATION);
+        if (organisation != null) {
+            gatewayAccount.setOrganisation(PaymentProviderOrganisationIdentifier.of(organisation));
+        }
+        
+        return gatewayAccount;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/GatewayAccount.java
@@ -3,6 +3,8 @@ package uk.gov.pay.directdebit.gatewayaccounts.model;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.gatewayaccounts.exception.InvalidGatewayAccountException;
 
+import java.util.Optional;
+
 public class GatewayAccount {
 
     public enum Type {
@@ -24,8 +26,11 @@ public class GatewayAccount {
     private String serviceName;
     private String description;
     private String analyticsId;
+    private PaymentProviderAccessToken accessToken;
+    private PaymentProviderOrganisationIdentifier organisation;
 
-    public GatewayAccount(Long id, String externalId, PaymentProvider paymentProvider, Type type, String serviceName, String description, String analyticsId) {
+    public GatewayAccount(Long id, String externalId, PaymentProvider paymentProvider, Type type, String serviceName, String description, String analyticsId,
+                          PaymentProviderAccessToken accessToken, PaymentProviderOrganisationIdentifier organisation) {
         this.id = id;
         this.externalId = externalId;
         this.paymentProvider = paymentProvider;
@@ -33,10 +38,16 @@ public class GatewayAccount {
         this.serviceName = serviceName;
         this.description = description;
         this.analyticsId = analyticsId;
+        this.accessToken = accessToken;
+        this.organisation = organisation;
     }
 
+    public GatewayAccount(Long id, String externalId, PaymentProvider paymentProvider, Type type, String serviceName, String description, String analyticsId) {
+        this(id, externalId, paymentProvider, type, serviceName, description, analyticsId, null, null);
+    }
+    
     public GatewayAccount(PaymentProvider paymentProvider, Type type, String serviceName, String description, String analyticsId) {
-        this(null, generateExternalId(), paymentProvider, type, serviceName, description, analyticsId);
+        this(null, generateExternalId(), paymentProvider, type, serviceName, description, analyticsId, null, null);
     }
 
     private static String generateExternalId() {
@@ -103,6 +114,24 @@ public class GatewayAccount {
         return this;
     }
 
+    public Optional<PaymentProviderAccessToken> getAccessToken() {
+        return Optional.ofNullable(accessToken);
+    }
+
+    public GatewayAccount setAccessToken(PaymentProviderAccessToken accessToken) {
+        this.accessToken = accessToken;
+        return this;
+    }
+
+    public Optional<PaymentProviderOrganisationIdentifier> getOrganisation() {
+        return Optional.ofNullable(organisation);
+    }
+
+    public GatewayAccount setOrganisation(PaymentProviderOrganisationIdentifier organisation) {
+        this.organisation = organisation;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -134,6 +163,14 @@ public class GatewayAccount {
                 : that.description != null) {
             return false;
         }
+        if (accessToken != null ? !accessToken.equals(that.accessToken)
+                : that.accessToken != null) {
+            return false;
+        }
+        if (organisation != null ? !organisation.equals(that.organisation)
+                : that.organisation != null) {
+            return false;
+        }
         return analyticsId != null ? analyticsId.equals(that.analyticsId)
                 : that.analyticsId == null;
     }
@@ -147,6 +184,9 @@ public class GatewayAccount {
         result = 31 * result + (serviceName != null ? serviceName.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (analyticsId != null ? analyticsId.hashCode() : 0);
+        result = 31 * result + (accessToken != null ? accessToken.hashCode() : 0);
+        result = 31 * result + (organisation != null ? organisation.hashCode() : 0);
+
         return result;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/PaymentProviderAccessToken.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/PaymentProviderAccessToken.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.directdebit.gatewayaccounts.model;
+
+import java.util.Objects;
+
+public class PaymentProviderAccessToken {
+
+    private final String paymentProviderAccessToken;
+
+    private PaymentProviderAccessToken(String paymentProviderAccessToken) {
+        this.paymentProviderAccessToken = Objects.requireNonNull(paymentProviderAccessToken);
+    }
+
+    public static PaymentProviderAccessToken of(String paymentProviderAccessToken) {
+        return new PaymentProviderAccessToken(paymentProviderAccessToken);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == PaymentProviderAccessToken.class) {
+            PaymentProviderAccessToken that = (PaymentProviderAccessToken) other;
+            return this.paymentProviderAccessToken.equals(that.paymentProviderAccessToken);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return paymentProviderAccessToken.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return paymentProviderAccessToken;
+    }
+    
+}

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/PaymentProviderOrganisationIdentifier.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/PaymentProviderOrganisationIdentifier.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.directdebit.gatewayaccounts.model;
+
+import java.util.Objects;
+
+public class PaymentProviderOrganisationIdentifier {
+
+    private final String paymentProviderOrganisationIdentifier;
+
+    private PaymentProviderOrganisationIdentifier(String paymentProviderOrganisationIdentifier) {
+        this.paymentProviderOrganisationIdentifier = Objects.requireNonNull(paymentProviderOrganisationIdentifier);
+    }
+
+    public static PaymentProviderOrganisationIdentifier of(String paymentProviderAccessToken) {
+        return new PaymentProviderOrganisationIdentifier(paymentProviderAccessToken);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == PaymentProviderOrganisationIdentifier.class) {
+            PaymentProviderOrganisationIdentifier that = (PaymentProviderOrganisationIdentifier) other;
+            return this.paymentProviderOrganisationIdentifier.equals(that.paymentProviderOrganisationIdentifier);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return paymentProviderOrganisationIdentifier.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return paymentProviderOrganisationIdentifier;
+    }
+    
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -58,6 +58,8 @@ public interface MandateDao {
             "  g.type AS gateway_account_type," +
             "  g.description AS gateway_account_description," +
             "  g.analytics_id AS gateway_account_analytics_id," +
+            "  g.access_token AS gateway_account_access_token," +
+            "  g.organisation AS gateway_account_organisation," +
             "  p.id AS payer_id," +
             "  p.mandate_id AS payer_mandate_id," +
             "  p.external_id AS payer_external_id," +

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
@@ -1,17 +1,20 @@
 package uk.gov.pay.directdebit.mandate.dao.mapper;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderOrganisationIdentifier;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.payers.model.Payer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 public class MandateMapper implements RowMapper<Mandate> {
 
@@ -30,6 +33,8 @@ public class MandateMapper implements RowMapper<Mandate> {
     private static final String GATEWAY_ACCOUNT_SERVICE_NAME_COLUMN = "gateway_account_service_name";
     private static final String GATEWAY_ACCOUNT_DESCRIPTION_COLUMN = "gateway_account_description";
     private static final String GATEWAY_ACCOUNT_ANALYTICS_ID_COLUMN = "gateway_account_analytics_id";
+    private static final String GATEWAY_ACCOUNT_ACCESS_TOKEN_COLUMN = "gateway_account_access_token";
+    private static final String GATEWAY_ACCOUNT_ORGANISATION_COLUMN = "gateway_account_organisation";
     private static final String PAYER_ID_COLUMN = "payer_id";
     private static final String PAYER_MANDATE_ID_COLUMN = "payer_mandate_id";
     private static final String PAYER_EXTERNAL_ID_COLUMN = "payer_external_id";
@@ -59,6 +64,7 @@ public class MandateMapper implements RowMapper<Mandate> {
                     resultSet.getString(PAYER_BANK_NAME_COLUMN),
                     ZonedDateTime.ofInstant(resultSet.getTimestamp(PAYER_CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC));
         }
+        
         GatewayAccount gatewayAccount = new GatewayAccount(
                 resultSet.getLong(GATEWAY_ACCOUNT_ID_COLUMN),
                 resultSet.getString(GATEWAY_ACCOUNT_EXTERNAL_ID_COLUMN),
@@ -68,6 +74,15 @@ public class MandateMapper implements RowMapper<Mandate> {
                 resultSet.getString(GATEWAY_ACCOUNT_DESCRIPTION_COLUMN),
                 resultSet.getString(GATEWAY_ACCOUNT_ANALYTICS_ID_COLUMN)
         );
+        String accessToken = resultSet.getString(GATEWAY_ACCOUNT_ACCESS_TOKEN_COLUMN);
+        if (accessToken != null) {
+            gatewayAccount.setAccessToken(PaymentProviderAccessToken.of(accessToken));
+        }
+        String organisation = resultSet.getString(GATEWAY_ACCOUNT_ORGANISATION_COLUMN);
+        if (organisation != null) {
+            gatewayAccount.setOrganisation(PaymentProviderOrganisationIdentifier.of(organisation));
+        }
+        
         return new Mandate(
                 resultSet.getLong(ID_COLUMN),
                 gatewayAccount,

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/TransactionDao.java
@@ -45,6 +45,8 @@ public interface TransactionDao {
             "  g.type AS gateway_account_type," +
             "  g.description AS gateway_account_description," +
             "  g.analytics_id AS gateway_account_analytics_id," +
+            "  g.access_token AS gateway_account_access_token," +
+            "  g.organisation AS gateway_account_organisation," +
             "  y.id AS payer_id," +
             "  y.mandate_id AS payer_mandate_id," +
             "  y.external_id AS payer_external_id," +

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/GatewayAccountDaoIT.java
@@ -8,6 +8,8 @@ import uk.gov.pay.directdebit.DirectDebitConnectorApp;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderOrganisationIdentifier;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
@@ -15,9 +17,10 @@ import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Arrays;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -147,11 +150,13 @@ public class GatewayAccountDaoIT {
         String description               = "tests pls";
         String analyticsId               = "DD_234099_TOOLONGWONTREAD";
 
-        PaymentProvider paymentProvider2 = PaymentProvider.GOCARDLESS;
-        String serviceName2              = "aservice";
-        String externalId2               = "multiple";
-        String description2              = "tests pls";
-        String analyticsId2              = "DD_234199_TOOLONGWONTREAD";
+        PaymentProvider paymentProvider2                   = PaymentProvider.GOCARDLESS;
+        String serviceName2                                = "aservice";
+        String externalId2                                 = "multiple";
+        String description2                                = "tests pls";
+        String analyticsId2                                = "DD_234199_TOOLONGWONTREAD";
+        PaymentProviderAccessToken accessToken             = PaymentProviderAccessToken.of("gimmeaccess");
+        PaymentProviderOrganisationIdentifier organisation = PaymentProviderOrganisationIdentifier.of("organisation");
 
         GatewayAccountFixture
           .aGatewayAccountFixture()
@@ -169,6 +174,8 @@ public class GatewayAccountDaoIT {
           .withDescription(description2)
           .withPaymentProvider(paymentProvider2)
           .withAnalyticsId(analyticsId2)
+          .withAccessToken(accessToken)
+          .withOrganisation(organisation)          
           .insert(testContext.getJdbi());
 
         gatewayAccounts = gatewayAccountDao.find(
@@ -211,6 +218,8 @@ public class GatewayAccountDaoIT {
         assertThat(second.getDescription(), is(description2));
         assertThat(second.getAnalyticsId(), is(analyticsId2));
         assertThat(second.getType(), is(TYPE));
+        assertThat(second.getAccessToken(), is(Optional.of(accessToken)));
+        assertThat(second.getOrganisation(), is(Optional.of(organisation)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GatewayAccountFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GatewayAccountFixture.java
@@ -7,6 +7,8 @@ import uk.gov.pay.directdebit.common.fixtures.DbFixture;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderOrganisationIdentifier;
 
 public class GatewayAccountFixture implements DbFixture<GatewayAccountFixture, GatewayAccount> {
 
@@ -17,6 +19,8 @@ public class GatewayAccountFixture implements DbFixture<GatewayAccountFixture, G
     private String serviceName = RandomStringUtils.randomAlphabetic(25);
     private String description = RandomStringUtils.randomAlphabetic(25);
     private String analyticsId = RandomStringUtils.randomAlphanumeric(25);
+    private PaymentProviderAccessToken accessToken = PaymentProviderAccessToken.of(RandomStringUtils.randomAlphabetic(25));
+    private PaymentProviderOrganisationIdentifier organisation = PaymentProviderOrganisationIdentifier.of(RandomStringUtils.randomAlphanumeric(25));
 
     private GatewayAccountFixture() {
     }
@@ -52,6 +56,16 @@ public class GatewayAccountFixture implements DbFixture<GatewayAccountFixture, G
 
     public GatewayAccountFixture withAnalyticsId(String analyticsId) {
         this.analyticsId = analyticsId;
+        return this;
+    }
+
+    public GatewayAccountFixture withAccessToken(PaymentProviderAccessToken accessToken) {
+        this.accessToken = accessToken;
+        return this;
+    }
+
+    public GatewayAccountFixture withOrganisation(PaymentProviderOrganisationIdentifier organisation) {
+        this.organisation = organisation;
         return this;
     }
 
@@ -95,16 +109,20 @@ public class GatewayAccountFixture implements DbFixture<GatewayAccountFixture, G
                                 "        service_name,\n" +
                                 "        type,\n" +
                                 "        description,\n" +
-                                "        analytics_id\n" +
+                                "        analytics_id,\n" +
+                                "        access_token,\n" +
+                                "        organisation\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, ?, ?, ?, ?, ?)\n",
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
                         id,
                         externalId,
                         paymentProvider.toString(),
                         serviceName,
                         type.toString(),
                         description,
-                        analyticsId
+                        analyticsId,
+                        accessToken != null ? accessToken.toString() : null,
+                        organisation != null ? organisation.toString() : null
                 )
         );
         return this;
@@ -112,7 +130,7 @@ public class GatewayAccountFixture implements DbFixture<GatewayAccountFixture, G
 
     @Override
     public GatewayAccount toEntity() {
-        return new GatewayAccount(id, externalId, paymentProvider, type, serviceName, description, analyticsId);
+        return new GatewayAccount(id, externalId, paymentProvider, type, serviceName, description, analyticsId, accessToken, organisation);
     }
 
 }


### PR DESCRIPTION
Add `accessToken` and `organisation` fields to the `GatewayAccount` object and populate them with the values of the (nullable) `access_token` and `organisation` columns when de-persisting a `GatewayAccount` entity from the database.

Introduce specific types to represent access tokens and organisation identifiers rather than using strings.

No changes to `GatewayAccountParser` because we do not currently support specifying an access token or organisation identifier when creating a gateway account from a JSON payload.

No changes to `GatewayAccountResponse` because we there’s no need for anyone outside of Direct Debit connector to know about these values (in particular, the access token must be kept secret).

On `GatewayAccount`, I made the getters for the new fields return `Optional`s. This is a little inconsistent with the other getters (some of which may return `null`) but does make it harder to accidentally call one of the new getters and blindly `toString()` the result. I’m happy to just return `null`s for consistency if preferred though.

Some of the null-checking code in the mappers is a bit ugly: suggestions for better approaches welcome.