### PR TITLE
PP-4197 Enable "networkaddress cache ttl" setting

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -56,6 +56,10 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
     private static final boolean NON_STRICT_VARIABLE_SUBSTITUTOR = false;
 
     public static void main(String[] args) throws Exception {
+        // Initialise java.security options
+        java.security.Security.setProperty("networkaddress.cache.ttl", "1");
+
+        // Run the application
         new DirectDebitConnectorApp().run(args);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.common.clients;
 
-import com.gocardless.GoCardlessException;
 import com.gocardless.resources.BankDetailsLookup;
 import com.gocardless.resources.BankDetailsLookup.AvailableDebitScheme;
 import com.gocardless.resources.Creditor;
@@ -8,8 +7,6 @@ import com.gocardless.resources.Creditor.SchemeIdentifier.Scheme;
 import com.gocardless.resources.Customer;
 import com.gocardless.resources.CustomerBankAccount;
 import com.gocardless.resources.Payment;
-import org.slf4j.Logger;
-import uk.gov.pay.directdebit.app.logger.PayLoggerFactory;
 import uk.gov.pay.directdebit.common.model.subtype.SunName;
 import uk.gov.pay.directdebit.common.model.subtype.gocardless.creditor.GoCardlessCreditorId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
@@ -29,8 +26,6 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 public class GoCardlessClientFacade {
-
-    private static final Logger LOGGER = PayLoggerFactory.getLogger(GoCardlessClientFacade.class);
 
     private final GoCardlessClientWrapper goCardlessClientWrapper;
 
@@ -72,20 +67,10 @@ public class GoCardlessClientFacade {
     }
 
     public GoCardlessBankAccountLookup validate(BankAccountDetails bankAccountDetails) {
-        try {
-            BankDetailsLookup gcBankDetailsLookup = goCardlessClientWrapper.validate(bankAccountDetails);
-            return new GoCardlessBankAccountLookup(
-                    gcBankDetailsLookup.getBankName(),
-                    gcBankDetailsLookup.getAvailableDebitSchemes().contains(AvailableDebitScheme.BACS));
-        } catch (GoCardlessException goCardlessException) {
-            // this code is temporary setup for debugging purposes to investigate https://github.com/gocardless/gocardless-pro-java/issues/12
-            LOGGER.error("!!! GOCARDLESS ERROR GoCardlessException !!!", goCardlessException);
-            StackTraceElement[] stackTraceElements = goCardlessException.getStackTrace(); // this can be used with live debugging
-            LOGGER.error("!!! GOCARDLESS ERROR goCardlessException.printStackTrace() !!!");
-            goCardlessException.printStackTrace();
-        }
-
-        return null;
+        BankDetailsLookup gcBankDetailsLookup = goCardlessClientWrapper.validate(bankAccountDetails);
+        return new GoCardlessBankAccountLookup(
+                gcBankDetailsLookup.getBankName(),
+                gcBankDetailsLookup.getAvailableDebitSchemes().contains(AvailableDebitScheme.BACS));
     }
 
     public Optional<SunName> getSunName(GoCardlessCreditorId goCardlessCreditorId) {

--- a/src/main/java/uk/gov/pay/directdebit/healthcheck/resources/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/healthcheck/resources/HealthCheckResource.java
@@ -43,7 +43,7 @@ public class HealthCheckResource {
                 .filter(HealthCheck.Result::isHealthy)
                 .count();
 
-        if(healthy) {
+        if (healthy) {
             return Response.ok().entity(response).build();
         }
         return status(503).entity(response).build();
@@ -51,7 +51,7 @@ public class HealthCheckResource {
 
     private Map<String, Map<String, Object>> getResponse(SortedMap<String, HealthCheck.Result> results) {
         Map<String, Map<String, Object>> response = new HashMap<>();
-        for (SortedMap.Entry<String, HealthCheck.Result> entry : results.entrySet() ) {
+        for (SortedMap.Entry<String, HealthCheck.Result> entry : results.entrySet()) {
             response.put(entry.getKey(), ImmutableMap.of(
                     "healthy", entry.getValue().isHealthy(),
                     "message", isBlank(entry.getValue().getMessage()) ? "Healthy" : entry.getValue().getMessage()));


### PR DESCRIPTION
## WHAT YOU DID

- `networkaddress.cache.ttl` is a setting specified in `java.security` to indicate the caching policy for successful name lookups from the name service.
  The default behavior is to cache forever when a security manager is installed, and to cache for an implementation specific period of time, when a security manager is not installed.
- we want to change DNS name lookups cache timeout to be very short, because our proxy's dns needs to be accurate, especially when making reguests to GoCardless

More information:

- https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-jvm-ttl.html
- https://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html
