### PR TITLE
Remove parameters from the maven surefire plugin

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -4,5 +4,5 @@ set -e
 
 cd "$(dirname "$0")"
 
-mvn -DskipITs clean package
+mvn -DskipITs clean verify
 docker build -t govukpay/directdebit-connector:local .

--- a/pom.xml
+++ b/pom.xml
@@ -299,10 +299,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
-                <configuration>
-                    <junitArtifactName>junit:junit</junitArtifactName>
-                    <testFailureIgnore>false</testFailureIgnore>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
These parameters were being set to their default values, so we don't need to
set them. See
http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html

Also, correct the maven target for local builds - `verify` is the catch-all maven target so we should use that instead of just `package`. This matches what CI does.