### PR TITLE
PP-4002 Use real SunName instead of placeholder when sending emails.

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/services/SunService.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/services/SunService.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.directdebit.common.services;
+
+import uk.gov.pay.directdebit.common.model.subtype.SunName;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProviderCommandService;
+import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+public class SunService {
+
+    private final PaymentProviderFactory paymentProviderFactory;
+
+    @Inject
+    public SunService(PaymentProviderFactory paymentProviderFactory) {
+        this.paymentProviderFactory = paymentProviderFactory;
+    }
+
+    public Optional<SunName> getSunNameFor(Mandate mandate) {
+        DirectDebitPaymentProviderCommandService paymentProviderCommandService =
+                paymentProviderFactory.getCommandServiceFor(mandate.getGatewayAccount().getPaymentProvider());
+        return paymentProviderCommandService.getSunName(mandate);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -18,18 +18,11 @@ import uk.gov.pay.directdebit.mandate.api.GetMandateResponse;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
-import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
-import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
-import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
-import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
-import uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
-import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.model.Token;
-import uk.gov.pay.directdebit.payments.services.DirectDebitEventService;
 import uk.gov.pay.directdebit.payments.services.TransactionService;
 import uk.gov.pay.directdebit.tokens.model.TokenExchangeDetails;
 import uk.gov.pay.directdebit.tokens.services.TokenService;
@@ -38,28 +31,20 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.ACTIVE;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.AWAITING_DIRECT_DEBIT_DETAILS;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.PENDING;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_PENDING;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MandateServiceTest {
@@ -177,7 +162,7 @@ public class MandateServiceTest {
     @Test
     public void shouldCreateAMandateForSandbox_withCustomGeneratedReference() {
         Mandate mandate = getMandateForProvider(PaymentProvider.SANDBOX);
-       
+
         assertThat(mandate.getMandateReference(), is(not("gocardless-default")));
     }
 
@@ -203,9 +188,9 @@ public class MandateServiceTest {
         when(mockedMandateDao.insert(any(Mandate.class))).thenReturn(1L);
 
         CreateMandateRequest createMandateRequest = CreateMandateRequest.of(getMandateRequestPayload());
-        
+
         Mandate mandate = service.createMandate(createMandateRequest, gatewayAccount.getExternalId());
-        
+
         verify(mockedMandateStateUpdateService).mandateCreatedFor(mandate);
         return mandate;
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/SunServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/SunServiceTest.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.directdebit.mandate.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.common.model.subtype.SunName;
+import uk.gov.pay.directdebit.common.services.SunService;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
+import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProviderCommandService;
+import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SunServiceTest {
+
+    @Mock
+    private PaymentProviderFactory mockPaymentProviderFactory;
+    @Mock
+    private DirectDebitPaymentProviderCommandService mockDirectDebitPaymentProviderCommandService;
+    private SunService sunService;
+
+    @Before
+    public void setUp() {
+        sunService = new SunService(mockPaymentProviderFactory);
+    }
+
+    @Test
+    public void shouldReturnSunNameForGoCardless() {
+        GatewayAccountFixture gatewayAccountFixture =
+                GatewayAccountFixture.aGatewayAccountFixture().withPaymentProvider(PaymentProvider.GOCARDLESS);
+        Mandate mandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).toEntity();
+        SunName sunName = SunName.of("BACS Test SUN Name");
+        when(mockPaymentProviderFactory.getCommandServiceFor(mandate.getGatewayAccount().getPaymentProvider()))
+                .thenReturn(mockDirectDebitPaymentProviderCommandService);
+        when(mockDirectDebitPaymentProviderCommandService.getSunName(mandate)).thenReturn(Optional.of(sunName));
+        assertThat(sunService.getSunNameFor(mandate), is(Optional.of(sunName)));
+    }
+
+    @Test
+    public void shouldReturnSunNameForSandbox() {
+        GatewayAccountFixture gatewayAccountFixture =
+                GatewayAccountFixture.aGatewayAccountFixture().withPaymentProvider(PaymentProvider.SANDBOX);
+        Mandate mandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).toEntity();
+        SunName sunName = SunName.of("Sandbox SUN Name");
+        when(mockPaymentProviderFactory.getCommandServiceFor(mandate.getGatewayAccount().getPaymentProvider()))
+                .thenReturn(mockDirectDebitPaymentProviderCommandService);
+        when(mockDirectDebitPaymentProviderCommandService.getSunName(mandate)).thenReturn(Optional.of(sunName));
+        assertThat(sunService.getSunNameFor(mandate), is(Optional.of(sunName)));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/util/TestRequestResponsesLoader.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/TestRequestResponsesLoader.java
@@ -19,6 +19,7 @@ public class TestRequestResponsesLoader {
     public static final String GOCARDLESS_CREATE_PAYMENT_REQUEST = REQUESTS_GOCARLDESS_BASE_NAME + "/create-payment.json";
 
     //responses
+    public static final String GOCARDLESS_GET_CREDITOR_WITH_BACS_SUCCESS_RESPONSE = RESPONSES_GOCARLDESS_BASE_NAME + "/get-creditor-with-bacs-success.json";
     public static final String GOCARDLESS_CREATE_CUSTOMER_SUCCESS_RESPONSE = RESPONSES_GOCARLDESS_BASE_NAME + "/create-customer-success.json";
     public static final String GOCARDLESS_CREATE_CUSTOMER_BANK_ACCOUNT_SUCCESS_RESPONSE = RESPONSES_GOCARLDESS_BASE_NAME + "/create-customer-bank-account-success.json";
     public static final String GOCARDLESS_CREATE_MANDATE_SUCCESS_RESPONSE = RESPONSES_GOCARLDESS_BASE_NAME + "/create-mandate-success.json";

--- a/src/test/resources/it/responses/gocardless/get-creditor-with-bacs-success.json
+++ b/src/test/resources/it/responses/gocardless/get-creditor-with-bacs-success.json
@@ -1,0 +1,40 @@
+{
+  "creditors": {
+    "id": "{{gocardless_creditor_id}}",
+    "created_at": "2017-02-16T12:34:56.000Z",
+    "name": "Creditor Name",
+    "address_line1": "123 Street",
+    "address_line2": null,
+    "address_line3": null,
+    "city": "London",
+    "region": null,
+    "postal_code": "AB CDE",
+    "country_code": "GB",
+    "logo_url": null,
+    "verification_status": "successful",
+    "can_create_refunds": false,
+    "scheme_identifiers": [
+      {
+        "name": "{{gocardless_sun}}",
+        "scheme": "bacs",
+        "reference": "420042",
+        "minimum_advance_notice": 3,
+        "currency": "GBP",
+        "address_line1": "123 Example Road",
+        "address_line2": null,
+        "address_line3": null,
+        "city": "London",
+        "region": null,
+        "postal_code": "ABC XYZ",
+        "country_code": "GB",
+        "email": "email@example.com",
+        "phone_number": "+44 3069 990000",
+        "can_specify_mandate_reference": false
+      }
+    ],
+    "links": {
+      "default_gbp_payout_account": "BA123",
+      "default_eur_payout_account": "BA456"
+    }
+  }
+}


### PR DESCRIPTION
Use real SunName instead of placeholder when sending emails.
- Created SunService to expose getSunNameFor().
- Get SunName when sending created mandate and confirm transaction emails rather than using the default `THE-CAKE-IS-A-LIE`.
- Added WireMock for GoCardless GET creditor.
- Added tests as appropriate.

with @DanailMinchev 
