### PR TITLE
PP-5231 Introduce ServiceMandateReference

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequest.java
@@ -1,8 +1,10 @@
 package uk.gov.pay.directdebit.mandate.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Map;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReference;
+
+import java.util.Map;
 
 public class CreateMandateRequest implements CreateRequest {
 
@@ -13,10 +15,10 @@ public class CreateMandateRequest implements CreateRequest {
     private MandateType mandateType;
 
     @JsonProperty("service_reference")
-    private String reference;
+    private ServiceMandateReference reference;
 
     private CreateMandateRequest(String returnUrl,
-            MandateType mandateType, String reference) {
+            MandateType mandateType, ServiceMandateReference reference) {
         this.returnUrl = returnUrl;
         this.mandateType = mandateType;
         this.reference = reference;
@@ -26,7 +28,7 @@ public class CreateMandateRequest implements CreateRequest {
         return new CreateMandateRequest(
                 createMandateRequest.get("return_url"),
                 MandateType.fromString(createMandateRequest.get("agreement_type")),
-                createMandateRequest.get("service_reference")
+                ServiceMandateReference.valueOf(createMandateRequest.get("service_reference"))
         );
     }
 
@@ -39,6 +41,6 @@ public class CreateMandateRequest implements CreateRequest {
     }
 
     public String getReference() {
-        return reference;
+        return reference.toString();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReference;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 
 import java.net.URI;
@@ -40,7 +41,8 @@ public class CreateMandateResponse {
     private ExternalMandateState state;
 
     @JsonProperty("service_reference")
-    private String serviceReference;
+    @JsonSerialize(using = ToStringSerializer.class)
+    private ServiceMandateReference serviceReference;
 
     @JsonProperty("mandate_reference")
     private String mandateReference;
@@ -51,7 +53,7 @@ public class CreateMandateResponse {
                                  ZonedDateTime createdDate,
                                  ExternalMandateState state,
                                  List<Map<String, Object>> dataLinks,
-                                 String serviceReference,
+                                 ServiceMandateReference serviceReference,
                                  String mandateReference) {
         this.dataLinks = dataLinks;
         this.mandateId = mandateId;
@@ -83,7 +85,7 @@ public class CreateMandateResponse {
         return state;
     }
 
-    public String getServiceReference() {
+    public ServiceMandateReference getServiceReference() {
         return serviceReference;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/GetMandateResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/GetMandateResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReference;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 
 import java.util.List;
@@ -33,7 +34,8 @@ public class GetMandateResponse {
     private ExternalMandateState state;
 
     @JsonProperty("service_reference")
-    private String serviceReference;
+    @JsonSerialize(using = ToStringSerializer.class)
+    private ServiceMandateReference serviceReference;
 
     @JsonProperty("mandate_reference")
     private String mandateReference;
@@ -42,7 +44,7 @@ public class GetMandateResponse {
                               MandateType mandateType, String returnUrl,
                               List<Map<String, Object>> dataLinks,
                               ExternalMandateState state,
-                              String serviceReference,
+                              ServiceMandateReference serviceReference,
                               String mandateReference) {
         this.mandateId = mandateId;
         this.mandateType = mandateType;
@@ -73,7 +75,7 @@ public class GetMandateResponse {
         return state;
     }
 
-    public String getServiceReference() {
+    public ServiceMandateReference getServiceReference() {
         return serviceReference;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -11,6 +11,7 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.mandate.dao.mapper.MandateMapper;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReferenceArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalIdArgumentFactory;
 
@@ -20,6 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 
 @RegisterArgumentFactory(MandateExternalIdArgumentFactory.class)
+@RegisterArgumentFactory(ServiceMandateReferenceArgumentFactory.class)
 @RegisterRowMapper(MandateMapper.class)
 public interface MandateDao {
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
@@ -9,6 +9,7 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReference;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.model.Payer;
 
@@ -91,7 +92,7 @@ public class MandateMapper implements RowMapper<Mandate> {
                 MandateType.valueOf(resultSet.getString(MANDATE_TYPE_COLUMN)),
                 MandateExternalId.valueOf(resultSet.getString(EXTERNAL_ID_COLUMN)),
                 resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN),
-                resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN),
+                ServiceMandateReference.valueOf(resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN)),
                 MandateState.valueOf(resultSet.getString(STATE_COLUMN)),
                 resultSet.getString(RETURN_URL_COLUMN),
                 ZonedDateTime.ofInstant(resultSet.getTimestamp(CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC),

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
@@ -14,7 +14,7 @@ public class Mandate {
     private final String returnUrl;
     private final MandateType type;
     private String mandateReference;
-    private final String serviceReference;
+    private final ServiceMandateReference serviceReference;
     private final ZonedDateTime createdDate;
     private Payer payer;
 
@@ -24,7 +24,7 @@ public class Mandate {
             MandateType type,
             MandateExternalId externalId,
             String mandateReference,
-            String serviceReference,
+            ServiceMandateReference serviceReference,
             MandateState state,
             String returnUrl,
             ZonedDateTime createdDate,
@@ -82,7 +82,7 @@ public class Mandate {
         return mandateReference;
     }
 
-    public String getServiceReference() {
+    public ServiceMandateReference getServiceReference() {
         return serviceReference;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/ServiceMandateReference.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/ServiceMandateReference.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import java.util.Objects;
+
+/**
+ * The reference assigned to a mandate by a government service (set when the
+ * service sends the request to us to create the mandate)
+ */
+public class ServiceMandateReference {
+
+    private final String serviceMandateReference;
+
+    private ServiceMandateReference(String serviceMandateReference) {
+        this.serviceMandateReference = Objects.requireNonNull(serviceMandateReference);
+    }
+
+    public static ServiceMandateReference valueOf(String serviceMandateReference) {
+        return new ServiceMandateReference(serviceMandateReference);
+    }
+
+    @Override
+    public String toString() {
+        return serviceMandateReference;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == ServiceMandateReference.class) {
+            ServiceMandateReference that = (ServiceMandateReference) other;
+            return this.serviceMandateReference.equals(that.serviceMandateReference);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return serviceMandateReference.hashCode();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/ServiceMandateReferenceArgumentFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/ServiceMandateReferenceArgumentFactory.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import java.sql.Types;
+
+public class ServiceMandateReferenceArgumentFactory extends AbstractArgumentFactory<ServiceMandateReference> {
+
+    public ServiceMandateReferenceArgumentFactory()  {
+        super(Types.VARCHAR);
+    }
+
+    @Override
+    protected Argument build(ServiceMandateReference value, ConfigRegistry config) {
+        String serviceMandateReference = value == null ? null : value.toString();
+        return (pos, stmt, context) -> stmt.setString(pos, serviceMandateReference);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -21,6 +21,7 @@ import uk.gov.pay.directdebit.mandate.exception.WrongNumberOfTransactionsForOneO
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReference;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.model.Token;
@@ -86,7 +87,7 @@ public class MandateService {
                             createRequest.getMandateType(),
                             MandateExternalId.valueOf(RandomIdGenerator.newId()),
                             mandateReference,
-                            createRequest.getReference(),
+                            ServiceMandateReference.valueOf(createRequest.getReference()),
                             MandateState.CREATED,
                             createRequest.getReturnUrl(),
                             ZonedDateTime.now(ZoneOffset.UTC),

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CreatePaymentRequest.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.directdebit.payments.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Map;
 import uk.gov.pay.directdebit.mandate.api.CreateRequest;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
+
+import java.util.Map;
 
 public class CreatePaymentRequest implements CreateRequest, CollectRequest {
     @JsonProperty("return_url")

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -9,6 +9,7 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReference;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.model.Payer;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
@@ -98,7 +99,7 @@ public class TransactionMapper implements RowMapper<Transaction> {
                 MandateType.valueOf(resultSet.getString(MANDATE_TYPE_COLUMN)),
                 MandateExternalId.valueOf(resultSet.getString(MANDATE_EXTERNAL_ID_COLUMN)),
                 resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN),
-                resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN),
+                ServiceMandateReference.valueOf(resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN)),
                 MandateState.valueOf(resultSet.getString(MANDATE_STATE_COLUMN)),
                 resultSet.getString(MANDATE_RETURN_URL_COLUMN),
                 ZonedDateTime.ofInstant(resultSet.getTimestamp(MANDATE_CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC),

--- a/src/test/java/uk/gov/pay/directdebit/junit/TestContext.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/TestContext.java
@@ -4,6 +4,7 @@ import io.dropwizard.db.DataSourceFactory;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import uk.gov.pay.directdebit.common.model.subtype.gocardless.creditor.GoCardlessCreditorIdArgumentFactory;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReferenceArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventIdArgumentFactory;
 import uk.gov.pay.directdebit.util.DatabaseTestHelper;
@@ -28,6 +29,7 @@ public class TestContext {
         jdbi.registerArgument(new MandateExternalIdArgumentFactory());
         jdbi.registerArgument(new GoCardlessCreditorIdArgumentFactory());
         jdbi.registerArgument(new GoCardlessEventIdArgumentFactory());
+        jdbi.registerArgument(new ServiceMandateReferenceArgumentFactory());
         this.databaseTestHelper = new DatabaseTestHelper(jdbi);
         this.port = port;
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -14,6 +14,7 @@ import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReference;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.tokens.fixtures.TokenFixture;
@@ -87,7 +88,7 @@ public class MandateDaoIT {
                         MandateType.ONE_OFF,
                         MandateExternalId.valueOf(RandomIdGenerator.newId()),
                         "test-reference",
-                        "test-service-reference",
+                        ServiceMandateReference.valueOf("test-service-reference"),
                         MandateState.PENDING,
                         "https://www.example.com/return_url",
                         createdDate,
@@ -109,7 +110,7 @@ public class MandateDaoIT {
     public void shouldFindAMandateById() {
         MandateFixture mandateFixture = MandateFixture.aMandateFixture()
                 .withMandateReference("test-reference")
-                .withServiceReference("test-service-reference")
+                .withServiceReference(ServiceMandateReference.valueOf("test-service-reference"))
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .insert(testContext.getJdbi()
                 );
@@ -117,7 +118,7 @@ public class MandateDaoIT {
         assertThat(mandate.getId(), is(mandateFixture.getId()));
         assertThat(mandate.getExternalId(), is(notNullValue()));
         assertThat(mandate.getMandateReference(), is("test-reference"));
-        assertThat(mandate.getServiceReference(), is("test-service-reference"));
+        assertThat(mandate.getServiceReference(), is(ServiceMandateReference.valueOf("test-service-reference")));
         assertThat(mandate.getState(), is(MandateState.CREATED));
         assertThat(mandate.getType(), is(mandateFixture.getMandateType()));
     }
@@ -132,7 +133,7 @@ public class MandateDaoIT {
     public void shouldFindAMandateByTokenId() {
         MandateFixture mandateFixture = MandateFixture.aMandateFixture()
                 .withMandateReference("test-reference")
-                .withServiceReference("test-service-reference")
+                .withServiceReference(ServiceMandateReference.valueOf("test-service-reference"))
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .insert(testContext.getJdbi());
 
@@ -144,7 +145,7 @@ public class MandateDaoIT {
         assertThat(mandate.getId(), is(mandateFixture.getId()));
         assertThat(mandate.getExternalId(), is(mandateFixture.getExternalId()));
         assertThat(mandate.getMandateReference(), is("test-reference"));
-        assertThat(mandate.getServiceReference(), is("test-service-reference"));
+        assertThat(mandate.getServiceReference(), is(ServiceMandateReference.valueOf("test-service-reference")));
         assertThat(mandate.getState(), is(MandateState.CREATED));
         assertThat(mandate.getType(), is(mandateFixture.getMandateType()));
     }
@@ -159,7 +160,7 @@ public class MandateDaoIT {
     public void shouldFindAMandateByExternalId() {
         MandateFixture mandateFixture = MandateFixture.aMandateFixture()
                 .withMandateReference("test-reference")
-                .withServiceReference("test-service-reference")
+                .withServiceReference(ServiceMandateReference.valueOf("test-service-reference"))
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .insert(testContext.getJdbi());
 
@@ -167,7 +168,7 @@ public class MandateDaoIT {
         assertThat(mandate.getId(), is(mandateFixture.getId()));
         assertThat(mandate.getExternalId(), is(notNullValue()));
         assertThat(mandate.getMandateReference(), is("test-reference"));
-        assertThat(mandate.getServiceReference(), is("test-service-reference"));
+        assertThat(mandate.getServiceReference(), is(ServiceMandateReference.valueOf("test-service-reference")));
         assertThat(mandate.getState(), is(MandateState.CREATED));
         assertThat(mandate.getType(), is(mandateFixture.getMandateType()));
     }
@@ -189,7 +190,7 @@ public class MandateDaoIT {
         assertThat(mandateAfterUpdate.get("id"), is(testMandate.getId()));
         assertThat(mandateAfterUpdate.get("external_id"), is(testMandate.getExternalId().toString()));
         assertThat(mandateAfterUpdate.get("mandate_reference"), is(testMandate.getMandateReference()));
-        assertThat(mandateAfterUpdate.get("service_reference"), is(testMandate.getServiceReference()));
+        assertThat(mandateAfterUpdate.get("service_reference"), is(testMandate.getServiceReference().toString()));
         assertThat(mandateAfterUpdate.get("state"), is(newState.toString()));
         assertThat(mandateAfterUpdate.get("type"), is(testMandate.getType().toString()));
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
@@ -8,6 +8,7 @@ import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
+import uk.gov.pay.directdebit.mandate.model.ServiceMandateReference;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payers.model.Payer;
@@ -21,7 +22,7 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
     private Long id = RandomUtils.nextLong(1, 99999);
     private MandateExternalId mandateExternalId = MandateExternalId.valueOf(RandomIdGenerator.newId());
     private String mandateReference = RandomStringUtils.randomAlphanumeric(18);
-    private String serviceReference = RandomStringUtils.randomAlphanumeric(18);
+    private ServiceMandateReference serviceReference = ServiceMandateReference.valueOf(RandomStringUtils.randomAlphanumeric(18));
     private MandateState state = MandateState.CREATED;
     private String returnUrl = "http://service.test/success-page";
     private MandateType mandateType = MandateType.ONE_OFF;
@@ -88,11 +89,11 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
         return this;
     }
 
-    public String getServiceReference() {
+    public ServiceMandateReference getServiceReference() {
         return serviceReference;
     }
 
-    public MandateFixture withServiceReference(String serviceReference) {
+    public MandateFixture withServiceReference(ServiceMandateReference serviceReference) {
         this.serviceReference = serviceReference;
         return this;
     }
@@ -146,7 +147,7 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
                         mandateExternalId.toString(),
                         mandateType.toString(),
                         mandateReference,
-                        serviceReference,
+                        serviceReference.toString(),
                         returnUrl,
                         state.toString(),
                         createdDate

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -319,7 +319,7 @@ public class MandateResourceIT {
                 .body("return_url", is(mandateFixture.getReturnUrl()))
                 .body("state.status", is(mandateFixture.getState().toExternal().getState()))
                 .body("state.finished", is(mandateFixture.getState().toExternal().isFinished()))
-                .body("service_reference", is(mandateFixture.getServiceReference()))
+                .body("service_reference", is(mandateFixture.getServiceReference().toString()))
                 .body("mandate_reference", is(notNullValue()));
 
         String token = testContext.getDatabaseTestHelper().getTokenByMandateExternalId(mandateFixture.getExternalId()).get("secure_redirect_token").toString();


### PR DESCRIPTION
`ServiceMandateReference` represents the reference assigned to a mandate by a government service (set when the service sends the request to us to create the mandate). It wraps a string.

This isn’t quite as nice as it could be because `CreateMandateRequest` (create an on-demand mandate) and `CreatePaymentRequest` (either create a one-off mandate and payment to be collected from it, or collect a payment from an on-demand mandate) both implement `CreateRequest` and `CreatePaymentRequest` also implements `CollectRequest`, which both define the method `getReference()` to return a `String` object (it represents either a service’s reference for a mandate or a service’s reference for a payment or both at the same time).