### PR TITLE
Correct tests to enable DropWizard upgrade

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -486,7 +486,7 @@ public class MandateResourceIT {
 
         List<Map<String, Object>> transactionsForMandate = testContext.getDatabaseTestHelper().getTransactionsForMandate(mandateFixture.getExternalId());
         MatcherAssert.assertThat(transactionsForMandate.size(), is(1));
-        MatcherAssert.assertThat(transactionsForMandate.get(0).get("state"), is("SUBMITTED"));
+        MatcherAssert.assertThat(transactionsForMandate.get(0).get("state"), is("PENDING"));
     }
 
     @Test
@@ -607,7 +607,7 @@ public class MandateResourceIT {
 
         List<Map<String, Object>> transactionsForMandate = testContext.getDatabaseTestHelper().getTransactionsForMandate(mandateFixture.getExternalId());
         MatcherAssert.assertThat(transactionsForMandate.size(), is(1));
-        MatcherAssert.assertThat(transactionsForMandate.get(0).get("state"), is("SUBMITTED"));
+        MatcherAssert.assertThat(transactionsForMandate.get(0).get("state"), is("PENDING"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -17,7 +17,7 @@ public class DatabaseTestHelper {
     public Map<String, Object> getTokenByMandateExternalId(MandateExternalId externalId) {
         return jdbi.withHandle(handle ->
                 handle
-                        .createQuery("SELECT * from tokens t JOIN mandates m ON t.mandate_id = m.id WHERE m.external_id = :external_id ORDER BY t.id DESC")
+                        .createQuery("SELECT t.* from tokens t JOIN mandates m ON t.mandate_id = m.id WHERE m.external_id = :external_id ORDER BY t.id DESC")
                         .bind("external_id", externalId)
                         .mapToMap()
                         .findFirst()
@@ -84,7 +84,7 @@ public class DatabaseTestHelper {
     public List<Map<String, Object>> getTransactionsForMandate(MandateExternalId mandateExternalId) {
         return jdbi.withHandle(handle ->
                 handle
-                        .createQuery("SELECT * from transactions t JOIN mandates m ON t.mandate_id = m.id WHERE m.external_id = :mandateExternalId")
+                        .createQuery("SELECT t.* from transactions t JOIN mandates m ON t.mandate_id = m.id WHERE m.external_id = :mandateExternalId")
                         .bind("mandateExternalId", mandateExternalId)
                         .mapToMap()
                         .list()


### PR DESCRIPTION
Upgrading Drop Wizard to 1.3.9 upgrades JDBI which will not permit cols of the same name being returned in the same result set (appears to be related to how it uses reflection). This fixes the issue so that we can upgrade.

- Correct `DatabaseTestHelper.getTokenByMandateExternalId` and `getTrasnactionsForMandate`
to return only contents of `tokens` and `transactions` table respectively. New version of JDBI appears to use reflection which complains if two cols in the same result set have the same name
which makes sense since the returned map cannot know which of the multiple keys to
have used. This occurs on multiple fields if joining transactions and mandates tables.

- Correct the assertion to test the status of the transaction which should be
PENDING and not the mandate state which is SUBMITTED. This error became apparent when
the `getTransactionsForMandate` was changed to only return transaction details and
not include mandate detail (both have `state` cols and therefor the returned Map
is incorrect and the test was deemed wrong).
