### PR TITLE
PP-5020 Migrate to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM govukpay/openjdk:alpine-3.9-jre-base-8.201.08
+FROM govukpay/openjdk:adoptopenjdk-jre-11.0.2.9-alpine
 
 RUN apk --no-cache upgrade
 
 # openssl is only here temporarily whilst docker-startup.sh needs it
 RUN apk add --no-cache bash openssl
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-*/
+ENV JAVA_HOME /opt/java/openjdk
 ENV PORT 8080
 ENV ADMIN_PORT 8081
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
   environment {
     DOCKER_HOST = "unix:///var/run/docker.sock"
     RUN_END_TO_END_ON_PR = "${params.runEndToEndOnPR}"
+    JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
   }
 
   stages {
@@ -31,7 +32,7 @@ pipeline {
       steps {
         script {
           long stepBuildTime = System.currentTimeMillis()
-
+          sh 'mvn -version'
           sh 'mvn clean verify'
           runProviderContractTests() 
           postSuccessfulMetrics("directdebit-connector.maven-build", stepBuildTime)

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -8,7 +8,7 @@ JAVA_OPTS=${JAVA_OPTS:-}
 
 if [ -n "${CERTS_PATH:-}" ]; then
   i=0
-  truststore=/etc/ssl/certs/java/cacerts
+  truststore=$JAVA_HOME/lib/security/cacerts
   truststore_pass=changeit
   existing_fingerprints=$(keytool -list -keystore "$truststore" -storepass "$truststore_pass"| sed -ne 's/^Certificate fingerprint (SHA1): //p')
   for cert in "$CERTS_PATH"/*; do

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,16 @@
             <version>1.1.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.12</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -258,8 +258,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
- Set `JAVA_HOME` to the 11 JDK for building on CI.
- Replace `source` and `target` with new `release` flag and set it to `11`.
- Change base image to our new 11 JRE based upon AdoptOpenJDK image `openjdk:adoptopenjdk-jre-11.0.2.9-alpine`

## WHAT YOU DID
These changes will upgrade DDConnector to Java 11.
