### PR TITLE
Remove dependency-check plugin from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
         <mockito.version>2.26.0</mockito.version>
         <pay-java-commons.version>1.0.20190318073600</pay-java-commons.version>
         <surefire.version>2.22.1</surefire.version>
-        <dependency-check.skip>true</dependency-check.skip>
     </properties>
 
     <repositories>
@@ -379,31 +378,6 @@
                         <argument>src/main/resources/config/config.yaml</argument>
                     </arguments>
                 </configuration>
-            </plugin>
-            <!--
-                https://jeremylong.github.io/DependencyCheck/dependency-check-maven/
-                By default, the dependency-check plugin is tied to the verify phase
-                (when used as a build plugin). We don’t want this; we just want to
-                run it manually when required. So we define a property called
-                dependency-check.skip, set it to true, and use this property’s value
-                to set the dependency-check plugin’s own skip property. To execute
-                the plugin manually, override the dependency-check.skip property:
-                $ mvn dependency-check:check -Ddependency-check.skip=false
-            -->
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>4.0.2</version>
-                <configuration>
-                    <skip>${dependency-check.skip}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
We only ever run this manually, which we can do without it being in the POM:

```
$ mvn org.owasp:dependency-check-maven:check
```