### PR TITLE
PP-5232 Remove reliance on exception to control logic

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
@@ -14,6 +14,8 @@ import uk.gov.pay.directdebit.payments.services.DirectDebitEventService;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_ACTIVE;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_CANCELLED;

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitStatesGraph.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitStatesGraph.java
@@ -5,6 +5,7 @@ import com.google.common.graph.MutableValueGraph;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 public abstract class DirectDebitStatesGraph<T extends DirectDebitState> {
@@ -31,11 +32,10 @@ public abstract class DirectDebitStatesGraph<T extends DirectDebitState> {
         return priorStates;
     }
 
-    public T getNextStateForEvent(T from, DirectDebitEvent.SupportedEvent event) {
+    public Optional<T> getNextStateForEvent(T from, DirectDebitEvent.SupportedEvent event) {
         return graphStates.successors(from).stream()
                 .filter(to -> isValidTransition(from, to, event))
-                .findFirst()
-                .orElseThrow(() -> new InvalidStateTransitionException(event.toString(), from.toString()));
+                .findFirst();
     }
 
     protected void addNodes(MutableValueGraph<T, DirectDebitEvent.SupportedEvent> graph, T[] values) {

--- a/src/test/java/uk/gov/pay/directdebit/mandate/model/MandateStatesGraphTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/model/MandateStatesGraphTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -34,15 +35,12 @@ public class MandateStatesGraphTest {
 
     @Test
     public void getNextStateForEvent_shouldGiveTheNextStateIfEventIsValid() {
-        assertThat(mandateStatesGraph.getNextStateForEvent(PENDING, MANDATE_ACTIVE), is(MandateState.ACTIVE));
+        assertThat(mandateStatesGraph.getNextStateForEvent(PENDING, MANDATE_ACTIVE), is(Optional.of(MandateState.ACTIVE)));
     }
 
     @Test
-    public void getNextStateForEvent_shouldThrowExceptionIfTransitionIsInvalid() {
-        thrown.expect(InvalidStateTransitionException.class);
-        thrown.expectMessage("Transition MANDATE_ACTIVE from state FAILED is not valid");
-        thrown.reportMissingExceptionWithMessage("InvalidStateTransitionException expected");
-        mandateStatesGraph.getNextStateForEvent(FAILED, MANDATE_ACTIVE);
+    public void getNextStateForEvent_shouldReturnEmptyIfTransitionIsInvalid() {
+        assertThat(mandateStatesGraph.getNextStateForEvent(FAILED, MANDATE_ACTIVE), is(Optional.empty()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/OneOffMandateServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payments.api.CreatePaymentRequest;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
+import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
 import uk.gov.pay.directdebit.payments.model.Transaction;
 import uk.gov.pay.directdebit.payments.services.SandboxService;
@@ -85,6 +86,7 @@ public class OneOffMandateServiceTest {
                 mandateConfirmationRequest.getTransactionExternalId())).thenReturn(transaction);
         when(mockedSandboxService.confirmOneOffMandate(mandate, bankAccountDetails, transaction))
                 .thenReturn(oneOffConfirmationDetails);
+        when(mockedMandateStateUpdateService.canUpdateStateFor(mandate, DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED)).thenReturn(true);
         service.confirm(gatewayAccountFixture.toEntity(), mandate, mandateConfirmationRequest);
 
         verify(mockedMandateStateUpdateService).confirmedOneOffDirectDebitDetailsFor(mandate);

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraphTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/PaymentStatesGraphTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
 
+import java.util.Optional;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.CHARGE_CREATED;
@@ -30,15 +32,12 @@ public class PaymentStatesGraphTest {
 
     @Test
     public void getNextStateForEvent_shouldGiveTheNextStateIfEventIsValid() {
-        assertThat(paymentStatesGraph.getNextStateForEvent(NEW, PAYMENT_SUBMITTED_TO_PROVIDER), is(PaymentState.PENDING));
+        assertThat(paymentStatesGraph.getNextStateForEvent(NEW, PAYMENT_SUBMITTED_TO_PROVIDER), is(Optional.of(PaymentState.PENDING)));
     }
 
     @Test
-    public void getNextStateForEvent_shouldThrowExceptionIfTransitionIsInvalid() {
-        thrown.expect(InvalidStateTransitionException.class);
-        thrown.expectMessage("Transition CHARGE_CREATED from state NEW is not valid");
-        thrown.reportMissingExceptionWithMessage("InvalidStateTransitionException expected");
-        paymentStatesGraph.getNextStateForEvent(NEW, CHARGE_CREATED);
+    public void getNextStateForEvent_shouldReturnEmptyIfTransitionIsInvalid() {
+        assertThat(paymentStatesGraph.getNextStateForEvent(NEW, CHARGE_CREATED), is(Optional.empty()));
     }
 
     @Test


### PR DESCRIPTION
- Make `DirectDebitStatesGraph` return Optional<State> rather than throwing an
exception if no next state can be found. This exception was being relied upon
to control logic with confusing methods such as `void canUpdateStateFor` which
appears to be asking a question but with a return type of `void` was relying upon
the exception being thrown deeper down.
- Move the throwing of exception higher in the call stack and in the context of
the check that was being performed. e.g canUpdateState() ? do something : throw exception.