### PR TITLE
PP-4002 Move GoCardless client related classes to "common" package

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
@@ -1,17 +1,12 @@
 package uk.gov.pay.directdebit.app.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gocardless.GoCardlessClient;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.dropwizard.setup.Environment;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import javax.net.ssl.SSLSocketFactory;
 import org.jdbi.v3.core.Jdbi;
-import uk.gov.pay.directdebit.payments.clients.GoCardlessClientFactory;
-import uk.gov.pay.directdebit.payments.dao.DirectDebitEventDao;
+import uk.gov.pay.directdebit.common.clients.GoCardlessClientFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessMandateDao;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessPaymentDao;
@@ -20,13 +15,14 @@ import uk.gov.pay.directdebit.notifications.clients.AdminUsersClient;
 import uk.gov.pay.directdebit.notifications.clients.ClientFactory;
 import uk.gov.pay.directdebit.payers.dao.GoCardlessCustomerDao;
 import uk.gov.pay.directdebit.payers.dao.PayerDao;
-import uk.gov.pay.directdebit.payments.clients.GoCardlessClientWrapper;
+import uk.gov.pay.directdebit.payments.dao.DirectDebitEventDao;
 import uk.gov.pay.directdebit.payments.dao.GoCardlessEventDao;
 import uk.gov.pay.directdebit.payments.dao.PaymentViewDao;
 import uk.gov.pay.directdebit.payments.dao.TransactionDao;
 import uk.gov.pay.directdebit.tokens.dao.TokenDao;
-import uk.gov.pay.directdebit.webhook.gocardless.config.GoCardlessFactory;
 import uk.gov.pay.directdebit.webhook.gocardless.support.WebhookVerifier;
+
+import javax.net.ssl.SSLSocketFactory;
 
 public class DirectDebitModule extends AbstractModule {
 
@@ -49,10 +45,9 @@ public class DirectDebitModule extends AbstractModule {
     }
 
 
-
     @Provides
     @Singleton
-    public GoCardlessClientFactory provideGoCardlessClientFactory()  {
+    public GoCardlessClientFactory provideGoCardlessClientFactory() {
         return new GoCardlessClientFactory(configuration, sslSocketFactory);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.directdebit.payments.clients;
+package uk.gov.pay.directdebit.common.clients;
 
 import com.gocardless.resources.BankDetailsLookup;
 import com.gocardless.resources.Customer;

--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactory.java
@@ -1,21 +1,23 @@
-package uk.gov.pay.directdebit.payments.clients;
+package uk.gov.pay.directdebit.common.clients;
 
 import com.gocardless.GoCardlessClient;
 import com.google.common.collect.Maps;
+import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
+import uk.gov.pay.directdebit.webhook.gocardless.config.GoCardlessFactory;
+
+import javax.net.ssl.SSLSocketFactory;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Map;
 import java.util.Optional;
-import javax.net.ssl.SSLSocketFactory;
-import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
-import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
-import uk.gov.pay.directdebit.webhook.gocardless.config.GoCardlessFactory;
 
 public class GoCardlessClientFactory {
 
     private final Map<PaymentProviderAccessToken, GoCardlessClientFacade> clients;
     private final SSLSocketFactory sslSocketFactory;
     private final DirectDebitConfig configuration;
+
     public GoCardlessClientFactory(
             DirectDebitConfig configuration,
             SSLSocketFactory sslSocketFactory) {
@@ -23,7 +25,7 @@ public class GoCardlessClientFactory {
         this.sslSocketFactory = sslSocketFactory;
         this.clients = Maps.newConcurrentMap();
     }
-    
+
     public GoCardlessClientFacade getClientFor(Optional<PaymentProviderAccessToken> maybeAccessToken) {
         //backward compatibility for now, will use the token in the config if it's not there
         PaymentProviderAccessToken accessToken = maybeAccessToken.orElse(PaymentProviderAccessToken.of(configuration.getGoCardless().getAccessToken()));

--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientWrapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientWrapper.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.directdebit.payments.clients;
+package uk.gov.pay.directdebit.common.clients;
 
 
 import com.gocardless.resources.BankDetailsLookup;
@@ -36,7 +36,7 @@ public class GoCardlessClientWrapper {
     }
 
     public CustomerBankAccount createCustomerBankAccount(MandateExternalId mandateExternalId, GoCardlessCustomer customer,
-                                                         String accountHolderName, SortCode sortCode, AccountNumber accountNumber){
+                                                         String accountHolderName, SortCode sortCode, AccountNumber accountNumber) {
         return goCardlessClient.customerBankAccounts()
                 .create()
                 .withAccountHolderName(accountHolderName)

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessService.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.directdebit.mandate.services.gocardless;
 
-import java.time.LocalDate;
-import javax.inject.Inject;
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
+import uk.gov.pay.directdebit.common.clients.GoCardlessClientFacade;
+import uk.gov.pay.directdebit.common.clients.GoCardlessClientFactory;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessMandateDao;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessPaymentDao;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
@@ -18,8 +18,6 @@ import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.GoCardlessBankAccountLookup;
 import uk.gov.pay.directdebit.payers.model.GoCardlessCustomer;
 import uk.gov.pay.directdebit.payers.model.Payer;
-import uk.gov.pay.directdebit.payments.clients.GoCardlessClientFacade;
-import uk.gov.pay.directdebit.payments.clients.GoCardlessClientFactory;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerBankAccountFailedException;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerFailedException;
 import uk.gov.pay.directdebit.payments.exception.CreateMandateFailedException;
@@ -30,6 +28,9 @@ import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProviderCommandSe
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.GoCardlessEventService;
 
+import javax.inject.Inject;
+import java.time.LocalDate;
+
 public class GoCardlessService implements DirectDebitPaymentProviderCommandService {
     private static final Logger LOGGER = PayLoggerFactory.getLogger(GoCardlessEventService.class);
 
@@ -37,6 +38,7 @@ public class GoCardlessService implements DirectDebitPaymentProviderCommandServi
     private final GoCardlessCustomerDao goCardlessCustomerDao;
     private final GoCardlessMandateDao goCardlessMandateDao;
     private final GoCardlessPaymentDao goCardlessPaymentDao;
+
     @Inject
     public GoCardlessService(
             GoCardlessClientFactory goCardlessClientFactory,

--- a/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.directdebit.payments.clients;
+package uk.gov.pay.directdebit.common.clients;
 
 import com.gocardless.resources.BankDetailsLookup;
 import org.junit.Before;

--- a/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactoryTest.java
@@ -1,8 +1,6 @@
-package uk.gov.pay.directdebit.payments.clients;
+package uk.gov.pay.directdebit.common.clients;
 
 import com.gocardless.GoCardlessClient;
-import java.util.Optional;
-import javax.net.ssl.SSLSocketFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,6 +9,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -33,7 +34,7 @@ public class GoCardlessClientFactoryTest {
         when(mockedDirectDebitConfig.getGoCardless().getEnvironment()).thenReturn(GoCardlessClient.Environment.SANDBOX);
         goCardlessClientFactory = new GoCardlessClientFactory(mockedDirectDebitConfig, mockedSSLSocketFactory);
     }
-    
+
     @Test
     public void shouldCreateOnlyOneClientPerGatewayAccount() {
         GoCardlessClientFacade firstClient = goCardlessClientFactory
@@ -43,7 +44,7 @@ public class GoCardlessClientFactoryTest {
         assertThat(firstClient, is(secondClient));
     }
 
-    
+
     //backward compatibility, please remove once all gateway accounts have an access token
     @Test
     public void shouldCreateAClient_ifNoAccessTokenIsDefined() {


### PR DESCRIPTION
## WHAT YOU DID

- GoCardless client related classes `GoCardlessClientWrapper`, `GoCardlessClientFactory`, `GoCardlessClientFacade` belong to `common` package as they can be used outside of `payments` package
