### PR TITLE
Add dependency on GlassFish JSON processing default provider 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,12 @@
             </exclusions>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Some of our Pact tests seem to need this. It appears we were relying on getting this via EclipseLink previously.