### PR TITLE
Simplify object identity methods

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResponse.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.directdebit.payments.model.ViewPaginationBuilder;
 
 import java.util.List;
+import java.util.Objects;
+
+import static java.lang.String.format;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
@@ -51,20 +54,23 @@ public class PaymentViewResponse {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentViewResponse that = (PaymentViewResponse) o;
+        return Objects.equals(gatewayExternalId, that.gatewayExternalId) &&
+                Objects.equals(total, that.total) &&
+                Objects.equals(page, that.page);
+    }
+
+    @Override
     public int hashCode() {
-        int result = gatewayExternalId.hashCode();
-        result = 31 * result + page.hashCode();
-        result = 31 * result + total.hashCode();
-        return result;
+        return Objects.hash(gatewayExternalId, total, page);
     }
 
     @Override
     public String toString() {
-        return "TransactionResponse{" +
-                " gatewayExternalId='" + gatewayExternalId + '\n' +
-                ", page='" + page + '\'' +
-                ", total=" + total + '\'' +
-                ", paymentViewResponses='" + paymentViewResponses.toString() + '\'' +
-                "}";
+        return format("TransactionResponse{gatewayExternalId='%s', page='%s', total='%s', paymentViewResponses='%s'}"
+                        + gatewayExternalId, page, total, paymentViewResponses.toString());
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
@@ -122,7 +122,7 @@ public class PaymentViewResultResponse {
         if (!createdDate.equals(that.createdDate)) return false;
         if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (email != null ? !email.equalsIgnoreCase(that.email) : that.email != null) return false;
-        if (mandateExternalId != null ? !transactionId.equalsIgnoreCase(that.mandateExternalId) : that.transactionId != null)
+        if (mandateExternalId != null ? !mandateExternalId.equalsIgnoreCase(that.mandateExternalId) : that.mandateExternalId != null)
             return false;
         return state == that.state;
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
@@ -10,6 +10,9 @@ import uk.gov.pay.directdebit.payments.links.Link;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
+import static java.lang.String.format;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
@@ -115,43 +118,25 @@ public class PaymentViewResultResponse {
 
         PaymentViewResultResponse that = (PaymentViewResultResponse) o;
 
-        if (!transactionId.equals(that.transactionId)) return false;
-        if (!amount.equals(that.amount)) return false;
-        if (description != null ? !description.equals(that.description) : that.description != null) return false;
-        if (reference != null ? !reference.equals(that.reference) : that.reference != null) return false;
-        if (!createdDate.equals(that.createdDate)) return false;
-        if (name != null ? !name.equals(that.name) : that.name != null) return false;
-        if (email != null ? !email.equalsIgnoreCase(that.email) : that.email != null) return false;
-        if (mandateExternalId != null ? !mandateExternalId.equalsIgnoreCase(that.mandateExternalId) : that.mandateExternalId != null)
-            return false;
-        return state == that.state;
+        return Objects.equals(transactionId, that.transactionId)
+                && Objects.equals(amount, that.amount)
+                && Objects.equals(description, that.description)
+                && Objects.equals(reference, that.reference)
+                && Objects.equals(createdDate, that.createdDate)
+                && Objects.equals(name, that.name)
+                && (email == null ? that.email == null : email.equalsIgnoreCase(that.email))
+                && (mandateExternalId == null ? that.mandateExternalId == null : mandateExternalId.equalsIgnoreCase(that.mandateExternalId))
+                && Objects.equals(state, that.state);
     }
 
     @Override
     public int hashCode() {
-        int result = transactionId.hashCode();
-        result = 31 * result + transactionId.hashCode();
-        result = 31 * result + amount.hashCode();
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (reference != null ? reference.hashCode() : 0);
-        result = 31 * result + createdDate.hashCode();
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (email != null ? email.hashCode() : 0);
-        result = 31 * result + state.hashCode();
-        result = 31 * result + (mandateExternalId != null ? mandateExternalId.hashCode() : 0);
-        return result;
+        return Objects.hash(transactionId, amount, description, reference, createdDate, name, email, state, mandateExternalId);
     }
 
     @Override
     public String toString() {
-        return "TransactionResponse{" +
-                ", transactionId='" + transactionId + '\'' +
-                ", amount=" + amount +
-                ", reference='" + reference + '\'' +
-                ", createdDate=" + createdDate +
-                ", name=" + name +
-                ", email=" + email +
-                ", state='" + state.getState() + '\'' +
-                '}';
+        return format("TransactionResponse{transactionId='%s', amount='%s', reference='%s', createdDate='%s', name='%s', email='%s', state='%s'}",
+                transactionId, amount, reference, createdDate, name, email, state.getState());
     }
 }


### PR DESCRIPTION
Simplify object identity methods in `PaymentViewResponse` and `PaymentViewResultResponse` using `Objects.equals()`, `Objects.hash()` and `String.format()`.

In the process, I discovered a bug in `PaymentViewResultResponse.equals()` (see individual commits fot details)