### PR TITLE
PP-4002 Add creditor id to mandates

### DIFF
--- a/src/main/resources/migrations/00038_alter_table_mandates_add_column_creditor_id.sql
+++ b/src/main/resources/migrations/00038_alter_table_mandates_add_column_creditor_id.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-mandates-creditor-id
+ALTER TABLE mandates ADD COLUMN creditor_id VARCHAR(255);
+--rollback ALTER TABLE mandates DROP COLUMN creditor_id;


### PR DESCRIPTION
## WHAT YOU DID

- We need creditor id to query our provider for the creditor which will have the SUN (Service User Number).
- We make it varchar 255 to be future proof, but the current value is 18 characters.

with @danworth
