### PR TITLE
PP-5232 Remove collect method from OnDemandMandateService

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateService.java
@@ -59,23 +59,6 @@ public class OnDemandMandateService implements MandateCommandService {
         }
     }
 
-    public Transaction collect(GatewayAccount gatewayAccount, Mandate mandate,
-            CollectPaymentRequest collectPaymentRequest) {
-        if (MandateType.ONE_OFF.equals(mandate.getType())) {
-            throw new InvalidMandateTypeException(mandate.getExternalId(), MandateType.ONE_OFF);
-        }
-        Transaction transaction = transactionService.createTransaction(
-                collectPaymentRequest,
-                mandate,
-                gatewayAccount.getExternalId());
-        
-        LocalDate chargeDate = paymentProviderFactory
-                .getCommandServiceFor(gatewayAccount.getPaymentProvider())
-                .collect(mandate, transaction);
-        transactionService.onDemandPaymentSubmittedToProviderFor(transaction, chargeDate);
-        return transaction;
-    }
-
     public CreateMandateResponse create(GatewayAccount gatewayAccount, CreateMandateRequest createMandateRequest,
             UriInfo uriInfo) {
         if (MandateType.ONE_OFF.equals(createMandateRequest.getMandateType())) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/TransactionResource.java
@@ -82,7 +82,7 @@ public class TransactionResource {
         Mandate mandate = mandateServiceFactory
                 .getMandateQueryService()
                 .findByExternalId(collectPaymentRequest.getMandateExternalId());
-        Transaction paymentToCollect = mandateServiceFactory.getOnDemandMandateService().collect(gatewayAccount, mandate, collectPaymentRequest);
+        Transaction paymentToCollect = transactionService.createOnDemandTransaction(gatewayAccount, mandate, collectPaymentRequest);
         CollectPaymentResponse response = transactionService.collectPaymentResponseWithSelfLink(paymentToCollect, gatewayAccount.getExternalId(), uriInfo);
         return created(response.getLink("self")).entity(response).build();
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/OnDemandMandateServiceTest.java
@@ -103,26 +103,4 @@ public class OnDemandMandateServiceTest {
 
         service.confirm(gatewayAccountFixture.toEntity(), mandate, mandateConfirmationRequest);
     }
-
-    @Test
-    public void collect_shouldCreateATransactionAPaymentAndRegisterOnDemandPaymentSubmittedEvent() {
-        Transaction transaction = TransactionFixture.aTransactionFixture().withMandateFixture(mandateFixture).toEntity();
-        Mandate mandate = mandateFixture.toEntity();
-        CollectPaymentRequest collectPaymentRequest = new CollectPaymentRequest(
-                mandateFixture.getExternalId(),
-                123456L,
-                "a description",
-                "a reference"
-        );
-        LocalDate chargeDate = LocalDate.parse("1987-11-16");
-        when(mockedTransactionService
-                .createTransaction(collectPaymentRequest, mandate, gatewayAccountFixture.getExternalId()))
-                .thenReturn(transaction);
-        when(mockedSandboxService.collect(mandate, transaction)).thenReturn(chargeDate);
-
-        service.collect(gatewayAccountFixture.toEntity(), mandate, collectPaymentRequest);
-
-        verify(mockedTransactionService).onDemandPaymentSubmittedToProviderFor(transaction, chargeDate);
-    }
-
 }


### PR DESCRIPTION
- The collect method belongs in the TransactionService as it returns a Transaction
and deals primarily with TransactionService methods.
- This removes a key difference between the OnDemandMandateService and
the OneOffMandateService and will help to bring these two classes together, they
now contain only two methods of the same name.
- Transfer test of collect method to TransactionServiceTest.
- Rename collect method to createOnDemandTransaction to align with naming
convention within TransactionService and be more descriptive.