### PR TITLE
BAU: Rearrange Dockerfile to reduce the number of rebuilt layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ EXPOSE 8081
 
 WORKDIR /app
 
-ADD target/*.yaml /app/
-ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh
 ADD run-with-chamber.sh /app/run-with-chamber.sh
+ADD target/*.yaml /app/
+ADD target/pay-*-allinone.jar /app/
 
 CMD bash ./docker-startup.sh


### PR DESCRIPTION
The thing which changes most often is the .jar, so add that to the docker image
last. This means that in the common case, we only rebuild one layer rather than
several.