### PR TITLE
PP-4584 Use custom proxy selector for outbound HTTPS requests

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -27,6 +27,7 @@ import uk.gov.pay.directdebit.common.exception.ConflictExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.InternalServerErrorExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.NotFoundExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.PreconditionFailedExceptionMapper;
+import uk.gov.pay.directdebit.common.proxy.CustomInetSocketAddressProxySelector;
 import uk.gov.pay.directdebit.events.resources.DirectDebitEventsResource;
 import uk.gov.pay.directdebit.gatewayaccounts.GatewayAccountParamConverterProvider;
 import uk.gov.pay.directdebit.gatewayaccounts.resources.GatewayAccountResource;
@@ -45,6 +46,7 @@ import uk.gov.pay.directdebit.webhook.sandbox.resources.WebhookSandboxResource;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
+import java.net.ProxySelector;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.EnumSet.of;
@@ -80,6 +82,16 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
 
     @Override
     public void run(DirectDebitConfig configuration, Environment environment) {
+        if ((System.getProperty("https.proxyHost") != null) && (System.getProperty("https.proxyPort") != null)) {
+            CustomInetSocketAddressProxySelector customInetSocketAddressProxySelector =
+                    new CustomInetSocketAddressProxySelector(
+                            ProxySelector.getDefault(),
+                            System.getProperty("https.proxyHost"),
+                            Integer.parseInt(System.getProperty("https.proxyPort"))
+                    );
+            ProxySelector.setDefault(customInetSocketAddressProxySelector);
+        }
+
         DataSourceFactory dataSourceFactory = configuration.getDataSourceFactory();
         final Jdbi jdbi = createJdbi(dataSourceFactory);
 

--- a/src/main/java/uk/gov/pay/directdebit/common/proxy/CustomInetSocketAddressProxySelector.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/proxy/CustomInetSocketAddressProxySelector.java
@@ -1,0 +1,88 @@
+package uk.gov.pay.directdebit.common.proxy;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Custom {@link java.net.ProxySelector ProxySelector} which will use only one proxy and will return new instance each time.
+ *
+ * @see <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html">Java Networking and Proxies</a>
+ */
+public class CustomInetSocketAddressProxySelector extends ProxySelector {
+
+    /**
+     * Keep a reference on the previous default
+     */
+    private ProxySelector defaultProxySelector;
+
+    /**
+     * Proxy hostname to be used
+     */
+    private String proxyHostname;
+
+    /**
+     * Proxy port to be used
+     */
+    private int proxyPort;
+
+    /**
+     * CustomInetSocketAddressProxySelector constructor
+     *
+     * @param defaultProxySelector default proxy selector
+     * @param proxyHostname        proxy's hostname
+     * @param proxyPort            proxy's port
+     */
+    public CustomInetSocketAddressProxySelector(ProxySelector defaultProxySelector,
+                                                String proxyHostname,
+                                                int proxyPort) {
+        this.defaultProxySelector = defaultProxySelector;
+    }
+
+    @Override
+    public List<Proxy> select(URI uri) {
+        if (uri == null) {
+            throw new IllegalArgumentException("URI can't be null.");
+        }
+
+        /*
+         * If it's a http (or https) URL, then we use our own list.
+         */
+        String protocol = uri.getScheme();
+        if ((this.proxyHostname != null) &&
+                ("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol))) {
+            return Collections.singletonList(
+                    new Proxy(
+                            Proxy.Type.HTTP,
+                            new InetSocketAddress(this.proxyHostname, this.proxyPort)
+                    )
+            );
+        }
+
+        /*
+         * Not HTTP or HTTPS (could be SOCKS or FTP) defer to the default selector.
+         */
+        if (defaultProxySelector != null) {
+            return defaultProxySelector.select(uri);
+        } else {
+            return Collections.singletonList(Proxy.NO_PROXY);
+        }
+    }
+
+    @Override
+    public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+        if (uri == null || sa == null || ioe == null) {
+            throw new IllegalArgumentException("Arguments can't be null.");
+        }
+
+        if (defaultProxySelector != null) {
+            defaultProxySelector.connectFailed(uri, sa, ioe);
+        }
+    }
+
+}


### PR DESCRIPTION
## WHAT

- Add `CustomInetSocketAddressProxySelector` which sets proxy for all
  outbound HTTPS requests and uses new system properties introduced in
  #333
- `CustomInetSocketAddressProxySelector` will be used with GoCardless SDK
  when there is no explicit proxy setting on the SDK client
