### PR TITLE
BAU Fix tests to enable upgrade to Drop Wizard 1.3.9

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -138,7 +138,7 @@ public class DatabaseTestHelper {
     public Map<String, Object> getMandateByTransactionExternalId(String externalId) {
         return jdbi.withHandle(handle ->
                 handle
-                        .createQuery("SELECT * from mandates m JOIN transactions t ON t.mandate_id = m.id WHERE t.external_id = :externalId")
+                        .createQuery("SELECT m.* from mandates m JOIN transactions t ON t.mandate_id = m.id WHERE t.external_id = :externalId")
                         .bind("externalId", externalId)
                         .mapToMap()
                         .findFirst()


### PR DESCRIPTION
I found another test that needs correcting for Dropwizard upgrade.

Drop Wizard 1.3.9 upgrades JDBI which will not permit same named col in the same
result set (this makes sense since the resulting `Map<String, Object>` will not
know which key to use and this causes confusion/unexpected results). This
changes `DatabaseTestHelper.getMandateByTransactionExternalId` to only return the
mandate details and avoid conflicting cols of `id` and `external_id`.