### PR TITLE
PP-4584 Rollback GoCardless proxy settings

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactory.java
@@ -7,6 +7,8 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
 import uk.gov.pay.directdebit.webhook.gocardless.config.GoCardlessFactory;
 
 import javax.net.ssl.SSLSocketFactory;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.Map;
 import java.util.Optional;
 
@@ -44,8 +46,13 @@ public class GoCardlessClientFactory {
                     .build();
         }
 
+        Proxy proxy = new Proxy(
+                Proxy.Type.HTTP,
+                InetSocketAddress.createUnresolved(System.getProperty("https.proxyHost"), Integer.parseInt(System.getProperty("https.proxyPort")))
+        );
         return builder
                 .withEnvironment(goCardlessFactory.getEnvironment())
+                .withProxy(proxy)
                 .build();
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactoryTest.java
@@ -29,6 +29,8 @@ public class GoCardlessClientFactoryTest {
     @Before
     public void setUp() {
         when(mockedDirectDebitConfig.getGoCardless().getAccessToken()).thenReturn("aaa");
+        when(System.getProperty("https.proxyHost")).thenReturn("proxy.internal.example.com");
+        when(System.getProperty("https.proxyPort")).thenReturn("0");
         when(mockedDirectDebitConfig.getGoCardless().getEnvironment()).thenReturn(GoCardlessClient.Environment.SANDBOX);
         goCardlessClientFactory = new GoCardlessClientFactory(mockedDirectDebitConfig, mockedSSLSocketFactory);
     }


### PR DESCRIPTION
## WHAT YOU DID

- When https://github.com/alphagov/pay-direct-debit-connector/pull/333/ was merged it removed GoCardless SDK proxy settings
- The new proxy settings are now set via system variable
