### PR TITLE
PP-4043 Link GoCardless account to GOV.UK Pay account

### DIFF
--- a/src/main/resources/migrations/00043_create_table_oauth_states.sql
+++ b/src/main/resources/migrations/00043_create_table_oauth_states.sql
@@ -3,7 +3,7 @@
 --changeset uk.gov.pay:add_table-gocardless_partner_app_account_connect_tokens
 CREATE TABLE gocardless_partner_app_account_connect_tokens (
   id BIGSERIAL PRIMARY KEY,
-  gateway_account_id BIGSERIAL NOT NULL,
+  gateway_account_id BIGINT NOT NULL,
   token VARCHAR(26) NOT NULL,
   active BOOLEAN DEFAULT TRUE
 );

--- a/src/main/resources/migrations/00043_create_table_oauth_states.sql
+++ b/src/main/resources/migrations/00043_create_table_oauth_states.sql
@@ -1,0 +1,15 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_table-oauth_states
+CREATE TABLE oauth_states (
+  id BIGSERIAL PRIMARY KEY,
+  gateway_account_external_id VARCHAR(26) NOT NULL,
+  state VARCHAR(26) NOT NULL,
+  active BOOLEAN DEFAULT TRUE,
+  version INTEGER DEFAULT 0 NOT NULL
+);
+--rollback drop table oauth_states;
+
+--changeset uk.gov.pay:add_oauth_states_gateway_accounts_fk
+ALTER TABLE oauth_states ADD CONSTRAINT oauth_states_gateway_accounts_fk FOREIGN KEY (gateway_account_external_id) REFERENCES gateway_accounts (external_id);
+--rollback drop constraint oauth_states_gateway_accounts_fk;

--- a/src/main/resources/migrations/00043_create_table_oauth_states.sql
+++ b/src/main/resources/migrations/00043_create_table_oauth_states.sql
@@ -1,15 +1,14 @@
 --liquibase formatted sql
 
---changeset uk.gov.pay:add_table-oauth_states
-CREATE TABLE oauth_states (
+--changeset uk.gov.pay:add_table-gocardless_partner_app_account_connect_tokens
+CREATE TABLE gocardless_partner_app_account_connect_tokens (
   id BIGSERIAL PRIMARY KEY,
-  gateway_account_external_id VARCHAR(26) NOT NULL,
-  state VARCHAR(26) NOT NULL,
-  active BOOLEAN DEFAULT TRUE,
-  version INTEGER DEFAULT 0 NOT NULL
+  gateway_account_id BIGSERIAL NOT NULL,
+  token VARCHAR(26) NOT NULL,
+  active BOOLEAN DEFAULT TRUE
 );
---rollback drop table oauth_states;
+--rollback drop table gocardless_partner_app_account_connect_tokens;
 
---changeset uk.gov.pay:add_oauth_states_gateway_accounts_fk
-ALTER TABLE oauth_states ADD CONSTRAINT oauth_states_gateway_accounts_fk FOREIGN KEY (gateway_account_external_id) REFERENCES gateway_accounts (external_id);
---rollback drop constraint oauth_states_gateway_accounts_fk;
+--changeset uk.gov.pay:add_gocardless_partner_app_account_connect_tokens_gateway_accounts_fk
+ALTER TABLE gocardless_partner_app_account_connect_tokens ADD CONSTRAINT gocardless_partner_app_account_connect_tokens_gateway_accounts_fk FOREIGN KEY (gateway_account_id) REFERENCES gateway_accounts (id);
+--rollback drop constraint gocardless_partner_app_account_connect_tokens_gateway_accounts_fk;


### PR DESCRIPTION
## WHAT YOU DID
- Added a table that will hold state values used to send to GoCardless
- The state value is returned to us from GoCardless and we will use it
to check if is valid against a gateway account external id

## How to test

- check if migration run successfully

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
