### PR TITLE
DO NOT MERGE PP-4948 Set JAVA_HOME to 11 JDK to test installation of openJDK11.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
   environment {
     DOCKER_HOST = "unix:///var/run/docker.sock"
     RUN_END_TO_END_ON_PR = "${params.runEndToEndOnPR}"
+    JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
   }
 
   stages {
@@ -31,7 +32,7 @@ pipeline {
       steps {
         script {
           long stepBuildTime = System.currentTimeMillis()
-
+          sh 'mvn -version'
           sh 'mvn clean verify'
           runProviderContractTests() 
           postSuccessfulMetrics("directdebit-connector.maven-build", stepBuildTime)


### PR DESCRIPTION
## WHAT YOU DID
This sets `JAVA_HOME` to point to the openJDK11 to test its installation on CI.