### PR TITLE
PP-5246 Add PaymentProviderId to mandates

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -33,7 +33,8 @@ public interface MandateDao {
             "  service_reference,\n" +
             "  state,\n" +
             "  return_url,\n" +
-            "  created_date\n" +
+            "  created_date,\n" +
+            "  payment_provider_id\n" +
             ") VALUES (\n" +
             "  :externalId,\n" +
             "  :gatewayAccount.id,\n" +
@@ -41,7 +42,8 @@ public interface MandateDao {
             "  :serviceReference,\n" +
             "  :state,\n" +
             "  :returnUrl,\n" +
-            "  :createdDate" +
+            "  :createdDate," +
+            "  :paymentProviderId" +
             ")")
     @GetGeneratedKeys
     Long insert(@BindBean Mandate mandate);
@@ -55,6 +57,7 @@ public interface MandateDao {
             "  m.return_url AS mandate_return_url," +
             "  m.state AS mandate_state," +
             "  m.created_date AS mandate_created_date," +
+            "  m.payment_provider_id AS mandate_payment_provider_id," +
             "  g.id AS gateway_account_id," +
             "  g.external_id AS gateway_account_external_id," +
             "  g.payment_provider AS gateway_account_payment_provider," +

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandateId.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandateId.java
@@ -1,41 +1,17 @@
 package uk.gov.pay.directdebit.mandate.model;
 
-import java.util.Objects;
-
 /**
  * The ID assigned by GoCardless to a Direct Debit mandate e.g. "MD123"
  * 
  * @see <a href="https://developer.gocardless.com/api-reference/#core-endpoints-mandates">GoCardless Mandates</a>
  */
-public class GoCardlessMandateId {
+public class GoCardlessMandateId extends PaymentProviderMandateId {
     
-    private final String goCardlessMandateId;
-
     private GoCardlessMandateId(String goCardlessEventId) {
-        this.goCardlessMandateId = Objects.requireNonNull(goCardlessEventId);
+        super(goCardlessEventId);
     }
 
     public static GoCardlessMandateId valueOf(String goCardlessMandateId) {
         return new GoCardlessMandateId(goCardlessMandateId);
     }
-
-    @Override
-    public String toString() {
-        return goCardlessMandateId;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other != null && other.getClass() == GoCardlessMandateId.class) {
-            GoCardlessMandateId that = (GoCardlessMandateId) other;
-            return this.goCardlessMandateId.equals(that.goCardlessMandateId);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return goCardlessMandateId.hashCode();
-    }
-    
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
@@ -5,6 +5,8 @@ import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.model.Payer;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
 
 public class Mandate {
     private Long id;
@@ -16,26 +18,19 @@ public class Mandate {
     private final String serviceReference;
     private final ZonedDateTime createdDate;
     private Payer payer;
+    private PaymentProviderMandateId paymentProviderId;
 
-    public Mandate(Long id,
-                   GatewayAccount gatewayAccount,
-                   MandateExternalId externalId,
-                   MandateBankStatementReference mandateReference,
-                   String serviceReference,
-                   MandateState state,
-                   String returnUrl,
-                   ZonedDateTime createdDate,
-                   Payer payer
-    ) {
-        this.id = id;
-        this.gatewayAccount = gatewayAccount;
-        this.externalId = externalId;
-        this.mandateReference = mandateReference;
-        this.serviceReference = serviceReference;
-        this.state = state;
-        this.returnUrl = returnUrl;
-        this.createdDate = createdDate;
-        this.payer = payer;
+    private Mandate(MandateBuilder builder) {
+        this.id = builder.id;
+        this.gatewayAccount = builder.gatewayAccount;
+        this.externalId = builder.externalId;
+        this.mandateReference = builder.mandateReference;
+        this.serviceReference = builder.serviceReference;
+        this.state = builder.state;
+        this.returnUrl = builder.returnUrl;
+        this.createdDate = builder.createdDate;
+        this.payer = builder.payer;
+        this.paymentProviderId = builder.paymentProviderId;
     }
 
     public Payer getPayer() {
@@ -86,56 +81,109 @@ public class Mandate {
         this.mandateReference = mandateReference;
     }
 
+    public Optional<PaymentProviderMandateId> getPaymentProviderId() {
+        return Optional.ofNullable(paymentProviderId);
+    }
+
+    public void setPaymentProviderId(PaymentProviderMandateId paymentProviderId) {
+        this.paymentProviderId = paymentProviderId;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         Mandate mandate = (Mandate) o;
-
-        if (id != null ? !id.equals(mandate.id) : mandate.id != null) {
-            return false;
-        }
-        if (!externalId.equals(mandate.externalId)) {
-            return false;
-        }
-        if (state != mandate.state) {
-            return false;
-        }
-        if (!gatewayAccount.equals(mandate.gatewayAccount)) {
-            return false;
-        }
-        if (!returnUrl.equals(mandate.returnUrl)) {
-            return false;
-        }
-        if (mandateReference != null ? !mandateReference.equals(mandate.mandateReference) : mandate.mandateReference != null) {
-            return false;
-        }
-        if (serviceReference != null ? !serviceReference.equals(mandate.serviceReference) : mandate.serviceReference != null) {
-            return false;
-        }
-        if (payer != null ? !payer.equals(mandate.payer) : mandate.payer != null) {
-            return false;
-        }
-
-        return createdDate.equals(mandate.createdDate);
+        return Objects.equals(id, mandate.id) &&
+                Objects.equals(externalId, mandate.externalId) &&
+                state == mandate.state &&
+                Objects.equals(gatewayAccount, mandate.gatewayAccount) &&
+                Objects.equals(returnUrl, mandate.returnUrl) &&
+                Objects.equals(mandateReference, mandate.mandateReference) &&
+                Objects.equals(serviceReference, mandate.serviceReference) &&
+                Objects.equals(createdDate, mandate.createdDate) &&
+                Objects.equals(payer, mandate.payer) &&
+                Objects.equals(paymentProviderId, mandate.paymentProviderId);
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + externalId.hashCode();
-        result = 31 * result + state.hashCode();
-        result = 31 * result + (payer != null ? payer.hashCode() : 0);
-        result = 31 * result + gatewayAccount.hashCode();
-        result = 31 * result + returnUrl.hashCode();
-        result = 31 * result + mandateReference.hashCode();
-        result = 31 * result + (serviceReference != null ? serviceReference.hashCode() : 0);
-        result = 31 * result + createdDate.hashCode();
-        return result;
+        return Objects.hash(id, externalId, state, gatewayAccount, returnUrl,
+                mandateReference, serviceReference, createdDate, payer, paymentProviderId);
+    }
+
+
+    public static final class MandateBuilder {
+        private Long id;
+        private MandateExternalId externalId;
+        private MandateState state;
+        private GatewayAccount gatewayAccount;
+        private String returnUrl;
+        private MandateBankStatementReference mandateReference;
+        private String serviceReference;
+        private ZonedDateTime createdDate;
+        private Payer payer;
+        private PaymentProviderMandateId paymentProviderId;
+
+        private MandateBuilder() {
+        }
+
+        public static MandateBuilder aMandate() {
+            return new MandateBuilder();
+        }
+
+        public MandateBuilder withId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public MandateBuilder withExternalId(MandateExternalId externalId) {
+            this.externalId = externalId;
+            return this;
+        }
+
+        public MandateBuilder withState(MandateState state) {
+            this.state = state;
+            return this;
+        }
+
+        public MandateBuilder withGatewayAccount(GatewayAccount gatewayAccount) {
+            this.gatewayAccount = gatewayAccount;
+            return this;
+        }
+
+        public MandateBuilder withReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+        }
+
+        public MandateBuilder withMandateReference(MandateBankStatementReference mandateReference) {
+            this.mandateReference = mandateReference;
+            return this;
+        }
+
+        public MandateBuilder withServiceReference(String serviceReference) {
+            this.serviceReference = serviceReference;
+            return this;
+        }
+
+        public MandateBuilder withCreatedDate(ZonedDateTime createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public MandateBuilder withPayer(Payer payer) {
+            this.payer = payer;
+            return this;
+        }
+
+        public MandateBuilder withPaymentProviderId(PaymentProviderMandateId paymentProviderId) {
+            this.paymentProviderId = paymentProviderId;
+            return this;
+        }
+
+        public Mandate build() {
+            return new Mandate(this);
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/PaymentProviderMandateId.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/PaymentProviderMandateId.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import java.util.Objects;
+
+public abstract class PaymentProviderMandateId {
+
+    private final String paymentProviderId;
+
+    PaymentProviderMandateId(String paymentProviderId) {
+        this.paymentProviderId = Objects.requireNonNull(paymentProviderId);
+    }
+
+    @Override
+    public String toString() {
+        return paymentProviderId;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null) {
+            PaymentProviderMandateId that = (PaymentProviderMandateId) other;
+            return this.paymentProviderId.equals(that.paymentProviderId);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return paymentProviderId.hashCode();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/SandboxMandateId.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/SandboxMandateId.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+/**
+ * The ID of the mandate used by Sandbox provider
+ */
+public class SandboxMandateId extends PaymentProviderMandateId {
+
+    private SandboxMandateId(String sandboxMandateId) {
+        super(sandboxMandateId);
+    }
+
+    public static SandboxMandateId valueOf(String sandBoxMandateId) {
+        return new SandboxMandateId(sandBoxMandateId);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -46,6 +46,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.createLink;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.nextUrl;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.selfUriFor;
+import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 
 public class MandateService {
@@ -86,16 +87,16 @@ public class MandateService {
                             PaymentProvider.SANDBOX.equals(gatewayAccount.getPaymentProvider()) ?
                                     RandomStringUtils.randomAlphanumeric(18) : "gocardless-default");
 
-                    Mandate mandate = new Mandate(
-                            null,
-                            gatewayAccount,
-                            MandateExternalId.valueOf(RandomIdGenerator.newId()),
-                            mandateReference,
-                            createRequest.getReference(),
-                            MandateState.CREATED,
-                            createRequest.getReturnUrl(),
-                            ZonedDateTime.now(ZoneOffset.UTC),
-                            null);
+                    Mandate mandate = aMandate()
+                            .withGatewayAccount(gatewayAccount)
+                            .withExternalId(MandateExternalId.valueOf(RandomIdGenerator.newId()))
+                            .withMandateReference(mandateReference)
+                            .withServiceReference(createRequest.getReference())
+                            .withState(MandateState.CREATED)
+                            .withReturnUrl(createRequest.getReturnUrl())
+                            .withCreatedDate(ZonedDateTime.now(ZoneOffset.UTC))
+                            .build();
+
                     LOGGER.info("Creating mandate external id {}", mandate.getExternalId());
                     Long id = mandateDao.insert(mandate);
                     mandate.setId(id);

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -19,6 +19,8 @@ import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
+import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
+
 public class TransactionMapper implements RowMapper<Transaction> {
 
     private static final String TRANSACTION_ID_COLUMN = "transaction_id";
@@ -90,16 +92,17 @@ public class TransactionMapper implements RowMapper<Transaction> {
             gatewayAccount.setOrganisation(GoCardlessOrganisationId.valueOf(organisation));
         }
 
-        Mandate mandate = new Mandate(
-                resultSet.getLong(MANDATE_ID_COLUMN),
-                gatewayAccount,
-                MandateExternalId.valueOf(resultSet.getString(MANDATE_EXTERNAL_ID_COLUMN)),
-                MandateBankStatementReference.valueOf(resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN)),
-                resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN),
-                MandateState.valueOf(resultSet.getString(MANDATE_STATE_COLUMN)),
-                resultSet.getString(MANDATE_RETURN_URL_COLUMN),
-                ZonedDateTime.ofInstant(resultSet.getTimestamp(MANDATE_CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC),
-                payer);
+        Mandate mandate = aMandate()
+                .withId(resultSet.getLong(MANDATE_ID_COLUMN))
+                .withGatewayAccount(gatewayAccount)
+                .withExternalId(MandateExternalId.valueOf(resultSet.getString(MANDATE_EXTERNAL_ID_COLUMN)))
+                .withMandateReference(MandateBankStatementReference.valueOf(resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN)))
+                .withServiceReference(resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN))
+                .withState(MandateState.valueOf(resultSet.getString(MANDATE_STATE_COLUMN)))
+                .withReturnUrl(resultSet.getString(MANDATE_RETURN_URL_COLUMN))
+                .withCreatedDate(ZonedDateTime.ofInstant(resultSet.getTimestamp(MANDATE_CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC))
+                .withPayer(payer)
+                .build();
 
         return new Transaction(
                 resultSet.getLong(TRANSACTION_ID_COLUMN),

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -53,6 +53,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.AWAITING_DIRECT_DEBIT_DETAILS;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
@@ -200,16 +201,16 @@ public class MandateServiceTest {
     @Test
     public void confirm_shouldNotConfirmOnDemandMandateForInvalidState() {
         GatewayAccount gatewayAccount = aGatewayAccountFixture().withPaymentProvider(PaymentProvider.SANDBOX).toEntity();
-        Mandate mandate = new Mandate(
-                null,
-                gatewayAccount,
-                MandateExternalId.valueOf(RandomIdGenerator.newId()),
-                MandateBankStatementReference.valueOf("mandateReference"),
-                "reference",
-                MandateState.CANCELLED,
-                "http://returnUrl",
-                ZonedDateTime.now(ZoneOffset.UTC),
-                null);
+        Mandate mandate = aMandate()
+                .withGatewayAccount(gatewayAccount)
+                .withExternalId(MandateExternalId.valueOf(RandomIdGenerator.newId()))
+                .withMandateReference(MandateBankStatementReference.valueOf("mandateReference"))
+                .withServiceReference("reference")
+                .withState(MandateState.CANCELLED)
+                .withReturnUrl("http://returnUrl")
+                .withCreatedDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .build();
+
         Map<String, String> confirmMandateRequest = Map.of("sort_code", "123456", "account_number", "12345678");
         ConfirmMandateRequest mandateConfirmationRequest = ConfirmMandateRequest.of(confirmMandateRequest);
 


### PR DESCRIPTION
- Create PaymentProviderMandateId abstract class
- Make GoCardlessMandateId and SandboxMandateId extend PaymentProviderMandateId
- add paymentProviderId to Mandate typed as PaymentProviderMandateId.
- add MandateBuilder to avoid overloaded constructor with many arguments.
- amend SQL to store and retrieve payment_provider_id
- amend tests to ensure correct read/write of payment_provider_id.
