### PR TITLE
PP-3986 - Move state check first

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
@@ -13,7 +13,13 @@ import uk.gov.pay.directdebit.payments.services.DirectDebitEventService;
 
 import javax.inject.Inject;
 
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.*;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_CANCELLED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_FAILED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_PENDING;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.TOKEN_EXCHANGED;
+
 
 public class MandateStateUpdateService {
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateService.java
@@ -1,22 +1,21 @@
 package uk.gov.pay.directdebit.mandate.services;
 
-import java.time.LocalDate;
-import javax.inject.Inject;
-import javax.ws.rs.core.UriInfo;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.api.ConfirmMandateRequest;
 import uk.gov.pay.directdebit.mandate.api.CreateMandateRequest;
 import uk.gov.pay.directdebit.mandate.api.CreateMandateResponse;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
-import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
-import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequest;
 import uk.gov.pay.directdebit.payments.exception.InvalidMandateTypeException;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.UriInfo;
+import java.time.LocalDate;
 
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 
@@ -53,7 +52,7 @@ public class OnDemandMandateService implements MandateCommandService {
                                 confirmDetailsRequest.getAccountNumber(),
                                 confirmDetailsRequest.getSortCode())
                 );
-        mandateStateUpdateService.confirmedDirectDebitDetailsFor(confirmedMandate);
+        mandateStateUpdateService.confirmedOnDemandDirectDebitDetailsFor(confirmedMandate);
     }
 
     public Transaction collect(GatewayAccount gatewayAccount, Mandate mandate,

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateService.java
@@ -32,8 +32,7 @@ public class OneOffMandateService implements MandateCommandService {
         this.mandateService = mandateService;
     }
 
-    public Transaction create(GatewayAccount gatewayAccount,
-                              CreatePaymentRequest createPaymentRequest) {
+    public Transaction create(GatewayAccount gatewayAccount, CreatePaymentRequest createPaymentRequest) {
         Mandate mandate = mandateService.createMandate(createPaymentRequest, gatewayAccount.getExternalId());
         return transactionService.createTransaction(createPaymentRequest, mandate, gatewayAccount.getExternalId());
     }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateService.java
@@ -1,43 +1,47 @@
 package uk.gov.pay.directdebit.mandate.services;
 
-import javax.inject.Inject;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.api.ConfirmMandateRequest;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.OneOffConfirmationDetails;
-import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
-import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.api.CreatePaymentRequest;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
+
+import javax.inject.Inject;
+
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 
 public class OneOffMandateService implements MandateCommandService {
     private final PaymentProviderFactory paymentProviderFactory;
     private final TransactionService transactionService;
     private final MandateStateUpdateService mandateStateUpdateService;
     private final MandateService mandateService;
+
     @Inject
     public OneOffMandateService(
             PaymentProviderFactory paymentProviderFactory,
             TransactionService transactionService,
             MandateStateUpdateService mandateStateUpdateService,
-            MandateService mandateService){
+            MandateService mandateService) {
         this.paymentProviderFactory = paymentProviderFactory;
         this.transactionService = transactionService;
         this.mandateStateUpdateService = mandateStateUpdateService;
         this.mandateService = mandateService;
     }
-    
+
     public Transaction create(GatewayAccount gatewayAccount,
-            CreatePaymentRequest createPaymentRequest) {
+                              CreatePaymentRequest createPaymentRequest) {
         Mandate mandate = mandateService.createMandate(createPaymentRequest, gatewayAccount.getExternalId());
         return transactionService.createTransaction(createPaymentRequest, mandate, gatewayAccount.getExternalId());
     }
 
     @Override
     public void confirm(GatewayAccount gatewayAccount, Mandate mandate, ConfirmMandateRequest confirmMandateRequest) {
+        mandateStateUpdateService.canUpdateStateFor(mandate, DIRECT_DEBIT_DETAILS_CONFIRMED);
+
         Transaction transaction = transactionService
                 .findTransactionForExternalId(confirmMandateRequest.getTransactionExternalId());
 
@@ -50,7 +54,7 @@ public class OneOffMandateService implements MandateCommandService {
                         transaction
                 );
 
-        mandateStateUpdateService.confirmedDirectDebitDetailsFor(oneOffConfirmationDetails.getMandate());
+        mandateStateUpdateService.confirmedOneOffDirectDebitDetailsFor(oneOffConfirmationDetails.getMandate());
         transactionService.oneOffPaymentSubmittedToProviderFor(
                 transaction,
                 oneOffConfirmationDetails.getChargeDate());

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateServiceTest.java
@@ -20,8 +20,14 @@ import java.time.ZonedDateTime;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.ACTIVE;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.AWAITING_DIRECT_DEBIT_DETAILS;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.PENDING;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MandateStateUpdateServiceTest {
@@ -169,7 +175,7 @@ public class MandateStateUpdateServiceTest {
     @Test
     public void shouldSetMandateStatusToExpired_FromCreated() {
         Mandate mandate = MandateFixture.aMandateFixture()
-                .withState(MandateState.CREATED)
+                .withState(CREATED)
                 .withCreatedDate(ZonedDateTime.now().minusMinutes(91L))
                 .toEntity();
         service.mandateExpiredFor(mandate);
@@ -181,7 +187,7 @@ public class MandateStateUpdateServiceTest {
     @Test
     public void shouldSetMandateStatusToExpired_FromSubmitted() {
         Mandate mandate = MandateFixture.aMandateFixture()
-                .withState(MandateState.SUBMITTED)
+                .withState(SUBMITTED)
                 .withCreatedDate(ZonedDateTime.now().minusMinutes(91L))
                 .toEntity();
         service.mandateExpiredFor(mandate);
@@ -193,7 +199,7 @@ public class MandateStateUpdateServiceTest {
     @Test
     public void shouldSetMandateStatusToExpired_FromDdDetails() {
         Mandate mandate = MandateFixture.aMandateFixture()
-                .withState(MandateState.AWAITING_DIRECT_DEBIT_DETAILS)
+                .withState(AWAITING_DIRECT_DEBIT_DETAILS)
                 .withCreatedDate(ZonedDateTime.now().minusMinutes(91L))
                 .toEntity();
         service.mandateExpiredFor(mandate);
@@ -205,7 +211,7 @@ public class MandateStateUpdateServiceTest {
     @Test(expected = InvalidStateTransitionException.class)
     public void shouldNotExpireMandateSinceWrongState_PENDING() {
         Mandate mandate = MandateFixture.aMandateFixture()
-                .withState(MandateState.PENDING)
+                .withState(PENDING)
                 .withCreatedDate(ZonedDateTime.now().minusMinutes(91L))
                 .toEntity();
         service.mandateExpiredFor(mandate);

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateServiceTest.java
@@ -25,7 +25,10 @@ import uk.gov.pay.directdebit.payments.services.TransactionService;
 import javax.ws.rs.core.UriInfo;
 import java.time.LocalDate;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 
 @RunWith(MockitoJUnitRunner.class)
 public class OnDemandMandateServiceTest {
@@ -37,9 +40,9 @@ public class OnDemandMandateServiceTest {
     private MandateService mockedMandateService;
     @Mock
     private MandateStateUpdateService mockedMandateStateUpdateService;
-    @Mock 
+    @Mock
     private PaymentProviderFactory mockedPaymentProviderFactory;
-    
+
     private GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture
             .aGatewayAccountFixture().withPaymentProvider(PaymentProvider.SANDBOX);
     private MandateFixture mandateFixture = MandateFixture.aMandateFixture()
@@ -52,7 +55,7 @@ public class OnDemandMandateServiceTest {
             .of("sort_code", "123456", "account_number", "12345678");
 
     private OnDemandMandateService service;
-    
+
     @Before
     public void setUp() {
         service = new OnDemandMandateService(mockedPaymentProviderFactory, mockedMandateStateUpdateService, mockedTransactionService, mockedMandateService);
@@ -67,7 +70,7 @@ public class OnDemandMandateServiceTest {
 
         verify(mockedMandateService).createMandate(mandateCreationRequest, gatewayAccountFixture.getExternalId(), mockedUriInfo);
     }
-    
+
     @Test
     public void confirm_shouldConfirmOnDemandMandate() {
         Mandate mandate = mandateFixture.toEntity();
@@ -79,7 +82,7 @@ public class OnDemandMandateServiceTest {
 
         verify(mockedMandateStateUpdateService).confirmedOnDemandDirectDebitDetailsFor(mandate);
     }
-    
+
     @Test
     public void collect_shouldCreateATransactionAPaymentAndRegisterOnDemandPaymentSubmittedEvent() {
         Transaction transaction = TransactionFixture.aTransactionFixture().withMandateFixture(mandateFixture).toEntity();
@@ -97,9 +100,8 @@ public class OnDemandMandateServiceTest {
         when(mockedSandboxService.collect(mandate, transaction)).thenReturn(chargeDate);
 
         service.collect(gatewayAccountFixture.toEntity(), mandate, collectPaymentRequest);
-        
+
         verify(mockedTransactionService).onDemandPaymentSubmittedToProviderFor(transaction, chargeDate);
     }
-    
-    
+
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateServiceTest.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.directdebit.mandate.services;
 
 import com.google.common.collect.ImmutableMap;
-import java.time.LocalDate;
-import javax.ws.rs.core.UriInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,9 +22,10 @@ import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.SandboxService;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import javax.ws.rs.core.UriInfo;
+import java.time.LocalDate;
+
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class OnDemandMandateServiceTest {
@@ -78,7 +77,7 @@ public class OnDemandMandateServiceTest {
         when(mockedSandboxService.confirmOnDemandMandate(mandate, bankAccountDetails)).thenReturn(mandate);
         service.confirm(gatewayAccountFixture.toEntity(), mandate, mandateConfirmationRequest);
 
-        verify(mockedMandateStateUpdateService).confirmedDirectDebitDetailsFor(mandate);
+        verify(mockedMandateStateUpdateService).confirmedOnDemandDirectDebitDetailsFor(mandate);
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.directdebit.mandate.services;
 
 import com.google.common.collect.ImmutableMap;
-import java.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +21,8 @@ import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.SandboxService;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
+
+import java.time.LocalDate;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,7 +87,7 @@ public class OneOffMandateServiceTest {
                 .thenReturn(oneOffConfirmationDetails);
         service.confirm(gatewayAccountFixture.toEntity(), mandate, mandateConfirmationRequest);
 
-        verify(mockedMandateStateUpdateService).confirmedDirectDebitDetailsFor(mandate);
+        verify(mockedMandateStateUpdateService).confirmedOneOffDirectDebitDetailsFor(mandate);
         verify(mockedTransactionService)
                 .oneOffPaymentSubmittedToProviderFor(transaction, oneOffConfirmationDetails.getChargeDate());
     }


### PR DESCRIPTION
- Added check for valid state transition in OneOffMandateService,
to avoid further calls to GoCardless and persisting data locall
- Moved state transition before updating mandate to avoid
having updated the mandate, but could not transition state
- Split confirmedDirectDebitDetailsFor into two separate methods, specific
for each mandate type. These method was called from specific mandate service
so we knew beforehand what functionality we want.
- This brings more clarity in what the next action should be from each
specific mandate service

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
