### PR TITLE
PP-4043 Drop UNIQUE constraint gateway_accounts_organisation_key

### DIFF
--- a/src/main/resources/migrations/00045_drop_constraint_gateway_accounts_organisation_id.sql
+++ b/src/main/resources/migrations/00045_drop_constraint_gateway_accounts_organisation_id.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table_gateway_accounts_drop_constraint_gateway_accounts_organisation_key
+ALTER TABLE gateway_accounts DROP CONSTRAINT IF EXISTS gateway_accounts_organisation_key;
+--rollback ALTER TABLE gateway_accounts ADD UNIQUE (organisation);


### PR DESCRIPTION
- This is necessary as when updating column `organisation` in table
`gateway_accounts` it fails for the same value. Access token can change,
but the organisation will be the same when a new token is issued for an
existing merchant app.