### PR TITLE
PP-5142 Include error_identifier in error responses

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/exception/BadRequestExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/BadRequestExceptionMapper.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.directdebit.common.exception;
 
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
+import uk.gov.pay.directdebit.common.model.ErrorResponse;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -16,7 +17,7 @@ public class BadRequestExceptionMapper implements ExceptionMapper<BadRequestExce
     @Override
     public Response toResponse(BadRequestException exception) {
         LOGGER.error(exception.getMessage());
-        ImmutableMap<String, String> entity = ImmutableMap.of("message", exception.getMessage());
-        return Response.status(400).entity(entity).type(APPLICATION_JSON).build();
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        return Response.status(400).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/InternalServerErrorExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/InternalServerErrorExceptionMapper.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.directdebit.common.exception;
 
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
+import uk.gov.pay.directdebit.common.model.ErrorResponse;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -16,7 +17,7 @@ public class InternalServerErrorExceptionMapper implements ExceptionMapper<Inter
     @Override
     public Response toResponse(InternalServerErrorException exception) {
         LOGGER.error(exception.getMessage());
-        ImmutableMap<String, String> entity = ImmutableMap.of("message", exception.getMessage());
-        return Response.status(500).entity(entity).type(APPLICATION_JSON).build();
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        return Response.status(500).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/JsonMappingExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/JsonMappingExceptionMapper.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.directdebit.common.exception;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
+import uk.gov.pay.directdebit.common.model.ErrorResponse;
 
 import javax.annotation.Priority;
 import javax.ws.rs.core.Response;
@@ -19,7 +20,7 @@ public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingEx
     @Override
     public Response toResponse(JsonMappingException exception) {
         LOGGER.error(exception.getMessage());
-        ImmutableMap<String, String> entity = ImmutableMap.of("message", exception.getMessage());
-        return Response.status(400).entity(entity).type(APPLICATION_JSON).build();
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        return Response.status(400).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/NotFoundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/NotFoundExceptionMapper.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.directdebit.common.exception;
 
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
+import uk.gov.pay.directdebit.common.model.ErrorResponse;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -16,7 +17,7 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
     @Override
     public Response toResponse(NotFoundException exception) {
         LOGGER.error(exception.getMessage());
-        ImmutableMap<String, String> entity = ImmutableMap.of("message", exception.getMessage());
-        return Response.status(404).entity(entity).type(APPLICATION_JSON).build();
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        return Response.status(404).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedExceptionMapper.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.directdebit.common.exception;
 
-import com.google.common.collect.ImmutableMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
+import uk.gov.pay.directdebit.common.model.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -15,7 +17,7 @@ public class PreconditionFailedExceptionMapper implements ExceptionMapper<Precon
     @Override
     public Response toResponse(PreconditionFailedException exception) {
         LOGGER.error(exception.getMessage());
-        ImmutableMap<String, String> entity = ImmutableMap.of("message", exception.getMessage());
-        return Response.status(412).entity(entity).type(APPLICATION_JSON).build();
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        return Response.status(412).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/model/ErrorIdentifier.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/ErrorIdentifier.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.directdebit.common.model;
+
+public enum ErrorIdentifier {
+    GENERIC
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/model/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/ErrorResponse.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.directdebit.common.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public class ErrorResponse {
+    
+    @JsonProperty("error_identifier")
+    private final ErrorIdentifier identifier;
+    
+    @JsonProperty("message")
+    private final List<String> messages;
+    
+    public ErrorResponse(ErrorIdentifier identifier, List<String> messages) {
+        this.identifier = identifier;
+        this.messages = messages;
+    }
+
+    public ErrorResponse(ErrorIdentifier identifier, String message) {
+        this(identifier, List.of(message));
+    }
+
+    public ErrorIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
@@ -28,6 +29,8 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -343,7 +346,8 @@ public class GatewayAccountResourceIT {
                 .then()
                 .contentType(JSON)
                 .statusCode(400)
-                .body("message", Matchers.containsString("Unsupported payment provider: INVALID"));
+                .body("message", contains(containsString("Unsupported payment provider: INVALID")))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -13,6 +13,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
@@ -47,6 +48,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -214,7 +216,8 @@ public class MandateResourceIT {
                 .then()
                 .statusCode(Status.PRECONDITION_FAILED.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("Invalid operation on mandate of type ONE_OFF"));
+                .body("message", contains("Invalid operation on mandate of type ONE_OFF"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/resources/PayerResourceIT.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
@@ -26,6 +27,7 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
@@ -78,9 +80,9 @@ public class PayerResourceIT {
         response
                 .header("Location", is(documentLocation))
                 .body("payer_external_id", is(createdPayerExternalId))
-                .contentType(JSON);  
+                .contentType(JSON);
     }
-    
+
     @Test
     public void shouldCreateAPayer() throws JsonProcessingException {
         createPayerFor(SANDBOX);
@@ -116,7 +118,8 @@ public class PayerResourceIT {
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("Field(s) missing: [account_number]"));
+                .body("message", contains("Field(s) missing: [account_number]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -135,7 +138,8 @@ public class PayerResourceIT {
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("Field(s) missing: [sort_code]"));
+                .body("message", contains("Field(s) missing: [sort_code]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private RequestSpecification givenSetup() {

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
@@ -24,6 +25,7 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
@@ -95,7 +97,8 @@ public class PaymentViewResourceIT {
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("Query param 'page' should be a non zero positive integer"));
+                .body("message", contains("Query param 'page' should be a non zero positive integer"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -110,7 +113,8 @@ public class PaymentViewResourceIT {
                 .then()
                 .statusCode(Response.Status.NOT_FOUND.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("Unknown gateway account: non-existent-id"));
+                .body("message", contains("Unknown gateway account: non-existent-id"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -139,7 +143,7 @@ public class PaymentViewResourceIT {
                 .contentType(JSON)
                 .body("results", hasSize(0));
     }
-    
+
     @Test
     public void shouldReturn5Records_whenPaginationSetTo2PageAnd10DisplaySizeWith15records_withDateRange10days() {
         ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC).minusDays(1L);
@@ -238,7 +242,8 @@ public class PaymentViewResourceIT {
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("Input toDate (2018-14-08T15:00Z) is wrong format"));
+                .body("message", contains("Input toDate (2018-14-08T15:00Z) is wrong format"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -321,9 +326,9 @@ public class PaymentViewResourceIT {
                 .contentType(JSON)
                 .body("results", hasSize(6));
     }
-    
+
     @Test
-    public void shouldReturn3Records_whenSearchingByMandateId(){
+    public void shouldReturn3Records_whenSearchingByMandateId() {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());
@@ -348,7 +353,7 @@ public class PaymentViewResourceIT {
                 .withName("J. Doe")
                 .insert(testContext.getJdbi());
         for (int i = 0; i < 6; i++) {
-            if (i%2 == 0) {
+            if (i % 2 == 0) {
                 aTransactionFixture()
                         .withMandateFixture(mandateFixture2)
                         .insert(testContext.getJdbi());
@@ -373,7 +378,7 @@ public class PaymentViewResourceIT {
     }
 
     @Test
-    public void shouldReturn6Records_whenSearchingByFailedExternalState(){
+    public void shouldReturn6Records_whenSearchingByFailedExternalState() {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
@@ -14,6 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
@@ -46,6 +47,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
@@ -306,9 +308,9 @@ public class TransactionResourceIT {
                 .body(postBody)
                 .post(requestPath)
                 .then()
-                .body("message", containsString("Invalid operation"))
                 .statusCode(Status.PRECONDITION_FAILED.getStatusCode())
-                .contentType(JSON);
+                .contentType(JSON)
+                .body("message", contains(containsString("Invalid operation")));
     }
 
     @Test
@@ -403,7 +405,8 @@ public class TransactionResourceIT {
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("Field(s) missing: [reference]"));
+                .body("message", contains("Field(s) missing: [reference]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -426,7 +429,8 @@ public class TransactionResourceIT {
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("The size of a field(s) is invalid: [description]"));
+                .body("message", contains("The size of a field(s) is invalid: [description]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -448,7 +452,8 @@ public class TransactionResourceIT {
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("Field(s) are invalid: [amount]"));
+                .body("message", contains("Field(s) are invalid: [amount]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private TransactionFixture createTransactionFixtureWith(MandateFixture mandateFixture, PaymentState paymentState) {


### PR DESCRIPTION
- Make it so that all error responses include a "message" field, the value of which is an array of strings and and "error_identifier" field.
- For now, the "error_identifier" is always GENERIC.

- The ErrorIdentifier enum has been created here for now, but will be moved to pay-java-commons.
