### PR TITLE
PP-3835 Add MANDATE_CREATED event

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -93,6 +93,7 @@ public class MandateService {
                     LOGGER.info("Creating mandate external id {}", mandate.getExternalId());
                     Long id = mandateDao.insert(mandate);
                     mandate.setId(id);
+                    mandateStateUpdateService.mandateCreatedFor(mandate);
                     return mandate;
                 })
                 .orElseThrow(() -> {

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
@@ -41,6 +41,10 @@ public class MandateStateUpdateService {
     Mandate confirmedOneOffDirectDebitDetailsFor(Mandate mandate) {
         return confirmedDetailsFor(mandate);
     }
+    
+    DirectDebitEvent mandateCreatedFor(Mandate mandate) {
+        return directDebitEventService.registerMandateCreatedEventFor(mandate);
+    }
 
     Mandate confirmedOnDemandDirectDebitDetailsFor(Mandate mandate) {
         Mandate updatedMandate = confirmedDetailsFor(mandate);
@@ -48,12 +52,12 @@ public class MandateStateUpdateService {
         return updatedMandate;
     }
 
-    public DirectDebitEvent changePaymentMethodFor(Mandate mandate) {
+    DirectDebitEvent changePaymentMethodFor(Mandate mandate) {
         Mandate newMandate = updateStateFor(mandate, SupportedEvent.PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE);
         return directDebitEventService.registerPaymentMethodChangedEventFor(newMandate);
     }
 
-    public DirectDebitEvent cancelMandateCreation(Mandate mandate) {
+    DirectDebitEvent cancelMandateCreation(Mandate mandate) {
         Mandate newMandate = updateStateFor(mandate, SupportedEvent.PAYMENT_CANCELLED_BY_USER);
         return directDebitEventService.registerMandateCancelledEventFor(newMandate);
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitEvent.java
@@ -12,6 +12,7 @@ import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEv
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_RECEIVED;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_ACTIVE;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_CANCELLED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_EXPIRED_BY_SYSTEM;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_PENDING;
@@ -91,6 +92,10 @@ public class DirectDebitEvent {
 
     public static DirectDebitEvent directDebitDetailsConfirmed(Long mandateId) {
         return new DirectDebitEvent(mandateId, null, MANDATE, DIRECT_DEBIT_DETAILS_CONFIRMED);
+    }
+
+    public static DirectDebitEvent mandateCreated(Long mandateId) {
+        return new DirectDebitEvent(mandateId, null, MANDATE, MANDATE_CREATED);
     }
     
     public static DirectDebitEvent mandatePending(Long mandateId) {
@@ -241,6 +246,7 @@ public class DirectDebitEvent {
         PAYER_CREATED,
         PAYER_EDITED,
         DIRECT_DEBIT_DETAILS_CONFIRMED,
+        MANDATE_CREATED,
         MANDATE_PENDING,
         MANDATE_ACTIVE,
         MANDATE_FAILED,

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventService.java
@@ -65,6 +65,11 @@ public class DirectDebitEventService {
         return insertEventFor(mandate, directDebitEvent);
     }
 
+    public DirectDebitEvent registerMandateCreatedEventFor(Mandate mandate) {
+        DirectDebitEvent directDebitEvent = mandateCreated(mandate.getId());
+        return insertEventFor(mandate, directDebitEvent);
+    }
+    
     public DirectDebitEvent registerMandateFailedEventFor(Mandate mandate) {
         DirectDebitEvent directDebitEvent = mandateFailed(mandate.getId());
         return insertEventFor(mandate, directDebitEvent);

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -85,7 +85,6 @@ public class MandateServiceTest {
     private UriBuilder mockedUriBuilder;
 
     private MandateService service;
-    private static final MandateExternalId MANDATE_EXTERNAL_ID = MandateExternalId.of("test-mandate-ext-id");
 
     @Before
     public void setUp() throws URISyntaxException {
@@ -178,7 +177,7 @@ public class MandateServiceTest {
     @Test
     public void shouldCreateAMandateForSandbox_withCustomGeneratedReference() {
         Mandate mandate = getMandateForProvider(PaymentProvider.SANDBOX);
-
+       
         assertThat(mandate.getMandateReference(), is(not("gocardless-default")));
     }
 
@@ -204,6 +203,10 @@ public class MandateServiceTest {
         when(mockedMandateDao.insert(any(Mandate.class))).thenReturn(1L);
 
         CreateMandateRequest createMandateRequest = CreateMandateRequest.of(getMandateRequestPayload());
-        return service.createMandate(createMandateRequest, gatewayAccount.getExternalId());
+        
+        Mandate mandate = service.createMandate(createMandateRequest, gatewayAccount.getExternalId());
+        
+        verify(mockedMandateStateUpdateService).mandateCreatedFor(mandate);
+        return mandate;
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateServiceTest.java
@@ -85,6 +85,18 @@ public class MandateStateUpdateServiceTest {
     }
 
     @Test
+    public void mandateCreatedFor_shouldRegisterAMandateCreatedEvent() {
+        Mandate mandate = MandateFixture
+                .aMandateFixture()
+                .withState(CREATED)
+                .toEntity();
+        service.mandateCreatedFor(mandate);
+        
+        verify(mockedDirectDebitEventService).registerMandateCreatedEventFor(mandate);
+        assertThat(mandate.getState(), is(CREATED));
+    }
+    
+    @Test
     public void payerCreatedFor_shouldRegisterAPayerCreatedEvent() {
 
         service.payerCreatedFor(onDemandMandate);

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.PENDING;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_ACTIVE;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_CANCELLED;
+import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_CREATED;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_FAILED;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAID;
@@ -224,6 +225,19 @@ public class DirectDebitEventServiceTest {
         assertThat(directDebitEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
     }
 
+    @Test
+    public void registerMandateCreatedEventFor_shouldCreateExpectedEvent() {
+        service.registerMandateCreatedEventFor(mandateFixture.toEntity());
+
+        verify(mockedDirectDebitEventDao).insert(prCaptor.capture());
+        DirectDebitEvent directDebitEvent = prCaptor.getValue();
+        assertThat(directDebitEvent.getMandateId(), is(mandateFixture.getId()));
+        assertThat(directDebitEvent.getTransactionId(), is(nullValue()));
+        assertThat(directDebitEvent.getEvent(), is(MANDATE_CREATED));
+        assertThat(directDebitEvent.getEventType(), is(MANDATE));
+        assertThat(directDebitEvent.getEventDate(), is(ZonedDateTimeMatchers.within(10, ChronoUnit.SECONDS, ZonedDateTime.now())));
+    }
+    
     @Test
     public void registerMandateActiveEventFor_shouldCreateExpectedEvent() {
         service.registerMandateActiveEventFor(mandateFixture.toEntity());


### PR DESCRIPTION


## WHAT YOU DID
 - We should record an event when we create and store
   a mandate in our DB. Otherwise, for example, on demand
   mandates will have 0 events until the token exchange
## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
