### PR TITLE
PP-5242 Fix pact state for collect payment tests

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
@@ -25,7 +25,7 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
     private String serviceReference = RandomStringUtils.randomAlphanumeric(18);
     private MandateState state = MandateState.CREATED;
     private String returnUrl = "http://service.test/success-page";
-    private MandateType mandateType = MandateType.ONE_OFF;
+    private MandateType mandateType = MandateType.ON_DEMAND;
     private GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture();
     private PayerFixture payerFixture = null;
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -34,7 +34,6 @@ import java.util.Optional;
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"))
 //uncommenting the below is useful for testing pacts locally. grab the pact from the broker and put it in /pacts
 //@PactFolder("pacts")
-//@RunWith(PactRunner.class)
 public class PublicApiContractTest {
 
     @ClassRule
@@ -64,7 +63,10 @@ public class PublicApiContractTest {
     @State("a gateway account with external id and a mandate with external id exist")
     public void aGatewayAccountWithExternalIdAndAMandateWithExternalIdExist(Map<String, String> params) {
         testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
-        testMandate.withGatewayAccountFixture(testGatewayAccount).withExternalId(MandateExternalId.valueOf(params.get("mandate_id"))).insert(app.getTestContext().getJdbi());
+        testMandate.withGatewayAccountFixture(testGatewayAccount)
+                .withExternalId(MandateExternalId.valueOf(params.get("mandate_id")))
+                .withPayerFixture(PayerFixture.aPayerFixture())
+                .insert(app.getTestContext().getJdbi());
     }
 
     @State("three transaction records exist")


### PR DESCRIPTION
- There is not currently a pact test with Public API for the collect payment endpoint. Modify the setup of the state so that the test will work then it is added.