### PR TITLE
Revert "Bump org.eclipse.persistence.jpa from 2.6.4 to 2.7.3"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <rest-assured.version>3.2.0</rest-assured.version>
         <mockito.version>2.23.0</mockito.version>
         <docker-client.version>8.14.3</docker-client.version>
-        <eclipselink.version>2.7.3</eclipselink.version>
+        <eclipselink.version>2.6.4</eclipselink.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Reverts alphagov/pay-direct-debit-connector#294

Builds currently failing with `ERROR:  relation "public.databasechangeloglock" does not exist`. Let's revert this for now and get the other dependency upgrades done