### PR TITLE
PP-3986 - Move state check first

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateService.java
@@ -1,22 +1,21 @@
 package uk.gov.pay.directdebit.mandate.services;
 
-import java.time.LocalDate;
-import javax.inject.Inject;
-import javax.ws.rs.core.UriInfo;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.api.ConfirmMandateRequest;
 import uk.gov.pay.directdebit.mandate.api.CreateMandateRequest;
 import uk.gov.pay.directdebit.mandate.api.CreateMandateResponse;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
-import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
-import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequest;
 import uk.gov.pay.directdebit.payments.exception.InvalidMandateTypeException;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.UriInfo;
+import java.time.LocalDate;
 
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 
@@ -53,7 +52,7 @@ public class OnDemandMandateService implements MandateCommandService {
                                 confirmDetailsRequest.getAccountNumber(),
                                 confirmDetailsRequest.getSortCode())
                 );
-        mandateStateUpdateService.confirmedDirectDebitDetailsFor(confirmedMandate);
+        mandateStateUpdateService.confirmedOnDemandDirectDebitDetailsFor(confirmedMandate);
     }
 
     public Transaction collect(GatewayAccount gatewayAccount, Mandate mandate,

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateService.java
@@ -1,43 +1,47 @@
 package uk.gov.pay.directdebit.mandate.services;
 
-import javax.inject.Inject;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.api.ConfirmMandateRequest;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.OneOffConfirmationDetails;
-import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
-import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.api.CreatePaymentRequest;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
+
+import javax.inject.Inject;
+
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 
 public class OneOffMandateService implements MandateCommandService {
     private final PaymentProviderFactory paymentProviderFactory;
     private final TransactionService transactionService;
     private final MandateStateUpdateService mandateStateUpdateService;
     private final MandateService mandateService;
+
     @Inject
     public OneOffMandateService(
             PaymentProviderFactory paymentProviderFactory,
             TransactionService transactionService,
             MandateStateUpdateService mandateStateUpdateService,
-            MandateService mandateService){
+            MandateService mandateService) {
         this.paymentProviderFactory = paymentProviderFactory;
         this.transactionService = transactionService;
         this.mandateStateUpdateService = mandateStateUpdateService;
         this.mandateService = mandateService;
     }
-    
+
     public Transaction create(GatewayAccount gatewayAccount,
-            CreatePaymentRequest createPaymentRequest) {
+                              CreatePaymentRequest createPaymentRequest) {
         Mandate mandate = mandateService.createMandate(createPaymentRequest, gatewayAccount.getExternalId());
         return transactionService.createTransaction(createPaymentRequest, mandate, gatewayAccount.getExternalId());
     }
 
     @Override
     public void confirm(GatewayAccount gatewayAccount, Mandate mandate, ConfirmMandateRequest confirmMandateRequest) {
+        mandateStateUpdateService.canUpdateStateFor(mandate, DIRECT_DEBIT_DETAILS_CONFIRMED);
+
         Transaction transaction = transactionService
                 .findTransactionForExternalId(confirmMandateRequest.getTransactionExternalId());
 
@@ -50,7 +54,7 @@ public class OneOffMandateService implements MandateCommandService {
                         transaction
                 );
 
-        mandateStateUpdateService.confirmedDirectDebitDetailsFor(oneOffConfirmationDetails.getMandate());
+        mandateStateUpdateService.confirmedOneOffDirectDebitDetailsFor(oneOffConfirmationDetails.getMandate());
         transactionService.oneOffPaymentSubmittedToProviderFor(
                 transaction,
                 oneOffConfirmationDetails.getChargeDate());

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateServiceTest.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.directdebit.mandate.services;
 
 import com.google.common.collect.ImmutableMap;
-import java.time.LocalDate;
-import javax.ws.rs.core.UriInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,9 +22,10 @@ import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.SandboxService;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import javax.ws.rs.core.UriInfo;
+import java.time.LocalDate;
+
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class OnDemandMandateServiceTest {
@@ -78,7 +77,7 @@ public class OnDemandMandateServiceTest {
         when(mockedSandboxService.confirmOnDemandMandate(mandate, bankAccountDetails)).thenReturn(mandate);
         service.confirm(gatewayAccountFixture.toEntity(), mandate, mandateConfirmationRequest);
 
-        verify(mockedMandateStateUpdateService).confirmedDirectDebitDetailsFor(mandate);
+        verify(mockedMandateStateUpdateService).confirmedOnDemandDirectDebitDetailsFor(mandate);
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.directdebit.mandate.services;
 
 import com.google.common.collect.ImmutableMap;
-import java.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +21,8 @@ import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.SandboxService;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
+
+import java.time.LocalDate;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,7 +87,7 @@ public class OneOffMandateServiceTest {
                 .thenReturn(oneOffConfirmationDetails);
         service.confirm(gatewayAccountFixture.toEntity(), mandate, mandateConfirmationRequest);
 
-        verify(mockedMandateStateUpdateService).confirmedDirectDebitDetailsFor(mandate);
+        verify(mockedMandateStateUpdateService).confirmedOneOffDirectDebitDetailsFor(mandate);
         verify(mockedTransactionService)
                 .oneOffPaymentSubmittedToProviderFor(transaction, oneOffConfirmationDetails.getChargeDate());
     }


### PR DESCRIPTION
## WHAT YOU DID

- Added check for valid state transition in OneOffMandateService,
to avoid further calls to GoCardless and persisting data locall
- Moved state transition before updating mandate to avoid
having updated the mandate, but could not transition state
- Split confirmedDirectDebitDetailsFor into two separate methods, specific
for each mandate type. These method was called from specific mandate service
so we knew beforehand what functionality we want.
- This brings more clarity in what the next action should be from each
specific mandate service

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
