### PR TITLE
PP-5234: Remove references to service name

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountRequest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.directdebit.gatewayaccounts.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.hibernate.validator.constraints.NotEmpty;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount.Type;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
@@ -17,10 +16,6 @@ public class CreateGatewayAccountRequest {
     @NotNull
     private final PaymentProvider paymentProvider;
 
-    @NotEmpty
-    @Size(min = 1, max = 50, message = "service_name must be between {min} and {max} characters.")
-    private final String serviceName;
-
     @NotNull
     private final Type type;
 
@@ -34,14 +29,12 @@ public class CreateGatewayAccountRequest {
     private final GoCardlessOrganisationId organisation;
 
     public CreateGatewayAccountRequest(@JsonProperty("payment_provider") PaymentProvider paymentProvider,
-                                       @JsonProperty("service_name") String serviceName,
                                        @JsonProperty("type") Type type, 
                                        @JsonProperty("description") String description, 
                                        @JsonProperty("analytics_id") String analyticsId,
                                        @JsonProperty("access_token") PaymentProviderAccessToken accessToken,
                                        @JsonProperty("organisation") GoCardlessOrganisationId organisation) {
         this.paymentProvider = paymentProvider;
-        this.serviceName = serviceName;
         this.type = type;
         this.description = description;
         this.analyticsId = analyticsId;
@@ -52,11 +45,7 @@ public class CreateGatewayAccountRequest {
     public PaymentProvider getPaymentProvider() {
         return paymentProvider;
     }
-
-    public String getServiceName() {
-        return serviceName;
-    }
-
+    
     public Type getType() {
         return type;
     }

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/GatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/api/GatewayAccountResponse.java
@@ -25,8 +25,6 @@ public class GatewayAccountResponse {
     private String gatewayAccountExternalId;
     @JsonProperty("payment_method")
     private final String paymentMethod="DIRECT_DEBIT";
-    @JsonProperty("service_name")
-    private String serviceName;
     @JsonProperty("payment_provider")
     private String paymentProvider;
     @JsonProperty("description")
@@ -38,10 +36,9 @@ public class GatewayAccountResponse {
     @JsonProperty("links")
     private List<Map<String, Object>> links = new ArrayList<>();
 
-    public GatewayAccountResponse(Long gatewayAccountId, String gatewayAccountExternalId, String serviceName, String paymentProvider, String description, String type, String analyticsId) {
+    public GatewayAccountResponse(Long gatewayAccountId, String gatewayAccountExternalId, String paymentProvider, String description, String type, String analyticsId) {
         this.gatewayAccountId = gatewayAccountId;
         this.gatewayAccountExternalId = gatewayAccountExternalId;
-        this.serviceName = serviceName;
         this.paymentProvider = paymentProvider;
         this.description = description;
         this.type = type;
@@ -52,7 +49,6 @@ public class GatewayAccountResponse {
         return new GatewayAccountResponse(
                 gatewayAccount.getId(),
                 gatewayAccount.getExternalId(),
-                gatewayAccount.getServiceName(),
                 gatewayAccount.getPaymentProvider().toString(),
                 gatewayAccount.getDescription(),
                 gatewayAccount.getType().toString(),
@@ -74,9 +70,6 @@ public class GatewayAccountResponse {
                 .findFirst()
                 .map(link -> (URI) link.get("href"))
                 .orElse(URI.create(""));
-    }
-    public String getServiceName() {
-        return serviceName;
     }
 
     public Long getGatewayAccountId() {

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDao.java
@@ -30,9 +30,9 @@ public interface GatewayAccountDao {
     List<GatewayAccount> findAll();
 
     @SqlUpdate("INSERT INTO gateway_accounts(external_id, payment_provider, " +
-            "type, service_name, description, analytics_id, access_token, organisation) " +
+            "type, description, analytics_id, access_token, organisation) " +
             "VALUES (:externalId, :paymentProvider, " +
-            ":type, :serviceName, :description, :analyticsId, :accessToken, :organisation)")
+            ":type, :description, :analyticsId, :accessToken, :organisation)")
     @GetGeneratedKeys
     Long insert(@BindBean GatewayAccount gatewayAccount);
 

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/mapper/GatewayAccountMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/mapper/GatewayAccountMapper.java
@@ -15,7 +15,6 @@ public class GatewayAccountMapper implements RowMapper<GatewayAccount> {
     private static final String ID_COLUMN = "id";
     private static final String EXTERNAL_ID_COLUMN = "external_id";
     private static final String PAYMENT_PROVIDER_COLUMN = "payment_provider";
-    private static final String SERVICE_NAME_COLUMN = "service_name";
     private static final String TYPE_COLUMN = "type";
     private static final String DESCRIPTION_COLUMN = "description";
     private static final String ANALYTICS_ID_COLUMN = "analytics_id";
@@ -29,7 +28,6 @@ public class GatewayAccountMapper implements RowMapper<GatewayAccount> {
                 resultSet.getString(EXTERNAL_ID_COLUMN),
                 PaymentProvider.fromString(resultSet.getString(PAYMENT_PROVIDER_COLUMN)),
                 GatewayAccount.Type.fromString(resultSet.getString(TYPE_COLUMN)),
-                resultSet.getString(SERVICE_NAME_COLUMN),
                 resultSet.getString(DESCRIPTION_COLUMN),
                 resultSet.getString(ANALYTICS_ID_COLUMN)
         );

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/GatewayAccount.java
@@ -26,32 +26,30 @@ public class GatewayAccount {
     private String externalId;
     private PaymentProvider paymentProvider;
     private Type type;
-    private String serviceName;
     private String description;
     private String analyticsId;
     private PaymentProviderAccessToken accessToken;
     private GoCardlessOrganisationId organisation;
 
-    public GatewayAccount(Long id, String externalId, PaymentProvider paymentProvider, Type type, String serviceName, String description, String analyticsId,
+    public GatewayAccount(Long id, String externalId, PaymentProvider paymentProvider, Type type, String description, String analyticsId,
                           PaymentProviderAccessToken accessToken, GoCardlessOrganisationId organisation) {
         this.id = id;
         this.externalId = externalId;
         this.paymentProvider = paymentProvider;
         this.type = type;
-        this.serviceName = serviceName;
         this.description = description;
         this.analyticsId = analyticsId;
         this.accessToken = accessToken;
         this.organisation = organisation;
     }
 
-    public GatewayAccount(Long id, String externalId, PaymentProvider paymentProvider, Type type, String serviceName, String description, String analyticsId) {
-        this(id, externalId, paymentProvider, type, serviceName, description, analyticsId, null, null);
+    public GatewayAccount(Long id, String externalId, PaymentProvider paymentProvider, Type type, String description, String analyticsId) {
+        this(id, externalId, paymentProvider, type, description, analyticsId, null, null);
     }
 
-    public GatewayAccount(PaymentProvider paymentProvider, Type type, String serviceName, String description, String analyticsId,
+    public GatewayAccount(PaymentProvider paymentProvider, Type type, String description, String analyticsId,
                           PaymentProviderAccessToken accessToken, GoCardlessOrganisationId organisation) {
-        this(null, generateExternalId(), paymentProvider, type, serviceName, description, analyticsId, accessToken, organisation);
+        this(null, generateExternalId(), paymentProvider, type, description, analyticsId, accessToken, organisation);
     }
 
     private static String generateExternalId() {
@@ -81,16 +79,7 @@ public class GatewayAccount {
         this.type = type;
         return this;
     }
-
-    public String getServiceName() {
-        return serviceName;
-    }
-
-    public GatewayAccount setServiceName(String serviceName) {
-        this.serviceName = serviceName;
-        return this;
-    }
-
+    
     public String getDescription() {
         return description;
     }
@@ -159,10 +148,6 @@ public class GatewayAccount {
         if (type != that.type) {
             return false;
         }
-        if (serviceName != null ? !serviceName.equals(that.serviceName)
-                : that.serviceName != null) {
-            return false;
-        }
         if (description != null ? !description.equals(that.description)
                 : that.description != null) {
             return false;
@@ -185,7 +170,6 @@ public class GatewayAccount {
         result = 31 * result + externalId.hashCode();
         result = 31 * result + paymentProvider.hashCode();
         result = 31 * result + type.hashCode();
-        result = 31 * result + (serviceName != null ? serviceName.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (analyticsId != null ? analyticsId.hashCode() : 0);
         result = 31 * result + (accessToken != null ? accessToken.hashCode() : 0);

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountService.java
@@ -62,7 +62,6 @@ public class GatewayAccountService {
         GatewayAccount gatewayAccount = new GatewayAccount(
                 request.getPaymentProvider(),
                 request.getType(),
-                request.getServiceName(),
                 request.getDescription(),
                 request.getAnalyticsId(),
                 request.getAccessToken(),

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
@@ -48,8 +48,7 @@ public class MandateMapper implements RowMapper<Mandate> {
     private static final String PAYER_BANK_ACCOUNT_SORT_CODE_COLUMN = "payer_bank_account_sort_code";
     private static final String PAYER_BANK_NAME_COLUMN = "payer_bank_name";
     private static final String PAYER_CREATED_DATE_COLUMN = "payer_created_date";
-
-
+    
     @Override
     public Mandate map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
         Payer payer = null;
@@ -73,7 +72,6 @@ public class MandateMapper implements RowMapper<Mandate> {
                 resultSet.getString(GATEWAY_ACCOUNT_EXTERNAL_ID_COLUMN),
                 PaymentProvider.fromString(resultSet.getString(GATEWAY_ACCOUNT_PAYMENT_PROVIDER_COLUMN)),
                 GatewayAccount.Type.fromString(resultSet.getString(GATEWAY_ACCOUNT_TYPE_COLUMN)),
-                resultSet.getString(GATEWAY_ACCOUNT_SERVICE_NAME_COLUMN),
                 resultSet.getString(GATEWAY_ACCOUNT_DESCRIPTION_COLUMN),
                 resultSet.getString(GATEWAY_ACCOUNT_ANALYTICS_ID_COLUMN)
         );

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -33,7 +33,6 @@ public class TransactionMapper implements RowMapper<Transaction> {
     private static final String GATEWAY_ACCOUNT_EXTERNAL_ID_COLUMN = "gateway_account_external_id";
     private static final String GATEWAY_ACCOUNT_PAYMENT_PROVIDER_COLUMN = "gateway_account_payment_provider";
     private static final String GATEWAY_ACCOUNT_TYPE_COLUMN = "gateway_account_type";
-    private static final String GATEWAY_ACCOUNT_SERVICE_NAME_COLUMN = "gateway_account_service_name";
     private static final String GATEWAY_ACCOUNT_DESCRIPTION_COLUMN = "gateway_account_description";
     private static final String GATEWAY_ACCOUNT_ANALYTICS_ID_COLUMN = "gateway_account_analytics_id";
     private static final String GATEWAY_ACCOUNT_ACCESS_TOKEN_COLUMN = "gateway_account_access_token";
@@ -81,7 +80,6 @@ public class TransactionMapper implements RowMapper<Transaction> {
                 resultSet.getString(GATEWAY_ACCOUNT_EXTERNAL_ID_COLUMN),
                 PaymentProvider.fromString(resultSet.getString(GATEWAY_ACCOUNT_PAYMENT_PROVIDER_COLUMN)),
                 GatewayAccount.Type.fromString(resultSet.getString(GATEWAY_ACCOUNT_TYPE_COLUMN)),
-                resultSet.getString(GATEWAY_ACCOUNT_SERVICE_NAME_COLUMN),
                 resultSet.getString(GATEWAY_ACCOUNT_DESCRIPTION_COLUMN),
                 resultSet.getString(GATEWAY_ACCOUNT_ANALYTICS_ID_COLUMN));
         String accessToken = resultSet.getString(GATEWAY_ACCOUNT_ACCESS_TOKEN_COLUMN);

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountRequestTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountRequestTest.java
@@ -13,7 +13,6 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class CreateGatewayAccountRequestTest {
 
@@ -27,14 +26,6 @@ public class CreateGatewayAccountRequestTest {
     public void setUp() {
         ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
         validator = validatorFactory.getValidator();
-    }
-
-    @Test
-    public void shouldGiveConstraintViolationForServiceNameTooLong() {
-        String longServiceName = "THIS SERVICE NAME IS GREATER THAN 50 CHARACTERS AND SHOULD NOT BE PERMITTED";
-        Set<ConstraintViolation<CreateGatewayAccountRequest>> violations = validator.validateValue(CreateGatewayAccountRequest.class, "serviceName", longServiceName);
-        assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("service_name must be between 1 and 50 characters."));
     }
 
     @Test
@@ -69,7 +60,6 @@ public class CreateGatewayAccountRequestTest {
     public void shouldPassValidation() {
         CreateGatewayAccountRequest createGatewayAccountRequest = new CreateGatewayAccountRequest(
                 PaymentProvider.SANDBOX,
-                "a service name",
                 GatewayAccount.Type.TEST,
                 null,
                 null,

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
@@ -32,7 +32,6 @@ public class GatewayAccountDaoIT {
 
     private static final String EXTERNAL_ID = "external1d";
     private static final PaymentProvider PAYMENT_PROVIDER = PaymentProvider.SANDBOX;
-    private static final String SERVICE_NAME = "alex";
     private static final String DESCRIPTION = "is awesome";
     private static final String ANALYTICS_ID = "DD_234098_BBBLA";
     private static final GatewayAccount.Type TYPE = GatewayAccount.Type.TEST;
@@ -50,7 +49,6 @@ public class GatewayAccountDaoIT {
                 .withExternalId(EXTERNAL_ID)
                 .withPaymentProvider(PAYMENT_PROVIDER)
                 .withType(TYPE)
-                .withServiceName(SERVICE_NAME)
                 .withAnalyticsId(ANALYTICS_ID)
                 .withDescription(DESCRIPTION)
                 .withAccessToken(null)
@@ -64,7 +62,6 @@ public class GatewayAccountDaoIT {
         assertThat(foundGatewayAccount.get("id"), is(id));
         assertThat(foundGatewayAccount.get("external_id"), is(EXTERNAL_ID));
         assertThat(foundGatewayAccount.get("payment_provider"), is(PAYMENT_PROVIDER.toString()));
-        assertThat(foundGatewayAccount.get("service_name"), is(SERVICE_NAME));
         assertThat(foundGatewayAccount.get("analytics_id"), is(ANALYTICS_ID));
         assertThat(foundGatewayAccount.get("type"), is(TYPE.toString()));
         assertThat(foundGatewayAccount.get("description"), is(DESCRIPTION));
@@ -125,7 +122,6 @@ public class GatewayAccountDaoIT {
         assertThat(first.getId(), is(notNullValue()));
         assertThat(first.getExternalId(), is(EXTERNAL_ID));
         assertThat(first.getPaymentProvider(), is(PAYMENT_PROVIDER));
-        assertThat(first.getServiceName(), is(SERVICE_NAME));
         assertThat(first.getDescription(), is(DESCRIPTION));
         assertThat(first.getAnalyticsId(), is(ANALYTICS_ID));
         assertThat(first.getType(), is(TYPE));
@@ -133,7 +129,6 @@ public class GatewayAccountDaoIT {
         assertThat(second.getId(), is(notNullValue()));
         assertThat(second.getExternalId(), is(externalId2));
         assertThat(second.getPaymentProvider(), is(paymentProvider2));
-        assertThat(second.getServiceName(), is(serviceName2));
         assertThat(second.getDescription(), is(description2));
         assertThat(second.getAnalyticsId(), is(analyticsId2));
         assertThat(second.getType(), is(TYPE));
@@ -190,7 +185,6 @@ public class GatewayAccountDaoIT {
         assertThat(first.getId(),              is(notNullValue()));
         assertThat(first.getExternalId(),      is(externalId));
         assertThat(first.getPaymentProvider(), is(paymentProvider));
-        assertThat(first.getServiceName(),     is(serviceName));
         assertThat(first.getDescription(),     is(description));
         assertThat(first.getAnalyticsId(),     is(analyticsId));
         assertThat(first.getType(),            is(TYPE));
@@ -205,7 +199,6 @@ public class GatewayAccountDaoIT {
         assertThat(first.getId(),              is(notNullValue()));
         assertThat(first.getExternalId(),      is(externalId));
         assertThat(first.getPaymentProvider(), is(paymentProvider));
-        assertThat(first.getServiceName(),     is(serviceName));
         assertThat(first.getDescription(),     is(description));
         assertThat(first.getAnalyticsId(),     is(analyticsId));
         assertThat(first.getType(),            is(TYPE));
@@ -213,7 +206,6 @@ public class GatewayAccountDaoIT {
         assertThat(second.getId(), is(notNullValue()));
         assertThat(second.getExternalId(), is(externalId2));
         assertThat(second.getPaymentProvider(), is(paymentProvider2));
-        assertThat(second.getServiceName(), is(serviceName2));
         assertThat(second.getDescription(), is(description2));
         assertThat(second.getAnalyticsId(), is(analyticsId2));
         assertThat(second.getType(), is(TYPE));
@@ -238,7 +230,6 @@ public class GatewayAccountDaoIT {
         assertThat(foundGatewayAccount.get("id"), is(id));
         assertThat(foundGatewayAccount.get("external_id"), is(EXTERNAL_ID));
         assertThat(foundGatewayAccount.get("payment_provider"), is(PAYMENT_PROVIDER.toString()));
-        assertThat(foundGatewayAccount.get("service_name"), is(SERVICE_NAME));
         assertThat(foundGatewayAccount.get("analytics_id"), is(ANALYTICS_ID));
         assertThat(foundGatewayAccount.get("type"), is(TYPE.toString()));
         assertThat(foundGatewayAccount.get("description"), is(DESCRIPTION));
@@ -260,7 +251,6 @@ public class GatewayAccountDaoIT {
         assertThat(foundGatewayAccount.get("id"), is(id));
         assertThat(foundGatewayAccount.get("external_id"), is(EXTERNAL_ID));
         assertThat(foundGatewayAccount.get("payment_provider"), is(PAYMENT_PROVIDER.toString()));
-        assertThat(foundGatewayAccount.get("service_name"), is(SERVICE_NAME));
         assertThat(foundGatewayAccount.get("analytics_id"), is(ANALYTICS_ID));
         assertThat(foundGatewayAccount.get("type"), is(TYPE.toString()));
         assertThat(foundGatewayAccount.get("description"), is(DESCRIPTION));

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
@@ -48,7 +48,6 @@ import static uk.gov.pay.directdebit.util.ResponseContainsLinkMatcher.containsLi
 public class GatewayAccountResourceIT {
 
     private static final PaymentProvider PAYMENT_PROVIDER = PaymentProvider.SANDBOX;
-    private static final String SERVICE_NAME = "alex";
     private static final String DESCRIPTION = "is awesome";
     private static final String ANALYTICS_ID = "DD_234098_BBBLA";
     private static final GatewayAccount.Type TYPE = GatewayAccount.Type.TEST;
@@ -57,7 +56,6 @@ public class GatewayAccountResourceIT {
     private static final String PAYMENT_PROVIDER_KEY = "payment_provider";
     private static final String EXTERNAL_ID_KEY = "gateway_account_external_id";
     private static final String TYPE_KEY = "type";
-    private static final String SERVICE_NAME_KEY = "service_name";
     private static final String DESCRIPTION_KEY = "description";
     private static final String ANALYTICS_ID_KEY = "analytics_id";
     private static final String ACCESS_TOKEN_KEY = "access_token";
@@ -70,11 +68,9 @@ public class GatewayAccountResourceIT {
 
     @Before
     public void setUp() {
-        testGatewayAccount =
-                aGatewayAccountFixture()
+        testGatewayAccount = aGatewayAccountFixture()
                         .withExternalId(EXTERNAL_ID)
                         .withPaymentProvider(PAYMENT_PROVIDER)
-                        .withServiceName(SERVICE_NAME)
                         .withDescription(DESCRIPTION)
                         .withType(TYPE)
                         .withAnalyticsId(ANALYTICS_ID)
@@ -92,7 +88,6 @@ public class GatewayAccountResourceIT {
                 .body(PAYMENT_PROVIDER_KEY, is(PAYMENT_PROVIDER.toString()))
                 .body(TYPE_KEY, is(TYPE.toString()))
                 .body(EXTERNAL_ID_KEY, is(EXTERNAL_ID))
-                .body(SERVICE_NAME_KEY, is(SERVICE_NAME))
                 .body(DESCRIPTION_KEY, is(DESCRIPTION))
                 .body(ANALYTICS_ID_KEY, is(ANALYTICS_ID));
     }
@@ -116,7 +111,6 @@ public class GatewayAccountResourceIT {
                 .contentType(JSON)
                 .body(PAYMENT_PROVIDER_KEY, is(PaymentProvider.GOCARDLESS.toString()))
                 .body(TYPE_KEY, is(GatewayAccount.Type.LIVE.toString()))
-                .body(SERVICE_NAME_KEY, is("service"))
                 .body(EXTERNAL_ID_KEY, is("externalId"))
                 .body("payment_method", is("DIRECT_DEBIT"))
                 .body("containsKey('description')", is(false))
@@ -155,7 +149,6 @@ public class GatewayAccountResourceIT {
               .body("accounts", hasSize(2))
 
               .body(format("accounts[0].%s", PAYMENT_PROVIDER_KEY), is(PAYMENT_PROVIDER.toString()))
-              .body(format("accounts[0].%s", SERVICE_NAME_KEY), is(SERVICE_NAME))
               .body(format("accounts[0].%s", DESCRIPTION_KEY), is(DESCRIPTION))
               .body(format("accounts[0].%s", ANALYTICS_ID_KEY), is(ANALYTICS_ID))
               .body(format("accounts[0].%s", EXTERNAL_ID_KEY), is(EXTERNAL_ID))
@@ -165,7 +158,6 @@ public class GatewayAccountResourceIT {
                     expectedGatewayAccountLocationFor(testGatewayAccount.getExternalId())))
 
               .body(format("accounts[1].%s", PAYMENT_PROVIDER_KEY), is(paymentProvider2.toString()))
-              .body(format("accounts[1].%s", SERVICE_NAME_KEY), is(serviceName2))
               .body(format("accounts[1].%s", DESCRIPTION_KEY), is(description2))
               .body(format("accounts[1].%s", ANALYTICS_ID_KEY), is(analyticsId2))
               .body(format("accounts[1].%s", EXTERNAL_ID_KEY), is(externalId2))
@@ -183,7 +175,6 @@ public class GatewayAccountResourceIT {
               .body("accounts", hasSize(1))
 
               .body(format("accounts[0].%s", PAYMENT_PROVIDER_KEY), is(paymentProvider2.toString()))
-              .body(format("accounts[0].%s", SERVICE_NAME_KEY), is(serviceName2))
               .body(format("accounts[0].%s", DESCRIPTION_KEY), is(description2))
               .body(format("accounts[0].%s", ANALYTICS_ID_KEY), is(analyticsId2))
               .body(format("accounts[0].%s", EXTERNAL_ID_KEY), is(externalId2))
@@ -225,7 +216,6 @@ public class GatewayAccountResourceIT {
             .body("accounts", hasSize(2))
 
             .body(format("accounts[0].%s", PAYMENT_PROVIDER_KEY), is(PAYMENT_PROVIDER.toString()))
-            .body(format("accounts[0].%s", SERVICE_NAME_KEY), is(SERVICE_NAME))
             .body(format("accounts[0].%s", DESCRIPTION_KEY), is(DESCRIPTION))
             .body(format("accounts[0].%s", ANALYTICS_ID_KEY), is(ANALYTICS_ID))
             .body(format("accounts[0].%s", EXTERNAL_ID_KEY), is(EXTERNAL_ID))
@@ -235,7 +225,6 @@ public class GatewayAccountResourceIT {
                   expectedGatewayAccountLocationFor(testGatewayAccount.getExternalId())))
 
             .body(format("accounts[1].%s", PAYMENT_PROVIDER_KEY), is(paymentProvider3.toString()))
-            .body(format("accounts[1].%s", SERVICE_NAME_KEY), is(serviceName3))
             .body(format("accounts[1].%s", DESCRIPTION_KEY), is(description3))
             .body(format("accounts[1].%s", ANALYTICS_ID_KEY), is(analyticsId3))
             .body(format("accounts[1].%s", EXTERNAL_ID_KEY), is(externalId3))
@@ -250,7 +239,6 @@ public class GatewayAccountResourceIT {
         String postBody = new ObjectMapper().writeValueAsString(ImmutableMap.builder()
                 .put(PAYMENT_PROVIDER_KEY, PAYMENT_PROVIDER.toString())
                 .put(TYPE_KEY, TYPE.toString())
-                .put(SERVICE_NAME_KEY, SERVICE_NAME)
                 .put(DESCRIPTION_KEY, DESCRIPTION)
                 .put(ANALYTICS_ID_KEY, ANALYTICS_ID)
                 .put(ACCESS_TOKEN_KEY, "123")
@@ -271,7 +259,6 @@ public class GatewayAccountResourceIT {
                 .header("Location", is(documentLocation))
                 .body("gateway_account_id", is(notNullValue()))
                 .body("gateway_account_external_id", startsWith("DIRECT_DEBIT:"))
-                .body("service_name", is(SERVICE_NAME))
                 .body("payment_provider", is(PAYMENT_PROVIDER.toString()))
                 .body("type", is(TYPE.toString()))
                 .body("description", is(DESCRIPTION))
@@ -288,7 +275,6 @@ public class GatewayAccountResourceIT {
         String postBody = new ObjectMapper().writeValueAsString(ImmutableMap.builder()
                 .put(PAYMENT_PROVIDER_KEY, PAYMENT_PROVIDER.toString())
                 .put(TYPE_KEY, TYPE.toString())
-                .put(SERVICE_NAME_KEY, SERVICE_NAME)
                 .build());
 
         ValidatableResponse response = givenSetup()
@@ -305,7 +291,6 @@ public class GatewayAccountResourceIT {
                 .header("Location", is(documentLocation))
                 .body("gateway_account_id", is(notNullValue()))
                 .body("gateway_account_external_id", startsWith("DIRECT_DEBIT:"))
-                .body("service_name", is(SERVICE_NAME))
                 .body("payment_provider", is(PAYMENT_PROVIDER.toString()))
                 .body("type", is(TYPE.toString()))
                 .body("description", is(nullValue()))
@@ -317,7 +302,7 @@ public class GatewayAccountResourceIT {
         String postBody = new ObjectMapper().writeValueAsString(ImmutableMap.builder()
                 .put(PAYMENT_PROVIDER_KEY, PAYMENT_PROVIDER.toString())
                 .put(TYPE_KEY, TYPE.toString())
-                .put(DESCRIPTION_KEY, DESCRIPTION)
+                .put(DESCRIPTION_KEY, "verylongdescription".repeat(25))
                 .put(ANALYTICS_ID_KEY, ANALYTICS_ID)
                 .build());
 
@@ -327,15 +312,14 @@ public class GatewayAccountResourceIT {
                 .then()
                 .contentType(JSON)
                 .statusCode(422)
-                .body("errors[0]", is("serviceName may not be empty"));
+                .body("errors[0]", is("description size must be between 0 and 255"));
     }
-
+    
     @Test
     public void shouldReturnBadRequestIfPaymentProviderIsInvalid() throws JsonProcessingException {
         String postBody = new ObjectMapper().writeValueAsString(ImmutableMap.builder()
                 .put(PAYMENT_PROVIDER_KEY, "INVALID")
                 .put(TYPE_KEY, TYPE.toString())
-                .put(SERVICE_NAME_KEY, SERVICE_NAME)
                 .put(DESCRIPTION_KEY, DESCRIPTION)
                 .put(ANALYTICS_ID_KEY, ANALYTICS_ID)
                 .build());

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java
@@ -89,7 +89,6 @@ public class GatewayAccountServiceTest {
         assertThat(gatewayAccount.getPaymentProvider(), is(PAYMENT_PROVIDER));
         assertThat(gatewayAccount.getAnalyticsId(), is(ANALYTICS_ID));
         assertThat(gatewayAccount.getDescription(), is(DESCRIPTION));
-        assertThat(gatewayAccount.getServiceName(), is(SERVICE_NAME));
         assertThat(gatewayAccount.getType(), is(TYPE));
     }
 
@@ -112,7 +111,6 @@ public class GatewayAccountServiceTest {
         assertThat(gatewayAccount.getPaymentProvider(), is(PAYMENT_PROVIDER));
         assertThat(gatewayAccount.getAnalyticsId(), is(ANALYTICS_ID));
         assertThat(gatewayAccount.getDescription(), is(DESCRIPTION));
-        assertThat(gatewayAccount.getServiceName(), is(SERVICE_NAME));
         assertThat(gatewayAccount.getType(), is(TYPE));
     }
 
@@ -174,12 +172,11 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldStoreAGatewayAccount() {
-        CreateGatewayAccountRequest request = new CreateGatewayAccountRequest(PaymentProvider.SANDBOX, "aServiceName", GatewayAccount.Type.TEST, 
+        CreateGatewayAccountRequest request = new CreateGatewayAccountRequest(PaymentProvider.SANDBOX, GatewayAccount.Type.TEST, 
                         "aDescription", "123", PaymentProviderAccessToken.of("token"), GoCardlessOrganisationId.valueOf("provider"));
         ArgumentCaptor<GatewayAccount> capturedGatewayAccount = ArgumentCaptor.forClass(GatewayAccount.class);
         service.create(request);
         verify(mockedGatewayAccountDao).insert(capturedGatewayAccount.capture());
-        assertThat(capturedGatewayAccount.getValue().getServiceName(), is("aServiceName"));
         assertThat(capturedGatewayAccount.getValue().getPaymentProvider(), is(PaymentProvider.SANDBOX));
     }
     

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GatewayAccountFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GatewayAccountFixture.java
@@ -136,7 +136,7 @@ public class GatewayAccountFixture implements DbFixture<GatewayAccountFixture, G
 
     @Override
     public GatewayAccount toEntity() {
-        return new GatewayAccount(id, externalId, paymentProvider, type, serviceName, description, analyticsId, accessToken, organisation);
+        return new GatewayAccount(id, externalId, paymentProvider, type, description, analyticsId, accessToken, organisation);
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentViewServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentViewServiceTest.java
@@ -75,7 +75,7 @@ public class PaymentViewServiceTest {
                     RandomIdGenerator.newId());
             paymentViewList.add(paymentView);
         }
-        gatewayAccount = new GatewayAccount(1L, gatewayAccountExternalId, null, null, null, null, null);
+        gatewayAccount = new GatewayAccount(1L, gatewayAccountExternalId, null, null, null, null);
         when(mockUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://app.com"),
                 UriBuilder.fromUri("http://app.com"));
         when(mockUriInfo.getPath()).thenReturn("/v1/api/accounts/" + gatewayAccount.getExternalId() + "/transactions/view");


### PR DESCRIPTION
I'm not sure whether to just remove the `@NotEmpty` on CreateGatewayAccountRequest's `serviceName` field first. Given direct debit connector isn't in production i thought maybe we could remove the `serviceName` field as well. This relates to https://github.com/alphagov/pay-selfservice/commit/422511d1e0cfcb37568b390902a8db7ed6eddc66.