### PR TITLE
PP-5231 Rationalise methods in GoCardlessCreditorId

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
@@ -55,7 +55,7 @@ public class GoCardlessClientFacade {
                 mandate.getId(),
                 gcMandate.getId(),
                 gcMandate.getReference(),
-                GoCardlessCreditorId.of(gcMandate.getLinks().getCreditor()));
+                GoCardlessCreditorId.valueOf(gcMandate.getLinks().getCreditor()));
     }
 
     public GoCardlessPayment createPayment(Transaction transaction, GoCardlessMandate mandate) {

--- a/src/main/java/uk/gov/pay/directdebit/common/model/subtype/gocardless/creditor/GoCardlessCreditorId.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/subtype/gocardless/creditor/GoCardlessCreditorId.java
@@ -10,21 +10,20 @@ public class GoCardlessCreditorId {
         this.goCardlessCreditorId = Objects.requireNonNull(goCardlessCreditorId);
     }
 
-    public static GoCardlessCreditorId of(String goCardlessCreditorId) {
+    public static GoCardlessCreditorId valueOf(String goCardlessCreditorId) {
         return new GoCardlessCreditorId(goCardlessCreditorId);
     }
 
-    public static GoCardlessCreditorId valueOf(String goCardlessCreditorId) {
-        return GoCardlessCreditorId.of(goCardlessCreditorId);
+    @Override
+    public String toString() {
+        return goCardlessCreditorId;
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        GoCardlessCreditorId that = (GoCardlessCreditorId) o;
-
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        GoCardlessCreditorId that = (GoCardlessCreditorId) other;
         return goCardlessCreditorId.equals(that.goCardlessCreditorId);
     }
 
@@ -33,8 +32,4 @@ public class GoCardlessCreditorId {
         return goCardlessCreditorId.hashCode();
     }
 
-    @Override
-    public String toString() {
-        return goCardlessCreditorId;
-    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessMandateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessMandateMapper.java
@@ -21,6 +21,6 @@ public class GoCardlessMandateMapper implements RowMapper<GoCardlessMandate> {
                 resultSet.getLong(MANDATE_ID_COLUMN),
                 resultSet.getString(GOCARDLESS_MANDATE_ID_COLUMN),
                 null,
-                GoCardlessCreditorId.of(resultSet.getString(GOCARDLESS_CREDITOR_ID)));
+                GoCardlessCreditorId.valueOf(resultSet.getString(GOCARDLESS_CREDITOR_ID)));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
@@ -130,7 +130,7 @@ public class GoCardlessClientFacadeTest {
         given(mockSchemeIdentifier.getScheme()).willReturn(Creditor.SchemeIdentifier.Scheme.BACS);
         given(mockSchemeIdentifier.getName()).willReturn(sunName.toString());
 
-        Optional<SunName> result = goCardlessClientFacade.getSunName(GoCardlessCreditorId.of(creditorId));
+        Optional<SunName> result = goCardlessClientFacade.getSunName(GoCardlessCreditorId.valueOf(creditorId));
 
         assertThat(result, is(Optional.of(sunName)));
     }
@@ -142,14 +142,14 @@ public class GoCardlessClientFacadeTest {
         given(mockCreditor.getSchemeIdentifiers()).willReturn(Collections.singletonList(mockSchemeIdentifier));
         given(mockSchemeIdentifier.getScheme()).willReturn(Creditor.SchemeIdentifier.Scheme.SEPA);
 
-        Optional<SunName> result = goCardlessClientFacade.getSunName(GoCardlessCreditorId.of(creditorId));
+        Optional<SunName> result = goCardlessClientFacade.getSunName(GoCardlessCreditorId.valueOf(creditorId));
 
         assertThat(result, is(Optional.empty()));
     }
 
     @Test
     public void createMandateReturnsGoCardlessMandate() {
-        GoCardlessCreditorId goCardlessCreditorId = GoCardlessCreditorId.of("gocardless-test-creditor-id-here");
+        GoCardlessCreditorId goCardlessCreditorId = GoCardlessCreditorId.valueOf("gocardless-test-creditor-id-here");
         uk.gov.pay.directdebit.mandate.model.Mandate mandate =
                 MandateFixture.aMandateFixture().toEntity();
         GoCardlessCustomer goCardlessCustomer =

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDaoIT.java
@@ -33,7 +33,7 @@ public class GoCardlessMandateDaoIT {
     private MandateFixture mandateFixture;
 
     private final static String GOCARDLESS_MANDATE_ID = "NA23434";
-    private final static GoCardlessCreditorId GOCARDLESS_CREDITOR_ID = GoCardlessCreditorId.of("CREDITORID123");
+    private final static GoCardlessCreditorId GOCARDLESS_CREDITOR_ID = GoCardlessCreditorId.valueOf("CREDITORID123");
 
     private GoCardlessMandateFixture testGoCardlessMandate;
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessMandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessMandateFixture.java
@@ -12,7 +12,7 @@ public class GoCardlessMandateFixture implements DbFixture<GoCardlessMandateFixt
     private Long id = RandomUtils.nextLong(1, 99999);
     private Long mandateId = RandomUtils.nextLong(1, 99999);
     private String goCardlessMandateId = RandomIdGenerator.newId();
-    private GoCardlessCreditorId goCardlessCreditorId = GoCardlessCreditorId.of(RandomIdGenerator.newId());
+    private GoCardlessCreditorId goCardlessCreditorId = GoCardlessCreditorId.valueOf(RandomIdGenerator.newId());
 
     private GoCardlessMandateFixture() {
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessDirectDebitDirectDebitEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessDirectDebitDirectDebitEventDaoIT.java
@@ -2,10 +2,6 @@ package uk.gov.pay.directdebit.payments.dao;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.sql.Timestamp;
-import java.time.ZonedDateTime;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,6 +17,11 @@ import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.GoCardlessResourceType;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.ZonedDateTime;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -87,7 +87,7 @@ public abstract class GoCardlessServiceTest {
             .withMandateFixture(mandateFixture)
             .withExternalId(TRANSACTION_ID)
             .toEntity();
-    GoCardlessCreditorId goCardlessCreditorId = GoCardlessCreditorId.of("test_creditor_id");
+    GoCardlessCreditorId goCardlessCreditorId = GoCardlessCreditorId.valueOf("test_creditor_id");
     GoCardlessMandate goCardlessMandate =
             GoCardlessMandateFixture.aGoCardlessMandateFixture()
                     .withGoCardlessCreditorId(goCardlessCreditorId)


### PR DESCRIPTION
`of(…)` and `valueOf(…)` did the same thing — standardise on `valueOf()` because the default parameter conversion code used by JAX-RS looks for a `valueOf(String)` method and it’s easier to submit to its conventions than to add a `ParamConverter`.