### PR TITLE
PP-3680 Correcting parameter names for consistency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
         </dependency>

--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventExternalView.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventExternalView.java
@@ -2,13 +2,11 @@ package uk.gov.pay.directdebit.events.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import lombok.Getter;
 import uk.gov.pay.directdebit.payments.model.CustomDateSerializer;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 
 import java.time.ZonedDateTime;
 
-@Getter
 public class DirectDebitEventExternalView {
 
     @JsonProperty("external_id")
@@ -37,5 +35,29 @@ public class DirectDebitEventExternalView {
         this.event = directDebitEvent.getEvent();
         this.eventType = directDebitEvent.getEventType();
         this.eventDate = directDebitEvent.getEventDate();
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getMandateExternalId() {
+        return mandateExternalId;
+    }
+
+    public String getTransactionExternalId() {
+        return transactionExternalId;
+    }
+
+    public DirectDebitEvent.Type getEventType() {
+        return eventType;
+    }
+
+    public DirectDebitEvent.SupportedEvent getEvent() {
+        return event;
+    }
+
+    public ZonedDateTime getEventDate() {
+        return eventDate;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.directdebit.events.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
 import uk.gov.pay.directdebit.payments.links.PaginationLink;
 import uk.gov.pay.directdebit.payments.params.DirectDebitEventSearchParams;
 
@@ -12,21 +11,21 @@ import java.net.URI;
 
 public class DirectDebitEventsPagination {
 
-    @JsonProperty("self") @Getter
+    @JsonProperty("self")
     private PaginationLink selfLink;
-    @JsonProperty("first_page") @Getter
+    @JsonProperty("first_page")
     private PaginationLink firstLink;
-    @JsonProperty("last_page") @Getter
+    @JsonProperty("last_page")
     private PaginationLink lastLink;
-    @JsonProperty("prev_page") @Getter
+    @JsonProperty("prev_page")
     private PaginationLink prevLink;
-    @JsonProperty("next_page") @Getter
+    @JsonProperty("next_page")
     private PaginationLink nextLink;
 
     public DirectDebitEventsPagination(DirectDebitEventSearchParams searchParams, int total, UriInfo uriInfo) {
         selfLink = PaginationLink.ofValue(uriWithParams(searchParams, uriInfo).toString());
         firstLink = PaginationLink.ofValue(uriWithParams(searchParams.copy().page(1).build(), uriInfo).toString());
-        int lastPage = (int) Math.ceil(total / Integer.valueOf(searchParams.getPageSize()).doubleValue());
+        int lastPage = (int) Math.ceil(total / Integer.valueOf(searchParams.getDisplaySize()).doubleValue());
         lastLink = PaginationLink.ofValue(uriWithParams(searchParams.copy().page(lastPage).build(), uriInfo).toString());
         Integer currentPage = searchParams.getPage();
         prevLink = currentPage == 1 ? null : 
@@ -39,5 +38,25 @@ public class DirectDebitEventsPagination {
         UriBuilder uriBuilder = uriInfo.getBaseUriBuilder().path(uriInfo.getPath());
         params.getParamsAsMap().forEach((k, v) -> uriBuilder.queryParam(k, v));
         return uriBuilder.build();
+    }
+
+    public PaginationLink getSelfLink() {
+        return selfLink;
+    }
+
+    public PaginationLink getFirstLink() {
+        return firstLink;
+    }
+
+    public PaginationLink getLastLink() {
+        return lastLink;
+    }
+
+    public PaginationLink getPrevLink() {
+        return prevLink;
+    }
+
+    public PaginationLink getNextLink() {
+        return nextLink;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
@@ -29,20 +29,20 @@ public class DirectDebitEventsResource {
     @GET
     @Produces(APPLICATION_JSON)
     @Timed
-    public Response findEvents(@QueryParam("before") String beforeDate,
-                               @QueryParam("after") String afterDate,
-                               @QueryParam("page_size") Integer pageSize,
+    public Response findEvents(@QueryParam("to_date") String toDate,
+                               @QueryParam("from_date") String fromDate,
+                               @QueryParam("display_size") Integer displaySize,
                                @QueryParam("page") Integer page,
                                @QueryParam("mandate_external_id") String mandateId,
                                @QueryParam("transaction_external_id") String transactionId,
                                @Context UriInfo uriInfo) {
 
-        DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder()
-                .beforeDate(beforeDate)
-                .afterDate(afterDate)
+        DirectDebitEventSearchParams searchParams = new DirectDebitEventSearchParams.DirectDebitEventSearchParamsBuilder()
+                .toDate(toDate)
+                .fromDate(fromDate)
                 .mandateExternalId(mandateId)
                 .transactionExternalId(transactionId)
-                .pageSize(pageSize)
+                .pageSize(displaySize)
                 .page(page)
                 .build();
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.payments.model;
 
-import lombok.Data;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
@@ -32,7 +31,7 @@ import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.CHARGE
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.MANDATE;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.PAYER;
 
-@Data
+
 public class DirectDebitEvent {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(DirectDebitEvent.class);
 
@@ -157,6 +156,82 @@ public class DirectDebitEvent {
     
     public static DirectDebitEvent paymentExpired(Long mandateId, Long transactionId) {
         return new DirectDebitEvent(mandateId, transactionId, CHARGE, PAYMENT_EXPIRED_BY_SYSTEM);
+    }
+
+    public static Logger getLOGGER() {
+        return LOGGER;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public Long getMandateId() {
+        return mandateId;
+    }
+
+    public String getMandateExternalId() {
+        return mandateExternalId;
+    }
+
+    public Long getTransactionId() {
+        return transactionId;
+    }
+
+    public String getTransactionExternalId() {
+        return transactionExternalId;
+    }
+
+    public Type getEventType() {
+        return eventType;
+    }
+
+    public SupportedEvent getEvent() {
+        return event;
+    }
+
+    public ZonedDateTime getEventDate() {
+        return eventDate;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public void setMandateId(Long mandateId) {
+        this.mandateId = mandateId;
+    }
+
+    public void setMandateExternalId(String mandateExternalId) {
+        this.mandateExternalId = mandateExternalId;
+    }
+
+    public void setTransactionId(Long transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public void setTransactionExternalId(String transactionExternalId) {
+        this.transactionExternalId = transactionExternalId;
+    }
+
+    public void setEventType(Type eventType) {
+        this.eventType = eventType;
+    }
+
+    public void setEvent(SupportedEvent event) {
+        this.event = event;
+    }
+
+    public void setEventDate(ZonedDateTime eventDate) {
+        this.eventDate = eventDate;
     }
 
     public enum Type {

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.directdebit.payments.params;
 
-import lombok.Builder;
-import lombok.Getter;
 import uk.gov.pay.directdebit.payments.exception.UnparsableDateException;
 
 import java.time.ZonedDateTime;
@@ -10,27 +8,35 @@ import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Builder
 public class DirectDebitEventSearchParams {
-    @Getter private final ZonedDateTime beforeDate;
-    @Getter private final ZonedDateTime afterDate;
-    @Getter private final String mandateExternalId;
-    @Getter private final String transactionExternalId;
-    @Getter private final Integer pageSize;
-    @Getter private final Integer page;
+    private final ZonedDateTime toDate;
+    private final ZonedDateTime fromDate;
+    private final String mandateExternalId;
+    private final String transactionExternalId;
+    private final Integer displaySize;
+    private final Integer page;
 
     public DirectDebitEventSearchParamsBuilder copy() {
-        return new DirectDebitEventSearchParamsBuilder().page(page).pageSize(pageSize).transactionExternalId(transactionExternalId).mandateExternalId(mandateExternalId).afterDate(afterDate).beforeDate(beforeDate);
+        return new DirectDebitEventSearchParamsBuilder().page(getPage()).pageSize(getDisplaySize()).transactionExternalId(getTransactionExternalId()).mandateExternalId(getMandateExternalId()).fromDate(getFromDate()).toDate(getToDate());
+    }
+    
+    private DirectDebitEventSearchParams(DirectDebitEventSearchParamsBuilder builder) {
+        this.toDate = builder.toDate;
+        this.fromDate = builder.fromDate;
+        this.mandateExternalId = builder.mandateExternalId;
+        this.transactionExternalId = builder.transactionExternalId;
+        this.displaySize = builder.displaySize;
+        this.page = builder.page;
     }
 
     public Map<String, String> getParamsAsMap() {
         Map<String, String> params = new LinkedHashMap<>();
         
-        if (beforeDate != null) 
-            params.put("before", beforeDate.format(DateTimeFormatter.ISO_INSTANT));
+        if (toDate != null) 
+            params.put("to_date", toDate.format(DateTimeFormatter.ISO_INSTANT));
         
-        if (afterDate != null)
-            params.put("after", afterDate.format(DateTimeFormatter.ISO_INSTANT));
+        if (fromDate != null)
+            params.put("from_date", fromDate.format(DateTimeFormatter.ISO_INSTANT));
         
         if (mandateExternalId != null)
             params.put("mandate_external_id", mandateExternalId);
@@ -39,41 +45,82 @@ public class DirectDebitEventSearchParams {
             params.put("transaction_external_id", transactionExternalId);
 
         params.put("page", page.toString());
-        params.put("page_size", pageSize.toString());
+        params.put("display_size", displaySize.toString());
         
         return params;
     }
 
+    public ZonedDateTime getToDate() {
+        return toDate;
+    }
+
+    public ZonedDateTime getFromDate() {
+        return fromDate;
+    }
+
+    public String getMandateExternalId() {
+        return mandateExternalId;
+    }
+
+    public String getTransactionExternalId() {
+        return transactionExternalId;
+    }
+
+    public Integer getDisplaySize() {
+        return displaySize;
+    }
+
+    public Integer getPage() {
+        return page;
+    }
+
     public static class DirectDebitEventSearchParamsBuilder {
         
-        // These are required as defaults to the lombok builder.
-        private Integer pageSize = 500;
+        private Integer displaySize = 500;
         private Integer page = 1;
+        private ZonedDateTime toDate;
+        private ZonedDateTime fromDate;
+        private String mandateExternalId;
+        private String transactionExternalId;
+
+        public DirectDebitEventSearchParams build() {
+            return new DirectDebitEventSearchParams(this);
+        }
         
-        public DirectDebitEventSearchParamsBuilder beforeDate(String date) {
+        public DirectDebitEventSearchParamsBuilder mandateExternalId(String mandateExternalId) {
+            this.mandateExternalId = mandateExternalId;
+            return this;
+        }
+
+        public DirectDebitEventSearchParamsBuilder transactionExternalId(String transactionExternalId) {
+            this.transactionExternalId = transactionExternalId;
+            return this;
+        }
+
+        public DirectDebitEventSearchParamsBuilder toDate(String date) {
             if (date != null) {
-                this.beforeDate = parseDate(date, "beforeDate");    
+                this.toDate = parseDate(date, "toDate");    
             }
             return this;
         }
 
-        public DirectDebitEventSearchParamsBuilder beforeDate(ZonedDateTime date) {
-            this.beforeDate = date;
+        public DirectDebitEventSearchParamsBuilder toDate(ZonedDateTime date) {
+            this.toDate = date;
             return this;
         }
-        
-        public DirectDebitEventSearchParamsBuilder afterDate(String date) {
+
+        public DirectDebitEventSearchParamsBuilder fromDate(String date) {
             if (date != null) {
-                this.afterDate = parseDate(date, "afterDate");    
+                this.fromDate = parseDate(date, "fromDate");
             }
             return this;
         }
 
-        public DirectDebitEventSearchParamsBuilder afterDate(ZonedDateTime date) {
-            this.afterDate = date;    
+        public DirectDebitEventSearchParamsBuilder fromDate(ZonedDateTime date) {
+            this.fromDate = date;
             return this;
         }
-        
+
         public DirectDebitEventSearchParamsBuilder page(Integer page) {
             if (page != null) {
                 this.page = page;
@@ -81,13 +128,12 @@ public class DirectDebitEventSearchParams {
             return this;
         }
 
-        public DirectDebitEventSearchParamsBuilder pageSize(Integer pageSize) {
-            if (pageSize != null && pageSize < 500) {
-                this.pageSize = pageSize;
+        public DirectDebitEventSearchParamsBuilder pageSize(Integer displaySize) {
+            if (displaySize != null && displaySize < 500) {
+                this.displaySize = displaySize;
             }
             return this;
         }
-
 
         private ZonedDateTime parseDate(String date, String fieldName) {
             ZonedDateTime dateTime;

--- a/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
@@ -33,31 +33,31 @@ public class DirectDebitEventsPaginationTest {
 
     @Test
     public void testWithAllSearchParameters() {
-        DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder()
+        DirectDebitEventSearchParams searchParams = new DirectDebitEventSearchParams.DirectDebitEventSearchParamsBuilder()
                 .page(2)
-                .afterDate(ZonedDateTime.of(2018, 6, 29, 8, 0, 0, 0, ZoneId.of("UTC")))
-                .beforeDate(ZonedDateTime.of(2018, 6, 29, 9, 0, 0, 0, ZoneId.of("UTC")))
+                .fromDate(ZonedDateTime.of(2018, 6, 29, 8, 0, 0, 0, ZoneId.of("UTC")))
+                .toDate(ZonedDateTime.of(2018, 6, 29, 9, 0, 0, 0, ZoneId.of("UTC")))
                 .mandateExternalId("1234L")
                 .transactionExternalId("5678L")
                 .pageSize(10)
                 .build();
         DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 100, mockUriInfo);
         
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?before=2018-06-29T09%3A00%3A00Z&after=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=2&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=2&display_size=10")
                 , pagination.getSelfLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?before=2018-06-29T09%3A00%3A00Z&after=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=3&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=3&display_size=10")
                 , pagination.getNextLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?before=2018-06-29T09%3A00%3A00Z&after=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=1&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=1&display_size=10")
                 , pagination.getFirstLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?before=2018-06-29T09%3A00%3A00Z&after=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=10&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=10&display_size=10")
                 , pagination.getLastLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?before=2018-06-29T09%3A00%3A00Z&after=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=1&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=1&display_size=10")
                 , pagination.getPrevLink());
     }
 
     @Test
     public void testWithSomeSearchParameters() {
-        DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder()
+        DirectDebitEventSearchParams searchParams = new DirectDebitEventSearchParams.DirectDebitEventSearchParamsBuilder()
                 .page(3)
                 .mandateExternalId("1234L")
                 .transactionExternalId("5678L")
@@ -65,26 +65,26 @@ public class DirectDebitEventsPaginationTest {
                 .build();
         DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 100, mockUriInfo);
 
-        assertEquals(pagination.getSelfLink(), PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=3&page_size=10"));
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=4&page_size=10")
+        assertEquals(pagination.getSelfLink(), PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=3&display_size=10"));
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=4&display_size=10")
                 , pagination.getNextLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=1&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=1&display_size=10")
                 , pagination.getFirstLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=10&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=10&display_size=10")
                 , pagination.getLastLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=2&page_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=2&display_size=10")
                 , pagination.getPrevLink());
     }
 
     @Test
     public void testWithNoSearchParameters() {
-        DirectDebitEventSearchParams searchParams = DirectDebitEventSearchParams.builder().build();
+        DirectDebitEventSearchParams searchParams = new DirectDebitEventSearchParams.DirectDebitEventSearchParamsBuilder().build();
         DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 5000, mockUriInfo);
 
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=1&page_size=500"), pagination.getSelfLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=2&page_size=500"), pagination.getNextLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=1&page_size=500"), pagination.getFirstLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=10&page_size=500"), pagination.getLastLink());
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=1&display_size=500"), pagination.getSelfLink());
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=2&display_size=500"), pagination.getNextLink());
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=1&display_size=500"), pagination.getFirstLink());
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?page=10&display_size=500"), pagination.getLastLink());
         assertNull(pagination.getPrevLink());
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsTest.java
@@ -88,7 +88,7 @@ public class GetDirectDebitEventsTest {
                 .withEventDate(ZonedDateTime.now())
                 .insert(testContext.getJdbi());
 
-        String requestPath = format("/v1/events?before=%s", "invalid_format");
+        String requestPath = format("/v1/events?to_date=%s", "invalid_format");
 
         given().port(testContext.getPort())
                 .contentType(JSON)
@@ -108,7 +108,7 @@ public class GetDirectDebitEventsTest {
                 .withEventDate(ZonedDateTime.now())
                 .insert(testContext.getJdbi());
 
-        String requestPath = format("/v1/events?before=%s&after=%s&page_size=100&page=1&mandate_external_id=%s&transaction_external_id=%s",
+        String requestPath = format("/v1/events?to_date=%s&from_date=%s&display_size=100&page=1&mandate_external_id=%s&transaction_external_id=%s",
                 ZonedDateTime.now().plusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
                 ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
                 testMandate.getExternalId(),
@@ -141,7 +141,7 @@ public class GetDirectDebitEventsTest {
                 .withEventDate(ZonedDateTime.now())
                 .insert(testContext.getJdbi());
 
-        String requestPath = format("/v1/events?before=%s&after=%s&page_size=100&page=1&mandate_external_id=%s&transaction_external_id=%s",
+        String requestPath = format("/v1/events?to_date=%s&from_date=%s&display_size=100&page=1&mandate_external_id=%s&transaction_external_id=%s",
                 ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
                 ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
                 testMandate.getId().toString(),
@@ -167,7 +167,7 @@ public class GetDirectDebitEventsTest {
                 .withEventDate(ZonedDateTime.now())
                 .insert(testContext.getJdbi());
 
-        String requestPath = format("/v1/events?before=%s",
+        String requestPath = format("/v1/events?to_date=%s",
                 ZonedDateTime.now().plusMinutes(5).format(DateTimeFormatter.ISO_INSTANT));
 
         given().port(testContext.getPort())
@@ -190,7 +190,7 @@ public class GetDirectDebitEventsTest {
                 .withEventDate(ZonedDateTime.now())
                 .insert(testContext.getJdbi());
 
-        String requestPath = format("/v1/events?after=%s",
+        String requestPath = format("/v1/events?from_date=%s",
                 ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT));
 
         given().port(testContext.getPort())
@@ -259,7 +259,7 @@ public class GetDirectDebitEventsTest {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = format("/v1/events?transaction_external_id=%s&page_size=2", testTransaction.getExternalId());
+        String requestPath = format("/v1/events?transaction_external_id=%s&display_size=2", testTransaction.getExternalId());
 
         given().port(testContext.getPort())
                 .contentType(JSON)
@@ -288,7 +288,7 @@ public class GetDirectDebitEventsTest {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = format("/v1/events?page_size=2&page=2");
+        String requestPath = format("/v1/events?display_size=2&page=2");
 
         given().port(testContext.getPort())
                 .contentType(JSON)
@@ -320,7 +320,7 @@ public class GetDirectDebitEventsTest {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = format("/v1/events?page_size=2&page=%s", currentPage);
+        String requestPath = format("/v1/events?display_size=2&page=%s", currentPage);
 
         String body = given().port(testContext.getPort())
                 .contentType(JSON)
@@ -329,20 +329,20 @@ public class GetDirectDebitEventsTest {
         String directDebitConnectorUrl = format("http://localhost:%s", app.getLocalPort());
         
         JsonAssert.with(body)
-                .assertThat("_links.self.href", is(format("%s/v1/events?page=%s&page_size=2", directDebitConnectorUrl, currentPage)))
-                .assertThat("_links.first_page.href", is(format("%s/v1/events?page=%s&page_size=2", directDebitConnectorUrl, firstPage)))
-                .assertThat("_links.last_page.href", is(format("%s/v1/events?page=%s&page_size=2", directDebitConnectorUrl, lastPage)));
+                .assertThat("_links.self.href", is(format("%s/v1/events?page=%s&display_size=2", directDebitConnectorUrl, currentPage)))
+                .assertThat("_links.first_page.href", is(format("%s/v1/events?page=%s&display_size=2", directDebitConnectorUrl, firstPage)))
+                .assertThat("_links.last_page.href", is(format("%s/v1/events?page=%s&display_size=2", directDebitConnectorUrl, lastPage)));
                 
         if (nextPage == null) {
             JsonAssert.with(body).assertNotDefined("_links.next_page.href");
         } else {
-            JsonAssert.with(body).assertThat("_links.next_page.href", is(format("%s/v1/events?page=%s&page_size=2", directDebitConnectorUrl, nextPage)));
+            JsonAssert.with(body).assertThat("_links.next_page.href", is(format("%s/v1/events?page=%s&display_size=2", directDebitConnectorUrl, nextPage)));
         }
         
         if (prevPage == null) {
             JsonAssert.with(body).assertNotDefined("_links.prev_page.href");
         } else{
-            JsonAssert.with(body).assertThat("_links.prev_page.href", is(format("%s/v1/events?page=%s&page_size=2", directDebitConnectorUrl, prevPage)));
+            JsonAssert.with(body).assertThat("_links.prev_page.href", is(format("%s/v1/events?page=%s&display_size=2", directDebitConnectorUrl, prevPage)));
         }
     }
     
@@ -359,7 +359,7 @@ public class GetDirectDebitEventsTest {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = format("/v1/events?page_size=501");
+        String requestPath = format("/v1/events?display_size=501");
 
         given().port(testContext.getPort())
                 .contentType(JSON)

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/DirectDebitEventFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/DirectDebitEventFixture.java
@@ -4,7 +4,6 @@ import java.sql.Timestamp;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import lombok.Getter;
 import org.apache.commons.lang3.RandomUtils;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.directdebit.common.fixtures.DbFixture;
@@ -16,7 +15,7 @@ import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEv
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.CHARGE;
 
-@Getter
+
 public class DirectDebitEventFixture implements DbFixture<DirectDebitEventFixture, DirectDebitEvent> {
     private Long id = RandomUtils.nextLong(1, 99999);
     private String externalId = RandomIdGenerator.newId();
@@ -83,13 +82,13 @@ public class DirectDebitEventFixture implements DbFixture<DirectDebitEventFixtur
                                 "        event_date\n" +
                                 "    )\n" +
                                 "   VALUES(?, ?, ?, ?, ?, ?, ?)\n",
-                        id,
-                        externalId,
-                        mandateId,
-                        transactionId,
-                        eventType.toString(),
-                        event.toString(),
-                        Timestamp.from(eventDate.toInstant())
+                        getId(),
+                        getExternalId(),
+                        getMandateId(),
+                        getTransactionId(),
+                        getEventType().toString(),
+                        getEvent().toString(),
+                        Timestamp.from(getEventDate().toInstant())
                 )
         );
         return this;
@@ -97,7 +96,34 @@ public class DirectDebitEventFixture implements DbFixture<DirectDebitEventFixtur
 
     @Override
     public DirectDebitEvent toEntity() {
-        return new DirectDebitEvent(id, externalId, mandateId, transactionId, eventType, event, eventDate);
+        return new DirectDebitEvent(getId(), getExternalId(), getMandateId(), getTransactionId(), getEventType(), getEvent(), getEventDate());
     }
 
+    public Long getId() {
+        return id;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public Long getMandateId() {
+        return mandateId;
+    }
+
+    public Long getTransactionId() {
+        return transactionId;
+    }
+
+    public Type getEventType() {
+        return eventType;
+    }
+
+    public SupportedEvent getEvent() {
+        return event;
+    }
+
+    public ZonedDateTime getEventDate() {
+        return eventDate;
+    }
 }


### PR DESCRIPTION
This corrects the url search parameters to match convention.
- `after` becomes `from_date`.
- `before` becomes `to_date`.
- `page_size` becomes `display_size`.

Also removed Lombok from the project after a team discussion and decision. 

@oswaldquek
