### PR TITLE
PP-3835 Remove extra TOKEN_EXCHANGED event

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
@@ -58,10 +58,6 @@ public class MandateStateUpdateService {
         return directDebitEventService.registerMandateCancelledEventFor(newMandate);
     }
 
-    public DirectDebitEvent awaitingDirectDebitDetailsFor(Mandate mandate) {
-        return directDebitEventService.registerAwaitingDirectDebitDetailsEventFor(mandate);
-    }
-
     public DirectDebitEvent mandateActiveFor(Mandate mandate) {
         updateStateFor(mandate, MANDATE_ACTIVE);
         return directDebitEventService.registerMandateActiveEventFor(mandate);

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
@@ -112,10 +112,6 @@ public class DirectDebitEvent {
     public static DirectDebitEvent mandateActive(Long mandateId) {
         return new DirectDebitEvent(mandateId, null, MANDATE, MANDATE_ACTIVE);
     }
-
-    public static DirectDebitEvent awaitingDirectDebitDetails(Long mandateId) {
-        return new DirectDebitEvent(mandateId, null, MANDATE, TOKEN_EXCHANGED);
-    }
     
     public static DirectDebitEvent paymentMethodChanged(Long mandateId) {
         return new DirectDebitEvent(mandateId, null, MANDATE, PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE);

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventService.java
@@ -126,11 +126,6 @@ public class DirectDebitEventService {
         return insertEventFor(mandate, directDebitEvent);
     }
 
-    public DirectDebitEvent registerAwaitingDirectDebitDetailsEventFor(Mandate mandate) {
-        DirectDebitEvent directDebitEvent = awaitingDirectDebitDetails(mandate.getId());
-        return insertEventFor(mandate, directDebitEvent);
-    }
-    
     public void registerPayerCreatedEventFor(Mandate mandate) {
         DirectDebitEvent directDebitEvent = payerCreated(mandate.getId());
         insertEventFor(mandate, directDebitEvent);

--- a/src/main/java/uk/gov/pay/directdebit/tokens/resources/SecurityTokensResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/tokens/resources/SecurityTokensResource.java
@@ -37,8 +37,6 @@ public class SecurityTokensResource {
         TokenResponse response = TokenResponse.from(
                 tokenExchangeDetails.getMandate(), 
                 tokenExchangeDetails.getTransactionExternalId());
-        mandateServiceFactory.getMandateStateUpdateService()
-                .awaitingDirectDebitDetailsFor(tokenExchangeDetails.getMandate());
         return Response.ok().entity(response).build();
     }
 


### PR DESCRIPTION
## WHAT YOU DID
 - We were recording an `awaiting direct debit details` event which was
   erroneously set to `TOKEN_EXCHANGED`.
   The awaiting direct debit details gives us no extra info, because it
   does happen straight after the token exchanged, so we might as well
   remove it.