### PR TITLE
PP-4864: Work on a writeable copy of the default Java truststore

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -6,9 +6,15 @@ RUN_MIGRATION=${RUN_MIGRATION:-false}
 RUN_APP=${RUN_APP:-true}
 JAVA_OPTS=${JAVA_OPTS:-}
 
+# Make a copy of the truststore to modify. We only need to do this as we have a
+# readonly Docker volume mounted on /etc/ssl/certs. Once that's removed, this
+# complexity goes away.
+truststore=$(mktemp)
+echo "Setting up temporary truststore $truststore"
+cat /etc/ssl/certs/java/cacerts > "$truststore"
+
 if [ -n "${CERTS_PATH:-}" ]; then
   i=0
-  truststore=/etc/ssl/certs/java/cacerts
   truststore_pass=changeit
   for cert in "$CERTS_PATH"/*; do
     echo "Adding $cert to $truststore"
@@ -16,14 +22,14 @@ if [ -n "${CERTS_PATH:-}" ]; then
   done
 fi
 
-java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
+java "-Djavax.net.ssl.trustStore=$truststore" $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then
-  java $JAVA_OPTS -jar *-allinone.jar db migrate *.yaml
+  java "-Djavax.net.ssl.trustStore=$truststore" $JAVA_OPTS -jar *-allinone.jar db migrate *.yaml
 fi
 
 if [ "$RUN_APP" == "true" ]; then
-  java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+  java "-Djavax.net.ssl.trustStore=$truststore" $JAVA_OPTS -jar *-allinone.jar server *.yaml
 fi
 
 exit 0


### PR DESCRIPTION
We can't modify the default Java truststore at the moment because we mount a
readonly volume over the top of it.

Until we can remove that volume, make a working copy of the truststore and
modify that instead.