### PR TITLE
PP-4082: Refresh database

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/junit/DropwizardAppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/DropwizardAppWithPostgresRule.java
@@ -8,6 +8,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
 import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
+import uk.gov.pay.directdebit.util.DatabaseTestHelper;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
@@ -24,6 +25,7 @@ public class DropwizardAppWithPostgresRule implements TestRule {
     private final RuleChain rules;
 
     private TestContext testContext;
+    private DatabaseTestHelper databaseTestHelper;
 
     public DropwizardAppWithPostgresRule() {
         configFilePath = resourceFilePath("config/test-it-config.yaml");
@@ -43,7 +45,8 @@ public class DropwizardAppWithPostgresRule implements TestRule {
             public void evaluate() throws Throwable {
                 app.getApplication().run("db", "migrate", configFilePath);
                 createTemplate(getDbUri(), DB_USERNAME, DB_PASSWORD);
-                testContext = new TestContext(app.getLocalPort(), ((DirectDebitConfig) app.getConfiguration()).getDataSourceFactory());
+                testContext = new TestContext(app.getLocalPort(), app.getConfiguration().getDataSourceFactory());
+                databaseTestHelper = new DatabaseTestHelper(testContext.getJdbi());
                 base.evaluate();
             }
         }, description);
@@ -55,5 +58,9 @@ public class DropwizardAppWithPostgresRule implements TestRule {
 
     public TestContext getTestContext() {
         return testContext;
+    }
+
+    public DatabaseTestHelper getDatabaseTestHelper() {
+        return databaseTestHelper;
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
 import au.com.dius.pact.provider.junit.target.HttpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -15,8 +16,8 @@ import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.junit.DropwizardAppWithPostgresRule;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
-import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
@@ -29,9 +30,11 @@ import java.util.Optional;
 
 @RunWith(PayPactRunner.class)
 @Provider("direct-debit-connector")
-@PactBroker(protocol = "https", host = "pact-broker-test.cloudapps.digital", port = "443", tags = {"${PACT_CONSUMER_TAG}"},
+@PactBroker(protocol = "https", host = "pact-broker-test.cloudapps.digital", port = "443", tags = {"master", "test", "staging", "production"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"))
-//@PactFolder("pacts") <-- this is useful for testing pacts locally
+//uncommenting the below is useful for testing pacts locally. grab the pact from the broker and put it in /pacts
+//@PactFolder("pacts")
+//@RunWith(PactRunner.class)
 public class PublicApiContractTest {
 
     @ClassRule
@@ -46,6 +49,11 @@ public class PublicApiContractTest {
     @BeforeClass
     public static void setUpService() {
         target = new HttpTarget(app.getLocalPort());
+    }
+
+    @Before
+    public void resetDatabase() {
+        app.getDatabaseTestHelper().truncateAllData();
     }
 
     @State("a gateway account with external id exists")

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -218,4 +218,11 @@ public class DatabaseTestHelper {
                         .findFirst()
                         .get());
     }
+
+    public void truncateAllData() {
+        jdbi.withHandle(h -> h.createScript(
+                "TRUNCATE TABLE events CASCADE; " +
+                "TRUNCATE TABLE gateway_accounts CASCADE"
+        ).execute());
+    }
 }


### PR DESCRIPTION
Because we need to run the contract tests multiple times (using pacts tagged
with 'master', 'test', 'staging' and 'production') we need to refresh the
database by deleting data.

@oswaldquek