### PR TITLE
Revert "Bump pact-jvm-provider-junit_2.12 from 3.5.18 to 3.5.24"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>
-            <version>3.5.24</version>
+            <version>3.5.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Reverts alphagov/pay-direct-debit-connector#288

This was causing some build breakage. Will investigate properly after other dependency updates.