### PR TITLE
Revert "Bump pact-jvm-provider-junit_2.12 from 3.5.24 to 3.6.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>
-            <version>3.6.0</version>
+            <version>3.5.24</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This reverts commit bf939bd9e3e56a1ae30286371cdbef0736cbd858.

It looks like upgrading pact stops us from publishing pacts. Revert this until
we can figure out what's going on.
