### PR TITLE
PP-4951 Fix date time precision in tests.

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsIT.java
@@ -26,6 +26,7 @@ import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture.aDirectDebitEventFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_ACKNOWLEDGED_BY_PROVIDER;
@@ -122,7 +123,7 @@ public class GetDirectDebitEventsIT {
                 .body("count", is(1))
                 .body("results[0].event_type", is(MANDATE.toString()))
                 .body("results[0].event", is(PAYMENT_ACKNOWLEDGED_BY_PROVIDER.toString()))
-                .body("results[0].event_date", is(directDebitEventFixture.getEventDate().format(DateTimeFormatter.ISO_INSTANT)))
+                .body("results[0].event_date", is(directDebitEventFixture.getEventDate().format(ISO_INSTANT_MILLISECOND_PRECISION)))
                 .body("results[0].external_id", is("externalId"))
                 .body("results[0].mandate_external_id", is(testMandate.getExternalId().toString()))
                 .body("results[0].transaction_external_id", is(testTransaction.getExternalId()))

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -55,6 +55,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.AWAITING_DIRECT_DEBIT_DETAILS;
 import static uk.gov.pay.directdebit.payers.fixtures.GoCardlessCustomerFixture.aGoCardlessCustomerFixture;
@@ -245,7 +246,7 @@ public class MandateResourceIT {
                 .body("internal_state", is(mandateFixture.getState().toString()))
                 .body("mandate_reference", is(mandateFixture.getMandateReference()))
                 .body("mandate_type", is(mandateFixture.getMandateType().toString()))
-                .body("created_date", is(mandateFixture.getCreatedDate().toString()))
+                .body("created_date", is(mandateFixture.getCreatedDate().format(ISO_INSTANT_MILLISECOND_PRECISION)))
                 .body("transaction." + JSON_AMOUNT_KEY, isNumber(transactionFixture.getAmount()))
                 .body("transaction." + JSON_REFERENCE_KEY, is(transactionFixture.getReference()))
                 .body("transaction." + JSON_DESCRIPTION_KEY, is(transactionFixture.getDescription()))
@@ -283,7 +284,7 @@ public class MandateResourceIT {
                 .body("internal_state", is(mandateFixture.getState().toString()))
                 .body("mandate_reference", is(mandateFixture.getMandateReference()))
                 .body("mandate_type", is(mandateFixture.getMandateType().toString()))
-                .body("created_date", is(mandateFixture.getCreatedDate().toString()))
+                .body("created_date", is(mandateFixture.getCreatedDate().format(ISO_INSTANT_MILLISECOND_PRECISION)))
                 .body("$", not(hasKey("transaction")))
                 .body("payer.payer_external_id", is(payerFixture.getExternalId()))
                 .body("payer.account_holder_name", is(payerFixture.getName()))

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
@@ -26,6 +26,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
 import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
@@ -79,7 +80,7 @@ public class PaymentViewResourceIT {
                 .body("results[0].reference", is("MBK2"))
                 .body("results[0].name", is("J. Doe2"))
                 .body("results[2].description", is("Description0"))
-                .body("results[1].created_date", is(createdDate.toString()));
+                .body("results[1].created_date", is(createdDate.format(ISO_INSTANT_MILLISECOND_PRECISION)));
     }
 
     @Test
@@ -177,7 +178,7 @@ public class PaymentViewResourceIT {
                 .body("results[0].reference", is("MBK4"))
                 .body("results[4].description", is("Description0"))
                 .body("results[1].name", is("J. Doe3"))
-                .body("results[2].created_date", is(createdDate.toString()));
+                .body("results[2].created_date", is(createdDate.format(ISO_INSTANT_MILLISECOND_PRECISION)));
     }
 
     @Test


### PR DESCRIPTION
In preparation for Java 11 fix the format of the expected date strings to
millisecond precision as per the agreed precision from our end-points.

## How to test
CI will ensure that this change is compatible with existing Java 8. If you wish to test that this addresses the date precision issue introduced with Java 11, then please....
set `JAVA_HOME` to point to an 11 JDK. Verify that Maven is using an 11 JDK with `mvn -version` and you should see something similar to:
```
gds5062:pay-direct-debit-connector danworth$ mvn -version
Apache Maven 3.5.3 (3383c37e1f9e9b3bc3df5050c29c8aff9f295297; 2018-02-24T19:49:05Z)
Maven home: /Users/danworth/Applications/apache-maven-3.5.3
Java version: 11, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.6", arch: "x86_64", family: "mac"
```

Change the `<source>` and `<target>` flags within the `pom.xml` to `11`.

Then run the integration tests with `mvn  verify`, unit tests with `mvn test` and you can also run the pact tests with something like:
`mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -Dpact.provider.version=e3446c80b24eae4117f0100e68b9cff3fd242bf5 -Dpact.verifier.publishResults=false
`
