### PR TITLE
PP-4043 Add Proxy to talk to GoCardless

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/app/config/GoCardlessAppConnectConfig.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/GoCardlessAppConnectConfig.java
@@ -39,6 +39,9 @@ public class GoCardlessAppConnectConfig extends Configuration {
     private String goCardlessConnectClientIdLive;
 
     @NotNull
+    private ProxyConfig proxyConfig;
+
+    @NotNull
     public String getGoCardlessConnectUrlTest() {
         return goCardlessConnectUrlTest;
     }
@@ -67,4 +70,8 @@ public class GoCardlessAppConnectConfig extends Configuration {
     public String getGoCardlessConnectClientIdLive() {
         return goCardlessConnectClientIdLive;
     }
+
+    @NotNull
+    public ProxyConfig getProxyConfig() {
+        return proxyConfig; }
 }


### PR DESCRIPTION
Added Proxy config to the GoCardlessAppConnectClient so it can talk to the outside world using our
proxy, otherwise cannot .
