### PR TITLE
Silence liquibase noise during tests

### DIFF
--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -7,13 +7,17 @@ server:
       port: 0
 
 logging:
-    level: WARN
-    appenders:
-      - type: console
-        threshold: ALL
-        timeZone: UTC
-        target: stdout
-        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+  level: WARN
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+  loggers:
+    # Liquibase is very chatty and we only want to hear from it if things go wrong
+    "liquibase": WARN
+
 links:
   frontendUrl: http://Frontend
 


### PR DESCRIPTION
Downgrade the logging level of liquibase during test runs. Liquibase logs all
its SQL which clutters the build log.