### PR TITLE
Remove EclipseLink JPA 2.6.4 from Maven POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <rest-assured.version>3.2.0</rest-assured.version>
         <mockito.version>2.23.0</mockito.version>
         <docker-client.version>8.14.3</docker-client.version>
-        <eclipselink.version>2.6.4</eclipselink.version>
     </properties>
 
     <repositories>
@@ -133,12 +132,6 @@
             <groupId>org.mindrot</groupId>
             <artifactId>jbcrypt</artifactId>
             <version>0.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.jpa</artifactId>
-            <version>${eclipselink.version}</version>
-            <scope>compile</scope>
         </dependency>
         <!-- testing -->
         <dependency>


### PR DESCRIPTION
Direct Debit connector does not currently use EclipseLink so this dependency can be removed