### PR TITLE
PP-5245: Make gocardless_creditor_id not null

### DIFF
--- a/src/main/resources/migrations/00049_alter_table_gocardless_mandates.sql
+++ b/src/main/resources/migrations/00049_alter_table_gocardless_mandates.sql
@@ -1,0 +1,1 @@
+ALTER TABLE gocardless_mandates ALTER COLUMN gocardless_creditor_id DROP NOT NULL;


### PR DESCRIPTION
This is a precusor to dropping the column
