### PR TITLE
PP-5234: Make service name nullable

### DIFF
--- a/src/main/resources/migrations/00045_alter_table_gateway_account.sql
+++ b/src/main/resources/migrations/00045_alter_table_gateway_account.sql
@@ -1,0 +1,1 @@
+ALTER TABLE gateway_accounts ALTER COLUMN service_name DROP NOT NULL;


### PR DESCRIPTION
The service name was removed in the call to dd-connector at
https://github.com/alphagov/pay-selfservice/pull/1482.

Before I remove the service name from GatewayAccountResponse and
CreateGatewayAccountRequest the service_name column in the gateway_accounts
table needs to be made nullable.

Once I remove the service name from GatewayAccountResponse and
CreateGatewayAccountRequest in another PR I'll be delete to drop the column
completely.
