### PR TITLE
PP-5246 Add payment_provider_id to mandates table

### DIFF
--- a/src/main/resources/migrations/00052_alter_table_mandates_add_payment_provider_id.sql
+++ b/src/main/resources/migrations/00052_alter_table_mandates_add_payment_provider_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mandates ADD COLUMN payment_provider_id VARCHAR(255);


### PR DESCRIPTION
- This id represents the id used by the payment provider (e.g. Gocardless)
to identify the mandate.