### PR TITLE
BAU: Upgrade libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,16 +17,16 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>1.3.2</dropwizard.version>
+        <dropwizard.version>1.3.5</dropwizard.version>
         <mainClass>uk.gov.pay.directdebit.DirectDebitConnectorApp</mainClass>
 
         <wiremock.version>2.17.0</wiremock.version>
         <liquibase.version>3.6.1</liquibase.version>
         <postgresql.version>42.2.2</postgresql.version>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
         <guice.version>4.2.0</guice.version>
         <guava.version>24.1-jre</guava.version>
-        <gocardless.version>3.5.1</gocardless.version>
+        <gocardless.version>3.7.0</gocardless.version>
         <hamcrest.version>1.3</hamcrest.version>
         <rest-assured.version>3.0.7</rest-assured.version>
         <mockito.version>2.18.0</mockito.version>


### PR DESCRIPTION
## WHAT YOU DID

- Upgrade Dropwizard from `1.3.2` to `1.3.5`
- Upgrade GoCardless SDK from `3.5.1` to `3.7.0`
- Upgrade Jackson from `2.9.5` to `2.9.6`
