### PR TITLE
(DO NOT MERGE) PP 5020 migrate to java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM govukpay/openjdk:alpine-3.9-jre-base-8.201.08
+FROM adoptopenjdk/openjdk11:jdk-11.0.2.9-alpine
 
 RUN apk --no-cache upgrade
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
   environment {
     DOCKER_HOST = "unix:///var/run/docker.sock"
     RUN_END_TO_END_ON_PR = "${params.runEndToEndOnPR}"
+    JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
   }
 
   stages {
@@ -31,7 +32,7 @@ pipeline {
       steps {
         script {
           long stepBuildTime = System.currentTimeMillis()
-
+          sh 'mvn -version'
           sh 'mvn clean verify'
           runProviderContractTests() 
           postSuccessfulMetrics("directdebit-connector.maven-build", stepBuildTime)

--- a/pom.xml
+++ b/pom.xml
@@ -248,8 +248,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## WHAT YOU DID
Updated the base image to use AdoptOpenJDK11 which is based on Alpine.
Update the `pom.xml` to replace `source` and `target` with new `release` flag and set it to 11.
Set `JAVA_HOME` to reference the 11 jdk on CI.