### PR TITLE
PP-3965 Instantiate a gocardless client for each gateway account

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
@@ -10,6 +10,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import javax.net.ssl.SSLSocketFactory;
 import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.directdebit.payments.clients.GoCardlessClientFactory;
 import uk.gov.pay.directdebit.payments.dao.DirectDebitEventDao;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessMandateDao;
@@ -47,25 +48,12 @@ public class DirectDebitModule extends AbstractModule {
         bind(Environment.class).toInstance(environment);
     }
 
-    private GoCardlessClient createGoCardlessClient() {
-        GoCardlessFactory goCardlessFactory = configuration.getGoCardless();
-        GoCardlessClient.Builder builder = GoCardlessClient.newBuilder(
-                goCardlessFactory.getAccessToken());
 
-        if (goCardlessFactory.isCallingStubs()) {
-            return builder.withBaseUrl(goCardlessFactory.getClientUrl())
-                    .withSslSocketFactory(sslSocketFactory)
-                    .build();
-        }
-        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(configuration.getProxyConfig().getHost(), configuration.getProxyConfig().getPort()));
-        return builder.withEnvironment(goCardlessFactory.getEnvironment())
-                .withProxy(proxy).build();
-    }
 
     @Provides
     @Singleton
-    public GoCardlessClientWrapper provideGoCardlessClientWrapper()  {
-        return new GoCardlessClientWrapper(createGoCardlessClient());
+    public GoCardlessClientFactory provideGoCardlessClientFactory()  {
+        return new GoCardlessClientFactory(configuration, sslSocketFactory);
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFactory.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.directdebit.payments.clients;
+
+import com.gocardless.GoCardlessClient;
+import com.google.common.collect.Maps;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.Map;
+import java.util.Optional;
+import javax.net.ssl.SSLSocketFactory;
+import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
+import uk.gov.pay.directdebit.webhook.gocardless.config.GoCardlessFactory;
+
+public class GoCardlessClientFactory {
+
+    private final Map<PaymentProviderAccessToken, GoCardlessClientFacade> clients;
+    private final SSLSocketFactory sslSocketFactory;
+    private final DirectDebitConfig configuration;
+    public GoCardlessClientFactory(
+            DirectDebitConfig configuration,
+            SSLSocketFactory sslSocketFactory) {
+        this.configuration = configuration;
+        this.sslSocketFactory = sslSocketFactory;
+        this.clients = Maps.newConcurrentMap();
+    }
+    
+    public GoCardlessClientFacade getClientFor(Optional<PaymentProviderAccessToken> maybeAccessToken) {
+        //backward compatibility for now, will use the token in the config if it's not there
+        PaymentProviderAccessToken accessToken = maybeAccessToken.orElse(PaymentProviderAccessToken.of(configuration.getGoCardless().getAccessToken()));
+        return clients.computeIfAbsent(accessToken, token -> {
+            GoCardlessClientWrapper clientWrapper = new GoCardlessClientWrapper(createGoCardlessClient(configuration, sslSocketFactory, token));
+            return new GoCardlessClientFacade(clientWrapper);
+        });
+    }
+
+    private GoCardlessClient createGoCardlessClient(DirectDebitConfig configuration, SSLSocketFactory sslSocketFactory, PaymentProviderAccessToken accessToken) {
+        GoCardlessFactory goCardlessFactory = configuration.getGoCardless();
+        GoCardlessClient.Builder builder = GoCardlessClient.newBuilder(accessToken.toString());
+
+        if (goCardlessFactory.isCallingStubs()) {
+            return builder.withBaseUrl(goCardlessFactory.getClientUrl())
+                    .withSslSocketFactory(sslSocketFactory)
+                    .build();
+        }
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(configuration.getProxyConfig().getHost(), configuration.getProxyConfig().getPort()));
+        return builder.withEnvironment(goCardlessFactory.getEnvironment())
+                .withProxy(proxy).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFactory.java
@@ -28,12 +28,12 @@ public class GoCardlessClientFactory {
         //backward compatibility for now, will use the token in the config if it's not there
         PaymentProviderAccessToken accessToken = maybeAccessToken.orElse(PaymentProviderAccessToken.of(configuration.getGoCardless().getAccessToken()));
         return clients.computeIfAbsent(accessToken, token -> {
-            GoCardlessClientWrapper clientWrapper = new GoCardlessClientWrapper(createGoCardlessClient(configuration, sslSocketFactory, token));
+            GoCardlessClientWrapper clientWrapper = new GoCardlessClientWrapper(createGoCardlessClient(token));
             return new GoCardlessClientFacade(clientWrapper);
         });
     }
 
-    private GoCardlessClient createGoCardlessClient(DirectDebitConfig configuration, SSLSocketFactory sslSocketFactory, PaymentProviderAccessToken accessToken) {
+    private GoCardlessClient createGoCardlessClient(PaymentProviderAccessToken accessToken) {
         GoCardlessFactory goCardlessFactory = configuration.getGoCardless();
         GoCardlessClient.Builder builder = GoCardlessClient.newBuilder(accessToken.toString());
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmMandateSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/ConfirmMandateSetupResourceIT.java
@@ -198,10 +198,10 @@ public class ConfirmMandateSetupResourceIT {
                 withCustomerId(customerId)
                 .withCustomerBankAccountId(customerBankAccountId)
                 .withPayerId(payerFixture.getId());
-        stubCreateCustomer(mandateFixture.getExternalId().toString(), payerFixture, customerId);
-        stubCreateCustomerBankAccount(mandateFixture.getExternalId().toString(), payerFixture, customerId, customerBankAccountId);
-        stubCreateMandate(mandateFixture.getExternalId().toString(), goCardlessCustomerFixture);
-        stubCreatePayment(transactionFixture.getAmount(), "MD123", transactionFixture.getExternalId());
+        stubCreateCustomer(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId);
+        stubCreateCustomerBankAccount(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId, customerBankAccountId);
+        stubCreateMandate(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), goCardlessCustomerFixture);
+        stubCreatePayment(gatewayAccountFixture.getAccessToken().toString(), transactionFixture.getAmount(), "MD123", transactionFixture.getExternalId());
 
         String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length() - 2);
 
@@ -263,9 +263,9 @@ public class ConfirmMandateSetupResourceIT {
                 withCustomerId(customerId)
                 .withCustomerBankAccountId(customerBankAccountId)
                 .withPayerId(payerFixture.getId());
-        stubCreateCustomer(mandateFixture.getExternalId().toString(), payerFixture, customerId);
-        stubCreateCustomerBankAccount(mandateFixture.getExternalId().toString(), payerFixture, customerId, customerBankAccountId);
-        stubCreateMandate(mandateFixture.getExternalId().toString(), goCardlessCustomerFixture);
+        stubCreateCustomer(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId);
+        stubCreateCustomerBankAccount(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId, customerBankAccountId);
+        stubCreateMandate(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), goCardlessCustomerFixture);
 
         String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length()-2);
         // language=JSON

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -552,10 +552,10 @@ public class MandateResourceIT {
                 withCustomerId(customerId)
                 .withCustomerBankAccountId(customerBankAccountId)
                 .withPayerId(payerFixture.getId());
-        stubCreateCustomer(mandateFixture.getExternalId().toString(), payerFixture, customerId);
-        stubCreateCustomerBankAccount(mandateFixture.getExternalId().toString(), payerFixture, customerId, customerBankAccountId);
-        stubCreateMandate(mandateFixture.getExternalId().toString(), goCardlessCustomerFixture);
-        stubCreatePayment(transactionFixture.getAmount(), "MD123", transactionFixture.getExternalId());
+        stubCreateCustomer(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId);
+        stubCreateCustomerBankAccount(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId, customerBankAccountId);
+        stubCreateMandate(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), goCardlessCustomerFixture);
+        stubCreatePayment(gatewayAccountFixture.getAccessToken().toString(), transactionFixture.getAmount(), "MD123", transactionFixture.getExternalId());
 
         String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length() - 2);
 
@@ -617,9 +617,9 @@ public class MandateResourceIT {
                 withCustomerId(customerId)
                 .withCustomerBankAccountId(customerBankAccountId)
                 .withPayerId(payerFixture.getId());
-        stubCreateCustomer(mandateFixture.getExternalId().toString(), payerFixture, customerId);
-        stubCreateCustomerBankAccount(mandateFixture.getExternalId().toString(), payerFixture, customerId, customerBankAccountId);
-        stubCreateMandate(mandateFixture.getExternalId().toString(), goCardlessCustomerFixture);
+        stubCreateCustomer(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId);
+        stubCreateCustomerBankAccount(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId, customerBankAccountId);
+        stubCreateMandate(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), goCardlessCustomerFixture);
 
         String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length()-2);
         // language=JSON

--- a/src/test/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/clients/GoCardlessClientFactoryTest.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.directdebit.payments.clients;
+
+import com.gocardless.GoCardlessClient;
+import java.util.Optional;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoCardlessClientFactoryTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private DirectDebitConfig mockedDirectDebitConfig;
+    @Mock
+    private SSLSocketFactory mockedSSLSocketFactory;
+    private GoCardlessClientFactory goCardlessClientFactory;
+
+    @Before
+    public void setUp() {
+        when(mockedDirectDebitConfig.getGoCardless().getAccessToken()).thenReturn("aaa");
+        when(mockedDirectDebitConfig.getProxyConfig().getHost()).thenReturn("aaa");
+        when(mockedDirectDebitConfig.getProxyConfig().getPort()).thenReturn(0);
+        when(mockedDirectDebitConfig.getGoCardless().getEnvironment()).thenReturn(GoCardlessClient.Environment.SANDBOX);
+        goCardlessClientFactory = new GoCardlessClientFactory(mockedDirectDebitConfig, mockedSSLSocketFactory);
+    }
+    
+    @Test
+    public void shouldCreateOnlyOneClientPerGatewayAccount() {
+        GoCardlessClientFacade firstClient = goCardlessClientFactory
+                .getClientFor(Optional.of(PaymentProviderAccessToken.of("accessToken")));
+        GoCardlessClientFacade secondClient = goCardlessClientFactory
+                .getClientFor(Optional.of(PaymentProviderAccessToken.of("accessToken")));
+        assertThat(firstClient, is(secondClient));
+    }
+
+    
+    //backward compatibility, please remove once all gateway accounts have an access token
+    @Test
+    public void shouldCreateAClient_ifNoAccessTokenIsDefined() {
+        GoCardlessClientFacade client = goCardlessClientFactory
+                .getClientFor(Optional.empty());
+        GoCardlessClientFacade clientWithConfigAccessToken = goCardlessClientFactory
+                .getClientFor(Optional.of(PaymentProviderAccessToken.of("aaa")));
+        assertThat(client, is(clientWithConfigAccessToken));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GatewayAccountFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GatewayAccountFixture.java
@@ -97,6 +97,10 @@ public class GatewayAccountFixture implements DbFixture<GatewayAccountFixture, G
         return analyticsId;
     }
 
+    public PaymentProviderAccessToken getAccessToken() {
+        return accessToken;
+    }
+
     public PaymentProviderOrganisationIdentifier getOrganisation() { return organisation; }
 
     @Override

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
@@ -228,7 +228,7 @@ public class TransactionResourceIT {
 
         String requestPath = "/v1/api/accounts/{accountId}/charges/collect"
                 .replace("{accountId}", accountExternalId);
-        stubCreatePayment(AMOUNT, goCardlessMandate.getGoCardlessMandateId(), null);
+        stubCreatePayment(gatewayAccountFixture.getAccessToken().toString(), AMOUNT, goCardlessMandate.getGoCardlessMandateId(), null);
         String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length()-2);
         String emailPayloadBody = "{\"address\": \"" + payerFixture.getEmail() + "\", " +
                 "\"gateway_account_external_id\": \"" + gatewayAccountFixture.getExternalId() + "\"," +

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceOnDemandTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceOnDemandTest.java
@@ -26,8 +26,8 @@ public class GoCardlessServiceOnDemandTest extends GoCardlessServiceTest {
     @Before
     public void setUp() {
         mandateFixture.withMandateType(MandateType.ON_DEMAND);
-        service = new GoCardlessService(mockedGoCardlessClientFacade, mockedGoCardlessCustomerDao, mockedGoCardlessPaymentDao, mockedGoCardlessMandateDao);
-
+        service = new GoCardlessService(mockedGoCardlessClientFactory, mockedGoCardlessCustomerDao, mockedGoCardlessPaymentDao, mockedGoCardlessMandateDao);
+        when(mockedGoCardlessClientFactory.getClientFor(Optional.of(gatewayAccountFixture.getAccessToken()))).thenReturn(mockedGoCardlessClientFacade);
         when(mockedGoCardlessClientFacade.createCustomer(MANDATE_ID, payerFixture.toEntity())).thenReturn(goCardlessCustomer);
         when(mockedGoCardlessClientFacade.createCustomerBankAccount(MANDATE_ID, goCardlessCustomer, payerFixture.getName(), SORT_CODE, ACCOUNT_NUMBER)).thenReturn(goCardlessCustomer);
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceOneOffTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceOneOffTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.directdebit.payments.services;
 
-import java.time.LocalDate;
-import org.junit.Assert;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,8 +13,7 @@ import uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessService;
 import uk.gov.pay.directdebit.payments.exception.InvalidMandateTypeException;
 
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -27,7 +25,8 @@ public class GoCardlessServiceOneOffTest extends GoCardlessServiceTest {
     @Before
     public void setUp() {
         mandateFixture.withMandateType(MandateType.ONE_OFF);
-        service = new GoCardlessService(mockedGoCardlessClientFacade, mockedGoCardlessCustomerDao, mockedGoCardlessPaymentDao, mockedGoCardlessMandateDao);
+        service = new GoCardlessService(mockedGoCardlessClientFactory, mockedGoCardlessCustomerDao, mockedGoCardlessPaymentDao, mockedGoCardlessMandateDao);
+        when(mockedGoCardlessClientFactory.getClientFor(Optional.of(gatewayAccountFixture.getAccessToken()))).thenReturn(mockedGoCardlessClientFacade);
         when(mockedGoCardlessClientFacade.createCustomer(MANDATE_ID, payerFixture.toEntity())).thenReturn(goCardlessCustomer);
         when(mockedGoCardlessClientFacade.createCustomerBankAccount(MANDATE_ID, goCardlessCustomer, payerFixture.getName(), SORT_CODE, ACCOUNT_NUMBER)).thenReturn(goCardlessCustomer);
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -25,6 +25,7 @@ import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
 import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.clients.GoCardlessClientFacade;
+import uk.gov.pay.directdebit.payments.clients.GoCardlessClientFactory;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerBankAccountFailedException;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerFailedException;
 import uk.gov.pay.directdebit.payments.exception.CreateMandateFailedException;
@@ -63,7 +64,8 @@ public abstract class GoCardlessServiceTest {
     protected GoCardlessPaymentDao mockedGoCardlessPaymentDao;
     @Mock
     protected MandateService mockedMandateService;
-
+    @Mock
+    protected GoCardlessClientFactory mockedGoCardlessClientFactory;
     GoCardlessService service;
 
     GatewayAccountFixture gatewayAccountFixture =  GatewayAccountFixture

--- a/src/test/java/uk/gov/pay/directdebit/util/GoCardlessStubs.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/GoCardlessStubs.java
@@ -24,7 +24,7 @@ import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.GOCARDLESS_
 import static uk.gov.pay.directdebit.util.TestRequestResponsesLoader.load;
 
 public class GoCardlessStubs {
-    public static void stubCreateCustomer(String idempotencyKey, PayerFixture payerFixture, String goCardlessCustomerId) {
+    public static void stubCreateCustomer(String accessToken, String idempotencyKey, PayerFixture payerFixture, String goCardlessCustomerId) {
         String customerRequestExpectedBody = load(GOCARDLESS_CREATE_CUSTOMER_REQUEST)
                 .replace("{{email}}", payerFixture.getEmail())
                 .replace("{{family_name}}", payerFixture.getName())
@@ -35,10 +35,10 @@ public class GoCardlessStubs {
                 .replace("{{given_name}}", payerFixture.getName())
                 .replace("{{gocardless_customer_id}}", goCardlessCustomerId);
 
-        stubCallsFor("/customers", 200, idempotencyKey, customerRequestExpectedBody, customerResponseBody);
+        stubCallsFor("/customers", accessToken, 200, idempotencyKey, customerRequestExpectedBody, customerResponseBody);
     }
 
-    public static void stubCreateCustomerBankAccount(String idempotencyKey, PayerFixture payerFixture, String goCardlessCustomerId, String goCardlessBankAccountId) {
+    public static void stubCreateCustomerBankAccount(String accessToken, String idempotencyKey, PayerFixture payerFixture, String goCardlessCustomerId, String goCardlessBankAccountId) {
         String customerBankAccountRequestExpectedBody = load(GOCARDLESS_CREATE_CUSTOMER_BANK_ACCOUNT_REQUEST)
                 .replace("{{account_holder_name}}", payerFixture.getName())
                 .replace("{{account_number}}", payerFixture.getAccountNumber())
@@ -49,10 +49,10 @@ public class GoCardlessStubs {
                 .replace("{{account_holder_name}}", payerFixture.getName())
                 .replace("{{gocardless_customer_id}}", goCardlessCustomerId)
                 .replace("{{gocardless_customer_bank_account_id}}", goCardlessBankAccountId);
-        stubCallsFor("/customer_bank_accounts", 200, idempotencyKey, customerBankAccountRequestExpectedBody, customerBankAccountResponseBody);
+        stubCallsFor("/customer_bank_accounts", accessToken,200, idempotencyKey, customerBankAccountRequestExpectedBody, customerBankAccountResponseBody);
     }
 
-    public static void stubCreateMandate(String idempotencyKey, GoCardlessCustomerFixture goCardlessCustomerFixture) {
+    public static void stubCreateMandate(String accessToken, String idempotencyKey, GoCardlessCustomerFixture goCardlessCustomerFixture) {
         String mandateRequestExpectedBody = load(GOCARDLESS_CREATE_MANDATE_REQUEST)
                 .replace("{{customer_bank_account_id}}", goCardlessCustomerFixture.getCustomerBankAccountId());
 
@@ -60,10 +60,10 @@ public class GoCardlessStubs {
                 .replace("{{customer_bank_account_id}}", goCardlessCustomerFixture.getCustomerBankAccountId())
                 .replace("{{customer_id}}", goCardlessCustomerFixture.getCustomerId())
                 .replace("{{gocardless_customer_bank_account_id}}", goCardlessCustomerFixture.getCustomerBankAccountId());
-        stubCallsFor("/mandates", 200, idempotencyKey, mandateRequestExpectedBody, mandateResponseBody);
+        stubCallsFor("/mandates", accessToken, 200, idempotencyKey, mandateRequestExpectedBody, mandateResponseBody);
     }
 
-    public static void stubCreatePayment(Long amount, String goCardlessMandateId, String idempotencyKey) {
+    public static void stubCreatePayment(String accessToken, Long amount, String goCardlessMandateId, String idempotencyKey) {
         String paymentRequestExpectedBody = load(GOCARDLESS_CREATE_PAYMENT_REQUEST)
                 .replace("{{amount}}", String.valueOf(amount))
                 .replace("{{gocardless_mandate_id}}", goCardlessMandateId);
@@ -71,16 +71,16 @@ public class GoCardlessStubs {
         String paymentResponseBody = load(GOCARDLESS_CREATE_PAYMENT_SUCCESS_RESPONSE)
                 .replace("{{amount}}", String.valueOf(amount))
                 .replace("{{gocardless_mandate_id}}", goCardlessMandateId);
-        stubCallsFor("/payments", 200, idempotencyKey, paymentRequestExpectedBody, paymentResponseBody);
+        stubCallsFor("/payments", accessToken,200, idempotencyKey, paymentRequestExpectedBody, paymentResponseBody);
     }
     
-    private static void stubCallsFor(String url, int statusCode, String idempotencyKey, String requestBody, String responseBody) {
+    private static void stubCallsFor(String url, String accessToken, int statusCode, String idempotencyKey, String requestBody, String responseBody) {
         MappingBuilder postRequest = post(urlPathEqualTo(url));
         if (idempotencyKey != null) {
             postRequest.withHeader("Idempotency-Key", equalTo(idempotencyKey));
         }
         postRequest
-                .withHeader("Authorization", equalTo("Bearer accesstoken"))
+                .withHeader("Authorization", equalTo("Bearer " + accessToken))
                 .withRequestBody(equalToJson(requestBody))
                 .willReturn(
                         aResponse()


### PR DESCRIPTION
## WHAT YOU DID
After introducing partner integration we are going to instantiate a client for each gateway account, using their access token (which we store).

For now, because partner integration is not yet done, if there's no access token we use the one coming from the config.