### PR TITLE
PP-5242 Make mandate type optional

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequest.java
@@ -23,11 +23,12 @@ public class CreateMandateRequest implements CreateRequest {
     }
 
     public static CreateMandateRequest of(Map<String, String> createMandateRequest) {
+        String agreementType = createMandateRequest.getOrDefault("agreement_type", MandateType.ON_DEMAND.toString());
+
         return new CreateMandateRequest(
                 createMandateRequest.get("return_url"),
-                MandateType.fromString(createMandateRequest.get("agreement_type")),
-                createMandateRequest.get("service_reference")
-        );
+                MandateType.fromString(agreementType),
+                createMandateRequest.get("service_reference"));
     }
 
     public String getReturnUrl() {

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequestValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequestValidator.java
@@ -19,7 +19,7 @@ public class CreateMandateRequestValidator extends ApiValidation {
                     .put(REFERENCE_KEY, ApiValidation::isNotNullOrEmpty)
                     .build();
 
-    private final static String[] requiredFields = {AGREEMENT_TYPE_KEY, RETURN_URL_KEY};
+    private final static String[] requiredFields = {RETURN_URL_KEY};
 
     private final static Map<String, FieldSize> fieldSizes =
             ImmutableMap.<String, FieldSize>builder()


### PR DESCRIPTION
Make agreement_type field in the create mandate request optional and default to ON_DEMAND so that it can be removed from consuming applications.

PP-5243 will remove mandate/agreement types entirely.