### PR TITLE
PP-3680 Fixed pagination when total is 0

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPagination.java
@@ -25,7 +25,7 @@ public class DirectDebitEventsPagination {
     public DirectDebitEventsPagination(DirectDebitEventSearchParams searchParams, int total, UriInfo uriInfo) {
         selfLink = PaginationLink.ofValue(uriWithParams(searchParams, uriInfo).toString());
         firstLink = PaginationLink.ofValue(uriWithParams(searchParams.copy().page(1).build(), uriInfo).toString());
-        int lastPage = (int) Math.ceil(total / Integer.valueOf(searchParams.getDisplaySize()).doubleValue());
+        int lastPage = total == 0 ? 1 : (int) Math.ceil(total / Integer.valueOf(searchParams.getDisplaySize()).doubleValue());
         lastLink = PaginationLink.ofValue(uriWithParams(searchParams.copy().page(lastPage).build(), uriInfo).toString());
         Integer currentPage = searchParams.getPage();
         prevLink = currentPage == 1 ? null : 


### PR DESCRIPTION
- Fix bug which incorrectly sets the last_page page number to 0 if the total is 0.
It should be 1.