### PR TITLE
PP-5231 Introduce GoCardlessMandateId type

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
@@ -10,6 +10,7 @@ import com.gocardless.resources.Payment;
 import uk.gov.pay.directdebit.common.model.subtype.SunName;
 import uk.gov.pay.directdebit.common.model.subtype.gocardless.creditor.GoCardlessCreditorId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
@@ -53,7 +54,7 @@ public class GoCardlessClientFacade {
         com.gocardless.resources.Mandate gcMandate = goCardlessClientWrapper.createMandate(mandate.getExternalId(), customer);
         return new GoCardlessMandate(
                 mandate.getId(),
-                gcMandate.getId(),
+                GoCardlessMandateId.valueOf(gcMandate.getId()),
                 gcMandate.getReference(),
                 GoCardlessCreditorId.valueOf(gcMandate.getLinks().getCreditor()));
     }

--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientWrapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientWrapper.java
@@ -61,7 +61,7 @@ public class GoCardlessClientWrapper {
                 .create()
                 .withAmount(Math.toIntExact(transaction.getAmount()))
                 .withCurrency(PaymentService.PaymentCreateRequest.Currency.GBP)
-                .withLinksMandate(mandate.getGoCardlessMandateId())
+                .withLinksMandate(mandate.getGoCardlessMandateId().toString())
                 .withIdempotencyKey(transaction.getExternalId())
                 .execute();
     }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDao.java
@@ -10,15 +10,18 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.common.model.subtype.gocardless.creditor.GoCardlessCreditorIdArgumentFactory;
 import uk.gov.pay.directdebit.mandate.dao.mapper.GoCardlessMandateMapper;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateIdArgumentFactory;
 
 import java.util.Optional;
 
+@RegisterArgumentFactory(GoCardlessMandateIdArgumentFactory.class)
 @RegisterArgumentFactory(GoCardlessCreditorIdArgumentFactory.class)
 @RegisterRowMapper(GoCardlessMandateMapper.class)
 public interface GoCardlessMandateDao {
 
     @SqlQuery("SELECT * FROM gocardless_mandates m WHERE m.gocardless_mandate_id = :entityId")
-    Optional<GoCardlessMandate> findByEventResourceId(@Bind("entityId") String entityId);
+    Optional<GoCardlessMandate> findByEventResourceId(@Bind("entityId") GoCardlessMandateId entityId);
 
     @SqlQuery("SELECT * FROM gocardless_mandates m WHERE m.mandate_id = :mandateId")
     Optional<GoCardlessMandate> findByMandateId(@Bind("mandateId") Long mandateId);

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessMandateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/GoCardlessMandateMapper.java
@@ -4,6 +4,7 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.directdebit.common.model.subtype.gocardless.creditor.GoCardlessCreditorId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -19,7 +20,7 @@ public class GoCardlessMandateMapper implements RowMapper<GoCardlessMandate> {
         return new GoCardlessMandate(
                 resultSet.getLong(ID_COLUMN),
                 resultSet.getLong(MANDATE_ID_COLUMN),
-                resultSet.getString(GOCARDLESS_MANDATE_ID_COLUMN),
+                GoCardlessMandateId.valueOf(resultSet.getString(GOCARDLESS_MANDATE_ID_COLUMN)),
                 null,
                 GoCardlessCreditorId.valueOf(resultSet.getString(GOCARDLESS_CREDITOR_ID)));
     }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandate.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandate.java
@@ -6,11 +6,11 @@ public class GoCardlessMandate {
 
     private Long id;
     private final Long mandateId;
-    private final String goCardlessMandateId;
+    private final GoCardlessMandateId goCardlessMandateId;
     private final String goCardlessReference;
     private final GoCardlessCreditorId goCardlessCreditorId;
 
-    public GoCardlessMandate(Long id, Long mandateId, String goCardlessMandateId, String goCardlessReference, GoCardlessCreditorId goCardlessCreditorId) {
+    public GoCardlessMandate(Long id, Long mandateId, GoCardlessMandateId goCardlessMandateId, String goCardlessReference, GoCardlessCreditorId goCardlessCreditorId) {
         this.id = id;
         this.mandateId = mandateId;
         this.goCardlessMandateId = goCardlessMandateId;
@@ -18,7 +18,7 @@ public class GoCardlessMandate {
         this.goCardlessCreditorId = goCardlessCreditorId;
     }
 
-    public GoCardlessMandate(Long mandateId, String goCardlessMandateId, String goCardlessReference, GoCardlessCreditorId goCardlessCreditorId) {
+    public GoCardlessMandate(Long mandateId, GoCardlessMandateId goCardlessMandateId, String goCardlessReference, GoCardlessCreditorId goCardlessCreditorId) {
         this(null, mandateId, goCardlessMandateId, goCardlessReference, goCardlessCreditorId);
     }
 
@@ -34,7 +34,7 @@ public class GoCardlessMandate {
         return mandateId;
     }
 
-    public String getGoCardlessMandateId() {
+    public GoCardlessMandateId getGoCardlessMandateId() {
         return goCardlessMandateId;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandateId.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandateId.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import java.util.Objects;
+
+/**
+ * The ID assigned by GoCardless to a Direct Debit mandate e.g. "MD123"
+ * 
+ * @see <a href="https://developer.gocardless.com/api-reference/#core-endpoints-mandates">GoCardless Mandates</a>
+ */
+public class GoCardlessMandateId {
+    
+    private final String goCardlessMandateId;
+
+    private GoCardlessMandateId(String goCardlessEventId) {
+        this.goCardlessMandateId = Objects.requireNonNull(goCardlessEventId);
+    }
+
+    public static GoCardlessMandateId valueOf(String goCardlessMandateId) {
+        return new GoCardlessMandateId(goCardlessMandateId);
+    }
+
+    @Override
+    public String toString() {
+        return goCardlessMandateId;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == GoCardlessMandateId.class) {
+            GoCardlessMandateId that = (GoCardlessMandateId) other;
+            return this.goCardlessMandateId.equals(that.goCardlessMandateId);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return goCardlessMandateId.hashCode();
+    }
+    
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandateIdArgumentFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandateIdArgumentFactory.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import java.sql.Types;
+
+public class GoCardlessMandateIdArgumentFactory extends AbstractArgumentFactory<GoCardlessMandateId> {
+
+    public GoCardlessMandateIdArgumentFactory() {
+        super(Types.VARCHAR);
+    }
+
+    @Override
+    protected Argument build(GoCardlessMandateId value, ConfigRegistry config) {
+        String goCardlessMandateId = value == null ? null : value.toString();
+        return (pos, stmt, context) -> stmt.setString(pos, goCardlessMandateId);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventService.java
@@ -1,16 +1,18 @@
 package uk.gov.pay.directdebit.payments.services;
 
-import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessMandateDao;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessPaymentDao;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
 import uk.gov.pay.directdebit.payments.dao.GoCardlessEventDao;
 import uk.gov.pay.directdebit.payments.exception.GoCardlessMandateNotFoundException;
 import uk.gov.pay.directdebit.payments.exception.GoCardlessPaymentNotFoundException;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+
+import javax.inject.Inject;
 
 public class GoCardlessEventService {
     private static final Logger LOGGER = LoggerFactory.getLogger(GoCardlessEventService.class);
@@ -49,7 +51,7 @@ public class GoCardlessEventService {
 
     public GoCardlessMandate findGoCardlessMandateForEvent(GoCardlessEvent event) {
         return goCardlessMandateDao
-                .findByEventResourceId(event.getResourceId())
+                .findByEventResourceId(GoCardlessMandateId.valueOf(event.getResourceId()))
                 .orElseThrow(() -> {
                     LOGGER.error("Couldn't find gocardless mandate for event: {}", event.getJson());
                     return new GoCardlessMandateNotFoundException("resource id", event.getResourceId());

--- a/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
@@ -12,6 +12,7 @@ import uk.gov.pay.directdebit.common.model.subtype.SunName;
 import uk.gov.pay.directdebit.common.model.subtype.gocardless.creditor.GoCardlessCreditorId;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.payers.fixtures.GoCardlessCustomerFixture;
 import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
@@ -156,8 +157,8 @@ public class GoCardlessClientFacadeTest {
                 GoCardlessCustomerFixture.aGoCardlessCustomerFixture().toEntity();
 
         String goCardlessReference = "test-gocardless-mandate-reference-here";
-        String goCardlessMandateId = "test-gocardless-mandate-id-here";
-        given(mockMandate.getId()).willReturn(goCardlessMandateId);
+        GoCardlessMandateId goCardlessMandateId = GoCardlessMandateId.valueOf("test-gocardless-mandate-id-here");
+        given(mockMandate.getId()).willReturn(goCardlessMandateId.toString());
         given(mockMandate.getReference()).willReturn(goCardlessReference);
         given(mockMandate.getLinks()).willReturn(mockMandateLinks);
         given(mockMandateLinks.getCreditor()).willReturn(goCardlessCreditorId.toString());

--- a/src/test/java/uk/gov/pay/directdebit/junit/TestContext.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/TestContext.java
@@ -4,6 +4,7 @@ import io.dropwizard.db.DataSourceFactory;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import uk.gov.pay.directdebit.common.model.subtype.gocardless.creditor.GoCardlessCreditorIdArgumentFactory;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventIdArgumentFactory;
 import uk.gov.pay.directdebit.util.DatabaseTestHelper;
@@ -26,6 +27,7 @@ public class TestContext {
         jdbi = Jdbi.create(databaseUrl, databaseUser, databasePassword);
         jdbi.installPlugin(new SqlObjectPlugin());
         jdbi.registerArgument(new MandateExternalIdArgumentFactory());
+        jdbi.registerArgument(new GoCardlessMandateIdArgumentFactory());
         jdbi.registerArgument(new GoCardlessCreditorIdArgumentFactory());
         jdbi.registerArgument(new GoCardlessEventIdArgumentFactory());
         this.databaseTestHelper = new DatabaseTestHelper(jdbi);

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDaoIT.java
@@ -12,6 +12,7 @@ import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.mandate.fixtures.GoCardlessMandateFixture;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 
@@ -32,7 +33,7 @@ public class GoCardlessMandateDaoIT {
     private GoCardlessMandateDao mandateDao;
     private MandateFixture mandateFixture;
 
-    private final static String GOCARDLESS_MANDATE_ID = "NA23434";
+    private final static GoCardlessMandateId GOCARDLESS_MANDATE_ID = GoCardlessMandateId.valueOf("NA23434");
     private final static GoCardlessCreditorId GOCARDLESS_CREDITOR_ID = GoCardlessCreditorId.valueOf("CREDITORID123");
 
     private GoCardlessMandateFixture testGoCardlessMandate;
@@ -60,7 +61,7 @@ public class GoCardlessMandateDaoIT {
         Map<String, Object> mandate = testContext.getDatabaseTestHelper().getGoCardlessMandateById(id);
         assertThat(mandate.get("id"), is(id));
         assertThat(mandate.get("mandate_id"), is(mandateFixture.getId()));
-        assertThat(mandate.get("gocardless_mandate_id"), is(GOCARDLESS_MANDATE_ID));
+        assertThat(mandate.get("gocardless_mandate_id"), is(GOCARDLESS_MANDATE_ID.toString()));
         assertThat(mandate.get("gocardless_creditor_id"), is(GOCARDLESS_CREDITOR_ID.toString()));
     }
 
@@ -87,7 +88,7 @@ public class GoCardlessMandateDaoIT {
 
     @Test
     public void shouldNotFindAGoCardlessMandateByEventResourceId_ifResourceIdIsInvalid() {
-        String resourceId = "non_existing_resourceId";
+        GoCardlessMandateId resourceId = GoCardlessMandateId.valueOf("non_existing_resourceId");
         assertThat(mandateDao.findByEventResourceId(resourceId), is(Optional.empty()));
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessMandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/GoCardlessMandateFixture.java
@@ -6,12 +6,13 @@ import uk.gov.pay.directdebit.common.fixtures.DbFixture;
 import uk.gov.pay.directdebit.common.model.subtype.gocardless.creditor.GoCardlessCreditorId;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 
 public class GoCardlessMandateFixture implements DbFixture<GoCardlessMandateFixture, GoCardlessMandate> {
 
     private Long id = RandomUtils.nextLong(1, 99999);
     private Long mandateId = RandomUtils.nextLong(1, 99999);
-    private String goCardlessMandateId = RandomIdGenerator.newId();
+    private GoCardlessMandateId goCardlessMandateId = GoCardlessMandateId.valueOf(RandomIdGenerator.newId());
     private GoCardlessCreditorId goCardlessCreditorId = GoCardlessCreditorId.valueOf(RandomIdGenerator.newId());
 
     private GoCardlessMandateFixture() {
@@ -39,11 +40,11 @@ public class GoCardlessMandateFixture implements DbFixture<GoCardlessMandateFixt
         return this;
     }
 
-    public String getGoCardlessMandateId() {
+    public GoCardlessMandateId getGoCardlessMandateId() {
         return goCardlessMandateId;
     }
 
-    public GoCardlessMandateFixture withGoCardlessMandateId(String goCardlessMandateId) {
+    public GoCardlessMandateFixture withGoCardlessMandateId(GoCardlessMandateId goCardlessMandateId) {
         this.goCardlessMandateId = goCardlessMandateId;
         return this;
     }
@@ -67,8 +68,8 @@ public class GoCardlessMandateFixture implements DbFixture<GoCardlessMandateFixt
                                 "   VALUES(?, ?, ?, ?)\n",
                         id,
                         mandateId,
-                        goCardlessMandateId,
-                        goCardlessCreditorId
+                        goCardlessMandateId.toString(),
+                        goCardlessCreditorId.toString()
                 )
         );
         return this;

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -21,6 +21,7 @@ import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.mandate.fixtures.GoCardlessMandateFixture;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
@@ -567,7 +568,7 @@ public class MandateResourceIT {
         stubCreateCustomer(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId);
         stubCreateCustomerBankAccount(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), payerFixture, customerId, customerBankAccountId);
         stubCreateMandate(gatewayAccountFixture.getAccessToken().toString(), mandateFixture.getExternalId().toString(), goCardlessCustomerFixture);
-        stubCreatePayment(gatewayAccountFixture.getAccessToken().toString(), transactionFixture.getAmount(), "MD123", transactionFixture.getExternalId());
+        stubCreatePayment(gatewayAccountFixture.getAccessToken().toString(), transactionFixture.getAmount(), GoCardlessMandateId.valueOf("MD123"), transactionFixture.getExternalId());
 
         String lastTwoDigitsBankAccount = payerFixture.getAccountNumber().substring(payerFixture.getAccountNumber().length() - 2);
         stubGetCreditor(gatewayAccountFixture.getAccessToken().toString(), goCardlessMandate.getGoCardlessCreditorId().toString(), sunName);

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.payments.services;
 
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -10,10 +9,13 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessMandateDao;
 import uk.gov.pay.directdebit.mandate.dao.GoCardlessPaymentDao;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.payments.dao.GoCardlessEventDao;
 import uk.gov.pay.directdebit.payments.exception.GoCardlessMandateNotFoundException;
 import uk.gov.pay.directdebit.payments.exception.GoCardlessPaymentNotFoundException;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+
+import java.util.Optional;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -60,8 +62,8 @@ public class GoCardlessEventServiceTest {
     @Test
     public void findMandateForEvent_shouldThrowIfNoMandateIsFoundForEvent() {
         GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture().toEntity();
-        String resourceId = "aaa";
-        goCardlessEvent.setResourceId(resourceId);
+        GoCardlessMandateId resourceId = GoCardlessMandateId.valueOf("aaa");
+        goCardlessEvent.setResourceId(resourceId.toString());
         when(mockedGoCardlessMandateDao.findByEventResourceId(resourceId)).thenReturn(Optional.empty());
         thrown.expect(GoCardlessMandateNotFoundException.class);
         thrown.expectMessage("No gocardless mandate found with resource id: aaa");

--- a/src/test/java/uk/gov/pay/directdebit/util/GoCardlessStubs.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/GoCardlessStubs.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.util;
 
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.payers.fixtures.GoCardlessCustomerFixture;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 
@@ -73,14 +74,14 @@ public class GoCardlessStubs {
         stubPostCallsFor("/mandates", accessToken, 200, idempotencyKey, mandateRequestExpectedBody, mandateResponseBody);
     }
 
-    public static void stubCreatePayment(String accessToken, Long amount, String goCardlessMandateId, String idempotencyKey) {
+    public static void stubCreatePayment(String accessToken, Long amount, GoCardlessMandateId goCardlessMandateId, String idempotencyKey) {
         String paymentRequestExpectedBody = load(GOCARDLESS_CREATE_PAYMENT_REQUEST)
                 .replace("{{amount}}", String.valueOf(amount))
-                .replace("{{gocardless_mandate_id}}", goCardlessMandateId);
+                .replace("{{gocardless_mandate_id}}", goCardlessMandateId.toString());
 
         String paymentResponseBody = load(GOCARDLESS_CREATE_PAYMENT_SUCCESS_RESPONSE)
                 .replace("{{amount}}", String.valueOf(amount))
-                .replace("{{gocardless_mandate_id}}", goCardlessMandateId);
+                .replace("{{gocardless_mandate_id}}", goCardlessMandateId.toString());
         stubPostCallsFor("/payments", accessToken, 200, idempotencyKey, paymentRequestExpectedBody, paymentResponseBody);
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateType;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
@@ -189,7 +190,7 @@ public class WebhookGoCardlessResourceIT {
                 .withTransactionId(transactionFixture.getId())
                 .insert(testContext.getJdbi());
         aGoCardlessMandateFixture()
-                .withGoCardlessMandateId("MD00008Q30R2BR")
+                .withGoCardlessMandateId(GoCardlessMandateId.valueOf("MD00008Q30R2BR"))
                 .withMandateId(mandateFixture.getId())
                 .insert(testContext.getJdbi());
 


### PR DESCRIPTION
`GoCardlessMandateId` represents the ID GoCardless assign to a Direct Debit mandate. It wraps a string like `"MD123"`.