### PR TITLE
PP-5231 Remove unused methods from MandateExternalId

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
@@ -89,7 +89,7 @@ public class MandateMapper implements RowMapper<Mandate> {
                 resultSet.getLong(ID_COLUMN),
                 gatewayAccount,
                 MandateType.valueOf(resultSet.getString(MANDATE_TYPE_COLUMN)),
-                MandateExternalId.of(resultSet.getString(EXTERNAL_ID_COLUMN)),
+                MandateExternalId.valueOf(resultSet.getString(EXTERNAL_ID_COLUMN)),
                 resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN),
                 resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN),
                 MandateState.valueOf(resultSet.getString(STATE_COLUMN)),

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/subtype/MandateExternalId.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/subtype/MandateExternalId.java
@@ -10,35 +10,26 @@ public class MandateExternalId {
         this.mandateExternalId = Objects.requireNonNull(mandateExternalId);
     }
 
-    public static MandateExternalId of(String mandateExternalId) {
-        return new MandateExternalId(mandateExternalId);
-    }
-
     public static MandateExternalId valueOf(String mandateExternalId) {
-        return MandateExternalId.of(mandateExternalId);
-    }
-
-    public String getMandateExternalId() {
-        return mandateExternalId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        MandateExternalId that = (MandateExternalId) o;
-        return Objects.equals(mandateExternalId, that.mandateExternalId);
-    }
-
-    @Override
-    public int hashCode() {
-
-        return Objects.hash(mandateExternalId);
+        return new MandateExternalId(mandateExternalId);
     }
 
     @Override
     public String toString() {
         return mandateExternalId;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        MandateExternalId that = (MandateExternalId) other;
+        return mandateExternalId.equals(that.mandateExternalId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mandateExternalId);
     }
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -84,7 +84,7 @@ public class MandateService {
                             null,
                             gatewayAccount,
                             createRequest.getMandateType(),
-                            MandateExternalId.of(RandomIdGenerator.newId()),
+                            MandateExternalId.valueOf(RandomIdGenerator.newId()),
                             mandateReference,
                             createRequest.getReference(),
                             MandateState.CREATED,

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequest.java
@@ -28,7 +28,7 @@ public class CollectPaymentRequest implements CollectRequest {
 
     public static CollectPaymentRequest of(Map<String, String> collectPaymentRequest) {
         return new CollectPaymentRequest(
-                MandateExternalId.of(collectPaymentRequest.get("agreement_id")),
+                MandateExternalId.valueOf(collectPaymentRequest.get("agreement_id")),
                 Long.valueOf(collectPaymentRequest.get("amount")),
                 collectPaymentRequest.get("description"),
                 collectPaymentRequest.get("reference")

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -96,7 +96,7 @@ public class TransactionMapper implements RowMapper<Transaction> {
                 resultSet.getLong(MANDATE_ID_COLUMN),
                 gatewayAccount,
                 MandateType.valueOf(resultSet.getString(MANDATE_TYPE_COLUMN)),
-                MandateExternalId.of(resultSet.getString(MANDATE_EXTERNAL_ID_COLUMN)),
+                MandateExternalId.valueOf(resultSet.getString(MANDATE_EXTERNAL_ID_COLUMN)),
                 resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN),
                 resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN),
                 MandateState.valueOf(resultSet.getString(MANDATE_STATE_COLUMN)),

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -57,7 +57,7 @@ public class MandateDaoIT {
                         null,
                         gatewayAccountFixture.toEntity(),
                         MandateType.ONE_OFF,
-                        MandateExternalId.of(RandomIdGenerator.newId()),
+                        MandateExternalId.valueOf(RandomIdGenerator.newId()),
                         "test-reference",
                         null,
                         MandateState.PENDING,
@@ -85,7 +85,7 @@ public class MandateDaoIT {
                         null,
                         gatewayAccountFixture.toEntity(),
                         MandateType.ONE_OFF,
-                        MandateExternalId.of(RandomIdGenerator.newId()),
+                        MandateExternalId.valueOf(RandomIdGenerator.newId()),
                         "test-reference",
                         "test-service-reference",
                         MandateState.PENDING,
@@ -174,7 +174,7 @@ public class MandateDaoIT {
 
     @Test
     public void shouldNotFindAMandateByExternalId_ifExternalIdIsInvalid() {
-        MandateExternalId invalidMandateId = MandateExternalId.of("invalid1d");
+        MandateExternalId invalidMandateId = MandateExternalId.valueOf("invalid1d");
         assertThat(mandateDao.findByExternalId(invalidMandateId), is(Optional.empty()));
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime;
 public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
 
     private Long id = RandomUtils.nextLong(1, 99999);
-    private MandateExternalId mandateExternalId = MandateExternalId.of(RandomIdGenerator.newId());
+    private MandateExternalId mandateExternalId = MandateExternalId.valueOf(RandomIdGenerator.newId());
     private String mandateReference = RandomStringUtils.randomAlphanumeric(18);
     private String serviceReference = RandomStringUtils.randomAlphanumeric(18);
     private MandateState state = MandateState.CREATED;

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -126,7 +126,7 @@ public class MandateResourceIT {
                 .body("return_url", is(returnUrl))
                 .body("created_date", is(notNullValue()))
                 .contentType(JSON);
-        MandateExternalId externalMandateId = MandateExternalId.of(response.extract().path(JSON_MANDATE_ID_KEY).toString());
+        MandateExternalId externalMandateId = MandateExternalId.valueOf(response.extract().path(JSON_MANDATE_ID_KEY).toString());
 
         String documentLocation = expectedMandateLocationFor(accountExternalId, externalMandateId);
         String token = testContext.getDatabaseTestHelper().getTokenByMandateExternalId(externalMandateId).get("secure_redirect_token").toString();
@@ -179,7 +179,7 @@ public class MandateResourceIT {
                 .body("service_reference", is("test-service-reference"))
                 .body("mandate_reference", is(notNullValue()))
                 .contentType(JSON);
-        MandateExternalId externalMandateId = MandateExternalId.of(response.extract().path(JSON_MANDATE_ID_KEY).toString());
+        MandateExternalId externalMandateId = MandateExternalId.valueOf(response.extract().path(JSON_MANDATE_ID_KEY).toString());
 
         String documentLocation = expectedMandateLocationFor(accountExternalId, externalMandateId);
         String token = testContext.getDatabaseTestHelper().getTokenByMandateExternalId(externalMandateId).get("secure_redirect_token").toString();

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -64,7 +64,7 @@ public class PublicApiContractTest {
     @State("a gateway account with external id and a mandate with external id exist")
     public void aGatewayAccountWithExternalIdAndAMandateWithExternalIdExist(Map<String, String> params) {
         testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
-        testMandate.withGatewayAccountFixture(testGatewayAccount).withExternalId(MandateExternalId.of(params.get("mandate_id"))).insert(app.getTestContext().getJdbi());
+        testMandate.withGatewayAccountFixture(testGatewayAccount).withExternalId(MandateExternalId.valueOf(params.get("mandate_id"))).insert(app.getTestContext().getJdbi());
     }
 
     @State("three transaction records exist")
@@ -72,7 +72,7 @@ public class PublicApiContractTest {
         testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
         MandateFixture testMandate = MandateFixture.aMandateFixture()
                 .withGatewayAccountFixture(testGatewayAccount)
-                .withExternalId(MandateExternalId.of(params.get("agreement_id")));
+                .withExternalId(MandateExternalId.valueOf(params.get("agreement_id")));
         testMandate.insert(app.getTestContext().getJdbi());
         PayerFixture testPayer = PayerFixture.aPayerFixture().withMandateId(testMandate.getId());
         testPayer.insert(app.getTestContext().getJdbi());
@@ -85,7 +85,7 @@ public class PublicApiContractTest {
     public void aDirectDebitEventExists(Map<String, String> params) {
 
         String transactionExternalId = params.getOrDefault("transaction_external_id", RandomIdGenerator.newId());
-        MandateExternalId mandateExternalId = MandateExternalId.of(params.getOrDefault("mandate_external_id", RandomIdGenerator.newId()));
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf(params.getOrDefault("mandate_external_id", RandomIdGenerator.newId()));
 
         GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()
                 .insert(app.getTestContext().getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/payers/services/PayerServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/services/PayerServiceTest.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.directdebit.payers.services;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,14 +11,17 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.mandate.exception.PayerNotFoundException;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
-import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
+import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
 import uk.gov.pay.directdebit.mandate.services.MandateServiceFactory;
 import uk.gov.pay.directdebit.mandate.services.MandateStateUpdateService;
 import uk.gov.pay.directdebit.payers.api.PayerParser;
 import uk.gov.pay.directdebit.payers.dao.PayerDao;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payers.model.Payer;
+
+import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -55,7 +56,7 @@ public class PayerServiceTest {
             "account_number", ACCOUNT_NUMBER,
             "bank_name", BANK_NAME
     );
-    private MandateExternalId mandateExternalId = MandateExternalId.of("sdkfhsdkjfhjdks");
+    private MandateExternalId mandateExternalId = MandateExternalId.valueOf("sdkfhsdkjfhjdks");
 
     private Payer payer = PayerFixture.aPayerFixture()
             .withName("mr payment").toEntity();

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
@@ -1,10 +1,5 @@
 package uk.gov.pay.directdebit.payments.dao;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +16,11 @@ import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.PaymentView;
 import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
 import uk.gov.pay.directdebit.payments.params.SearchDateParams;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -264,8 +264,8 @@ public class PaymentViewDaoIT {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());
-        MandateExternalId mandateExternalId = MandateExternalId.of("a-mandate-external-id");
-        MandateExternalId anotherMandateExternalId = MandateExternalId.of("another-external-id");
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf("a-mandate-external-id");
+        MandateExternalId anotherMandateExternalId = MandateExternalId.valueOf("another-external-id");
         MandateFixture mandateFixture1 = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withExternalId(mandateExternalId)
@@ -309,7 +309,7 @@ public class PaymentViewDaoIT {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());
-        MandateExternalId mandateExternalId = MandateExternalId.of("a-mandate-external-id");
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf("a-mandate-external-id");
         MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withExternalId(mandateExternalId)
@@ -340,7 +340,7 @@ public class PaymentViewDaoIT {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());
-        MandateExternalId mandateExternalId = MandateExternalId.of("a-mandate-external-id");
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf("a-mandate-external-id");
         MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withExternalId(mandateExternalId)
@@ -371,7 +371,7 @@ public class PaymentViewDaoIT {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());
-        MandateExternalId mandateExternalId = MandateExternalId.of("a-mandate-external-id");
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf("a-mandate-external-id");
         MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withExternalId(mandateExternalId)
@@ -402,7 +402,7 @@ public class PaymentViewDaoIT {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());
-        MandateExternalId mandateExternalId = MandateExternalId.of("a-mandate-external-id");
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf("a-mandate-external-id");
         MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withExternalId(mandateExternalId)
@@ -433,7 +433,7 @@ public class PaymentViewDaoIT {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());
-        MandateExternalId mandateExternalId = MandateExternalId.of("a-mandate-external-id");
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf("a-mandate-external-id");
         MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withExternalId(mandateExternalId)

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
@@ -332,8 +332,8 @@ public class PaymentViewResourceIT {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());
-        MandateExternalId mandateExternalId = MandateExternalId.of("a-mandate-external-id");
-        MandateExternalId anotherMandateExternalId = MandateExternalId.of("another-external-id");
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf("a-mandate-external-id");
+        MandateExternalId anotherMandateExternalId = MandateExternalId.valueOf("another-external-id");
         MandateFixture mandateFixture1 = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withExternalId(mandateExternalId)
@@ -382,7 +382,7 @@ public class PaymentViewResourceIT {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withExternalId("gateway-external-id")
                 .insert(testContext.getJdbi());
-        MandateExternalId mandateExternalId = MandateExternalId.of("a-mandate-external-id");
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf("a-mandate-external-id");
         MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withExternalId(mandateExternalId)

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/TransactionResourceIT.java
@@ -140,7 +140,7 @@ public class TransactionResourceIT {
         assertThat(createdMandate.get("return_url"), is(returnUrl));
         assertThat(createdMandate.get("gateway_account_id"), is(testGatewayAccount.getId()));
 
-        MandateExternalId mandateExternalId = MandateExternalId.of((String) createdMandate.get("external_id"));
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf((String) createdMandate.get("external_id"));
         List<Map<String, Object>> createdTransactions = testContext.getDatabaseTestHelper().getTransactionsForMandate(mandateExternalId);
         assertThat(createdTransactions.size(), is(1));
         assertThat(createdTransactions.get(0).get("payer"), is(nullValue()));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -51,7 +51,7 @@ public abstract class GoCardlessServiceTest {
 
     static final String CUSTOMER_ID = "CU328471";
     static final String BANK_ACCOUNT_ID = "BA34983496";
-    static final MandateExternalId MANDATE_ID = MandateExternalId.of("sdkfhsdkjfhjdks");
+    static final MandateExternalId MANDATE_ID = MandateExternalId.valueOf("sdkfhsdkjfhjdks");
     static final String TRANSACTION_ID = "sdkfhsd2jfhjdks";
     static final SortCode SORT_CODE = SortCode.of("123456");
     static final AccountNumber ACCOUNT_NUMBER = AccountNumber.of("12345678");


### PR DESCRIPTION
`of(…)` and `valueOf(…)` did the same thing — standardise on `valueOf()` because the default parameter conversion code used by JAX-RS looks for a `valueOf(String)` method and it’s easier to submit to its conventions than to add a `ParamConverter`.

