### PR TITLE
PP-4002 Migrate creditor id from `mandates` to `gocardless_mandates`

### DIFF
--- a/src/main/resources/migrations/00039_alter_table_mandates_drop_column_creditor_id.sql
+++ b/src/main/resources/migrations/00039_alter_table_mandates_drop_column_creditor_id.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-mandates-drop-creditor-id
+ALTER TABLE mandates DROP COLUMN creditor_id;
+--rollback ALTER TABLE mandates ADD COLUMN creditor_id VARCHAR(255);

--- a/src/main/resources/migrations/00040_alter_table_gocardless_mandates_add_column_gocardless_creditor_id.sql
+++ b/src/main/resources/migrations/00040_alter_table_gocardless_mandates_add_column_gocardless_creditor_id.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-gocardless-mandates-add-creditor-id
+ALTER TABLE gocardless_mandates ADD COLUMN gocardless_creditor_id VARCHAR(255);
+--rollback ALTER TABLE gocardless_mandates DROP COLUMN gocardless_creditor_id;


### PR DESCRIPTION
## WHAT YOU DID

Migrate creditor id from `mandates` to `gocardless_mandates`

`creditor_id` is GoCardless specific, so we need to migrate it to `gocardless_mandates`:
- Drop `mandates.creditor_id` (it is still not used)
- Create `gocardless_mandates.gocardless_creditor_id`

with @danworth
