### PR TITLE
PP-4002 Drop `DEFAULT` from `gocardless_mandates.gocardless_creditor_id`

### DIFF
--- a/src/main/resources/migrations/00042_alter_table_gocardless_mandates_drop_gocardless_creditor_id_default.sql
+++ b/src/main/resources/migrations/00042_alter_table_gocardless_mandates_drop_gocardless_creditor_id_default.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-gocardless-mandates-alter-column-gocardless-creditor-id-drop-default
+ALTER TABLE gocardless_mandates ALTER COLUMN gocardless_creditor_id DROP DEFAULT;
+--rollback ALTER TABLE gocardless_mandates ALTER COLUMN gocardless_creditor_id SET DEFAULT 'LEGACY_CREDITOR_ID';


### PR DESCRIPTION
## WHAT YOU DID

Drop `DEFAULT` from `gocardless_mandates.gocardless_creditor_id`

Part of https://github.com/alphagov/pay-direct-debit-connector/pull/248 clean up

with @danworth
