### PR TITLE
Cleanup test structure

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -4,5 +4,5 @@ set -e
 
 cd "$(dirname "$0")"
 
-mvn -DskipTests clean package
+mvn -DskipITs clean package
 docker build -t govukpay/directdebit-connector:local .

--- a/pom.xml
+++ b/pom.xml
@@ -288,9 +288,6 @@
                 <configuration>
                     <junitArtifactName>junit:junit</junitArtifactName>
                     <testFailureIgnore>false</testFailureIgnore>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -305,11 +302,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <includes>
-                        <include>**/*IT.java</include>
-                    </includes>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <rest-assured.version>3.3.0</rest-assured.version>
         <mockito.version>2.25.0</mockito.version>
         <pay-java-commons.version>1.0.20190226180729</pay-java-commons.version>
+        <surefire.version>2.22.1</surefire.version>
         <dependency-check.skip>true</dependency-check.skip>
     </properties>
 
@@ -283,7 +284,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>${surefire.version}</version>
                 <configuration>
                     <junitArtifactName>junit:junit</junitArtifactName>
                     <testFailureIgnore>false</testFailureIgnore>
@@ -417,7 +418,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.1</version>
+                        <version>${surefire.version}</version>
                         <configuration>
                             <excludes>
                                 <exclude>**/*ContractTest.java</exclude>
@@ -439,7 +440,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.1</version>
+                        <version>${surefire.version}</version>
                         <configuration>
                             <includes>
                                 <include>**/*ContractTestSuite.java</include>

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
@@ -100,7 +100,7 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
     private boolean isValidOrganisation(Mandate mandate, GoCardlessEvent event) {
         return mandate.getGatewayAccount().getOrganisation()
                 .map(organisationIdentifier -> organisationIdentifier.equals(event.getOrganisationIdentifier()))
-                // TODO: replace true with false after going live. kept now for backwards compatibilityGetDirectDebitEventsTest 
+                // TODO: replace true with false after going live. kept now for backwards compatibility with GetDirectDebitEventsIT
                 .orElse(true);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsIT.java
@@ -32,7 +32,7 @@ import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEv
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.MANDATE;
 
 @RunWith(JUnitParamsRunner.class)
-public class GetDirectDebitEventsTest {
+public class GetDirectDebitEventsIT {
 
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
@@ -33,7 +33,7 @@ import static uk.gov.pay.directdebit.payments.fixtures.TransactionFixture.aTrans
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
-public class PaymentViewResourceITest {
+public class PaymentViewResourceIT {
 
     private GatewayAccountFixture testGatewayAccount;
 

--- a/src/test/java/uk/gov/pay/directdebit/tasks/resources/ExpireResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/tasks/resources/ExpireResourceIT.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
-public class ExpireResourceTest {
+public class ExpireResourceIT {
 
     @DropwizardTestContext
     private TestContext testContext;


### PR DESCRIPTION
## WHAT YOU DID
Named all integration tests consistently, to match the default patterns for the surefire and failsafe maven plugins.

Removed duplication in the pom for the surefire version using a property.

Included unit tests in `build-local.sh`

## How to test

`mvn test` should only run unit tests, as should `./build-local.sh`
`mvn verify` should run all tests, first unit tests, then package the .jar and then finally run integration tests.

I'm not wholly convinced our integration tests meet the failsafe plugin's definition of what it expects an integration test to be, but they are a bit more bulky than unit tests have a right to be.

See the surefire documentation for the default inclusion pattern: https://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html
and the corresponding failsafe documentation: https://maven.apache.org/surefire/maven-failsafe-plugin/examples/inclusion-exclusion.html