### PR TITLE
PP-4268 Use InetSocketAddress.createUnresolved instead of setting default ProxySelector

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -83,15 +83,16 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
 
     @Override
     public void run(DirectDebitConfig configuration, Environment environment) {
-        if (!configuration.getProxyConfig().getHost().isEmpty()) {
-            CustomInetSocketAddressProxySelector customInetSocketAddressProxySelector =
-                    new CustomInetSocketAddressProxySelector(
-                            ProxySelector.getDefault(),
-                            configuration.getProxyConfig().getHost(),
-                            configuration.getProxyConfig().getPort()
-                    );
-            ProxySelector.setDefault(customInetSocketAddressProxySelector);
-        }
+        // TODO: remove CustomInetSocketAddressProxySelector and it's usage if InetSocketAddress.createUnresolved works
+//        if (!configuration.getProxyConfig().getHost().isEmpty()) {
+//            CustomInetSocketAddressProxySelector customInetSocketAddressProxySelector =
+//                    new CustomInetSocketAddressProxySelector(
+//                            ProxySelector.getDefault(),
+//                            configuration.getProxyConfig().getHost(),
+//                            configuration.getProxyConfig().getPort()
+//                    );
+//            ProxySelector.setDefault(customInetSocketAddressProxySelector);
+//        }
 
         DataSourceFactory dataSourceFactory = configuration.getDataSourceFactory();
         final Jdbi jdbi = createJdbi(dataSourceFactory);

--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactory.java
@@ -7,6 +7,8 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
 import uk.gov.pay.directdebit.webhook.gocardless.config.GoCardlessFactory;
 
 import javax.net.ssl.SSLSocketFactory;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.Map;
 import java.util.Optional;
 
@@ -44,8 +46,13 @@ public class GoCardlessClientFactory {
                     .build();
         }
 
+        Proxy proxy = new Proxy(
+                Proxy.Type.HTTP,
+                InetSocketAddress.createUnresolved(configuration.getProxyConfig().getHost(), configuration.getProxyConfig().getPort())
+        );
         return builder
                 .withEnvironment(goCardlessFactory.getEnvironment())
+                .withProxy(proxy)
                 .build();
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactoryTest.java
@@ -29,6 +29,8 @@ public class GoCardlessClientFactoryTest {
     @Before
     public void setUp() {
         when(mockedDirectDebitConfig.getGoCardless().getAccessToken()).thenReturn("aaa");
+        when(mockedDirectDebitConfig.getProxyConfig().getHost()).thenReturn("proxy.internal.example.com");
+        when(mockedDirectDebitConfig.getProxyConfig().getPort()).thenReturn(0);
         when(mockedDirectDebitConfig.getGoCardless().getEnvironment()).thenReturn(GoCardlessClient.Environment.SANDBOX);
         goCardlessClientFactory = new GoCardlessClientFactory(mockedDirectDebitConfig, mockedSSLSocketFactory);
     }


### PR DESCRIPTION
## WHAT YOU DID

This is small improvement to replace ProxySelector with InetSocketAddress.createUnresolved.

Currently we use custom ProxySelector ( https://github.com/alphagov/pay-direct-debit-connector/blob/6f423b5dddddf2039aa1f878c4865eefe2e226ae/src/main/java/uk/gov/pay/directdebit/common/proxy/CustomInetSocketAddressProxySelector.java ) which is used as a default proxy selector for any outbound Java requests https://github.com/alphagov/pay-direct-debit-connector/blob/6f423b5dddddf2039aa1f878c4865eefe2e226ae/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java#L93

We want to change the configuration and implementation and not to use custom ProxySelector when initialising GoCardless SDK

We should use `InetSocketAddress.createUnresolved(configuration.getProxyConfig().getHost(), configuration.getProxyConfig().getPort())` instead of `new InetSocketAddress(configuration.getProxyConfig().getHost(), configuration.getProxyConfig().getPort())`, because `new InetSocketAddress(...)` will resolve to IP address straight away and this IP address may be invalid in the future (we should use hostnames for our proxy address).

`InetSocketAddress.createUnresolved` will not resolve reverse proxy domain name to IP address, hence it will always be valid (even in case when the hostname changes it's IP address)

Removed the `ProxySelector.setDefault(customInetSocketAddressProxySelector)` call to apply `InetSocketAddress.createUnresolved`

related PR: https://github.com/alphagov/pay-direct-debit-connector/pull/271
