### PR TITLE
bau: Reinstate PACT_CONSUMER_TAG

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 
 @RunWith(PayPactRunner.class)
 @Provider("direct-debit-connector")
-@PactBroker(protocol = "https", host = "pact-broker-test.cloudapps.digital", port = "443", tags = {"master", "test", "staging", "production"},
+@PactBroker(protocol = "https", host = "pact-broker-test.cloudapps.digital", port = "443", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"))
 //uncommenting the below is useful for testing pacts locally. grab the pact from the broker and put it in /pacts
 //@PactFolder("pacts")


### PR DESCRIPTION
Taking out the PACT_CONSUMER_TAG before meant that the pay-direct-debit-connector provider
tests running in the consumer (e.g. pay-publicapi) PR builds wasn't using the
consumer pact tagged with its branch name.

@oswaldquek
