### PR TITLE
PP-4002 Make `gocardless_mandates.gocardless_creditor_id` not null

### DIFF
--- a/src/main/resources/migrations/00041_alter_table_gocardless_mandates_set_gocardless_creditor_id_not_null.sql
+++ b/src/main/resources/migrations/00041_alter_table_gocardless_mandates_set_gocardless_creditor_id_not_null.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-gocardless-mandates-alter-column-gocardless-creditor-id-set-default
+ALTER TABLE gocardless_mandates ALTER COLUMN gocardless_creditor_id SET DEFAULT 'LEGACY_CREDITOR_ID';
+--rollback ALTER TABLE gocardless_mandates ALTER COLUMN gocardless_creditor_id DROP DEFAULT;
+
+--changeset uk.gov.pay:alter_table-gocardless-mandates-update-gocardless-creditor-id
+UPDATE gocardless_mandates SET gocardless_creditor_id = 'LEGACY_CREDITOR_ID' WHERE gocardless_creditor_id IS NULL;
+--rollback UPDATE gocardless_mandates SET gocardless_creditor_id = NULL WHERE gocardless_creditor_id = 'LEGACY_CREDITOR_ID';
+
+--changeset uk.gov.pay:alter_table-gocardless-mandates-alter-column-gocardless-creditor-id-set-not-null
+ALTER TABLE gocardless_mandates ALTER COLUMN gocardless_creditor_id SET NOT NULL;
+--rollback ALTER TABLE gocardless_mandates ALTER COLUMN gocardless_creditor_id DROP NOT NULL;


### PR DESCRIPTION
## WHAT YOU DID

- Initialise `gocardless_mandates.gocardless_creditor_id` with default value `LEGACY_CREDITOR_ID` to make new mandates correct until all changes complete.
- Update `gocardless_mandates.gocardless_creditor_id` with value `LEGACY_CREDITOR_ID` to make existing mandates correct until all changes complete.
- Add `NOT NULL` constraint

with @danworth
