### PR TITLE
BAU: Switch to specifying scheme instead of protocol & port for pact

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 
 @RunWith(PayPactRunner.class)
 @Provider("direct-debit-connector")
-@PactBroker(protocol = "https", host = "pact-broker-test.cloudapps.digital", port = "443", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"))
 //uncommenting the below is useful for testing pacts locally. grab the pact from the broker and put it in /pacts
 //@PactFolder("pacts")


### PR DESCRIPTION
The upgrade of pact (https://github.com/alphagov/pay-direct-debit-connector/pull/311) has pulled in this change:
https://github.com/DiUS/pact-jvm/commit/65cd756497fd3f2161d00830c594fd37520d5ab5

which causes connection failures to our pact broker.

Specifying 'protocol' is now deprecated, so we should use 'scheme' instead and
let the port be inferred