### PR TITLE
PP-5142 Add error_identifier for InvalidMandateTypeException

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedException.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedException.java
@@ -1,8 +1,17 @@
 package uk.gov.pay.directdebit.common.exception;
 
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
+
 public class PreconditionFailedException extends RuntimeException {
 
-    public PreconditionFailedException(String message) {
+    private ErrorIdentifier errorIdentifier;
+
+    public PreconditionFailedException(String message, ErrorIdentifier errorIdentifier) {
         super(message);
+        this.errorIdentifier = errorIdentifier;
+    }
+
+    public ErrorIdentifier getErrorIdentifier() {
+        return errorIdentifier;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/PreconditionFailedExceptionMapper.java
@@ -17,7 +17,7 @@ public class PreconditionFailedExceptionMapper implements ExceptionMapper<Precon
     @Override
     public Response toResponse(PreconditionFailedException exception) {
         LOGGER.error(exception.getMessage());
-        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorIdentifier(), exception.getMessage());
         return Response.status(412).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/model/ErrorIdentifier.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/ErrorIdentifier.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.common.model;
 
 public enum ErrorIdentifier {
-    GENERIC
+    GENERIC,
+    INVALID_MANDATE_TYPE
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/InvalidMandateTypeException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/InvalidMandateTypeException.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.payments.exception;
 
 import uk.gov.pay.directdebit.common.exception.PreconditionFailedException;
+import uk.gov.pay.directdebit.common.model.ErrorIdentifier;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 
@@ -9,10 +10,10 @@ import static java.lang.String.format;
 public class InvalidMandateTypeException extends PreconditionFailedException {
 
     public InvalidMandateTypeException(MandateExternalId externalId, MandateType mandateType) {
-        super(format("Invalid operation on mandate with id %s of type %s", externalId, mandateType.toString()));
+        super(format("Invalid operation on mandate with id %s of type %s", externalId, mandateType.toString()), ErrorIdentifier.INVALID_MANDATE_TYPE);
     }
 
     public InvalidMandateTypeException(MandateType mandateType) {
-        super(format("Invalid operation on mandate of type %s", mandateType.toString()));
+        super(format("Invalid operation on mandate of type %s", mandateType.toString()), ErrorIdentifier.INVALID_MANDATE_TYPE);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -217,7 +217,7 @@ public class MandateResourceIT {
                 .statusCode(Status.PRECONDITION_FAILED.getStatusCode())
                 .contentType(JSON)
                 .body("message", contains("Invalid operation on mandate of type ONE_OFF"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.INVALID_MANDATE_TYPE.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
@@ -310,7 +310,8 @@ public class TransactionResourceIT {
                 .then()
                 .statusCode(Status.PRECONDITION_FAILED.getStatusCode())
                 .contentType(JSON)
-                .body("message", contains(containsString("Invalid operation")));
+                .body("message", contains(containsString("Invalid operation")))
+                .body("error_identifier", is(ErrorIdentifier.INVALID_MANDATE_TYPE.toString()));
     }
 
     @Test


### PR DESCRIPTION
- Public API handles precondition failed responses from some endpoints by assuming these are because the mandate type is invalid. Add in an error_identifier for these responses so that Public API can be sure of this rather than making assumptions.