### PR TITLE
PP-5246 No longer persist GoCardlessMandate

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacade.java
@@ -9,6 +9,7 @@ import com.gocardless.resources.CustomerBankAccount;
 import com.gocardless.resources.Payment;
 import uk.gov.pay.directdebit.common.model.subtype.SunName;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateAdaptor;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessPayment;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
@@ -50,12 +51,9 @@ public class GoCardlessClientFacade {
         return customer;
     }
 
-    public GoCardlessMandate createMandate(Mandate mandate, GoCardlessCustomer customer) {
+    public Mandate createMandate(Mandate mandate, GoCardlessCustomer customer) {
         com.gocardless.resources.Mandate gcMandate = goCardlessClientWrapper.createMandate(mandate.getExternalId(), customer);
-        return new GoCardlessMandate(
-                mandate.getId(),
-                GoCardlessMandateId.valueOf(gcMandate.getId()),
-                MandateBankStatementReference.valueOf(gcMandate.getReference()));
+        return new GoCardlessMandateAdaptor(gcMandate, mandate);
     }
 
     public GoCardlessPayment createPayment(Transaction transaction, GoCardlessMandate mandate) {

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDao.java
@@ -24,7 +24,4 @@ public interface GoCardlessMandateDao {
     @SqlQuery("SELECT * FROM gocardless_mandates m WHERE m.mandate_id = :mandateId")
     Optional<GoCardlessMandate> findByMandateId(@Bind("mandateId") Long mandateId);
 
-    @SqlUpdate("INSERT INTO gocardless_mandates(mandate_id, gocardless_mandate_id) VALUES (:mandateId, :goCardlessMandateId)")
-    @GetGeneratedKeys
-    Long insert(@BindBean GoCardlessMandate mandate);
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -8,11 +8,14 @@ import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.mandate.dao.mapper.MandateMapper;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReferenceArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
+import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateId;
+import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalIdArgumentFactory;
 
@@ -23,6 +26,7 @@ import java.util.Set;
 
 @RegisterArgumentFactory(MandateExternalIdArgumentFactory.class)
 @RegisterArgumentFactory(MandateBankStatementReferenceArgumentFactory.class)
+@RegisterArgumentFactory(PaymentProviderMandateIdArgumentFactory.class)
 @RegisterRowMapper(MandateMapper.class)
 public interface MandateDao {
 
@@ -38,12 +42,12 @@ public interface MandateDao {
             ") VALUES (\n" +
             "  :externalId,\n" +
             "  :gatewayAccount.id,\n" +
-            "  :mandateReference,\n" +
+            "  :mandateBankStatementReference,\n" +
             "  :serviceReference,\n" +
             "  :state,\n" +
             "  :returnUrl,\n" +
             "  :createdDate," +
-            "  :paymentProviderId" +
+            "  :paymentProviderMandateId" +
             ")")
     @GetGeneratedKeys
     Long insert(@BindBean Mandate mandate);
@@ -97,6 +101,6 @@ public interface MandateDao {
     @SqlUpdate("UPDATE mandates m SET state = :state WHERE m.id = :id")
     int updateState(@Bind("id") Long id, @Bind("state") MandateState mandateState);
 
-    @SqlUpdate("UPDATE mandates m SET mandate_reference = :mandateReference WHERE m.id = :id")
-    int updateMandateReference(@Bind("id") Long id, @Bind("mandateReference") MandateBankStatementReference mandateReference);
+    @SqlUpdate("UPDATE mandates m SET mandate_reference = :mandateBankStatementReference, payment_provider_id = :paymentProviderMandateId WHERE m.id = :id")
+    int updateReferenceAndPaymentProviderId(@BindBean Mandate mandate);
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
@@ -8,7 +8,7 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
-import uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder;
+import uk.gov.pay.directdebit.mandate.model.MandateImpl.MandateBuilder;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
+import static uk.gov.pay.directdebit.mandate.model.MandateImpl.MandateBuilder.aMandate;
 
 public class MandateMapper implements RowMapper<Mandate> {
 
@@ -90,7 +90,7 @@ public class MandateMapper implements RowMapper<Mandate> {
                 .withId(resultSet.getLong(ID_COLUMN))
                 .withGatewayAccount(gatewayAccount)
                 .withExternalId(MandateExternalId.valueOf(resultSet.getString(EXTERNAL_ID_COLUMN)))
-                .withMandateReference(MandateBankStatementReference.valueOf(resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN)))
+                .withMandateBankStatementReference(MandateBankStatementReference.valueOf(resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN)))
                 .withServiceReference(resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN))
                 .withState(MandateState.valueOf(resultSet.getString(STATE_COLUMN)))
                 .withReturnUrl(resultSet.getString(RETURN_URL_COLUMN))

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandateAdaptor.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/GoCardlessMandateAdaptor.java
@@ -1,0 +1,80 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
+import uk.gov.pay.directdebit.payers.model.Payer;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public class GoCardlessMandateAdaptor implements Mandate{
+
+    private final com.gocardless.resources.Mandate goCardlessMandate;
+    private final Mandate mandate;
+
+    public GoCardlessMandateAdaptor(com.gocardless.resources.Mandate goCardlessMandate, Mandate mandate) {
+        this.goCardlessMandate = goCardlessMandate;
+        this.mandate = mandate;
+    }
+
+    @Override
+    public Payer getPayer() {
+        return mandate.getPayer();
+    }
+
+    @Override
+    public GatewayAccount getGatewayAccount() {
+        return mandate.getGatewayAccount();
+    }
+
+    @Override
+    public String getReturnUrl() {
+        return mandate.getReturnUrl();
+    }
+
+    @Override
+    public ZonedDateTime getCreatedDate() {
+        return mandate.getCreatedDate();
+    }
+
+    @Override
+    public Long getId() {
+        return mandate.getId();
+    }
+
+    @Override
+    public void setId(Long id) {
+        mandate.setId(id);
+    }
+
+    @Override
+    public MandateExternalId getExternalId() {
+        return mandate.getExternalId();
+    }
+
+    @Override
+    public MandateState getState() {
+        return mandate.getState();
+    }
+
+    @Override
+    public void setState(MandateState state) {
+        mandate.setState(state);
+    }
+
+    @Override
+    public MandateBankStatementReference getMandateBankStatementReference() {
+        return MandateBankStatementReference.valueOf(goCardlessMandate.getReference());
+    }
+
+    @Override
+    public String getServiceReference() {
+        return mandate.getServiceReference();
+    }
+
+    @Override
+    public Optional<PaymentProviderMandateId> getPaymentProviderMandateId() {
+        return Optional.of(GoCardlessMandateId.valueOf(goCardlessMandate.getId()));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
@@ -5,185 +5,31 @@ import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.model.Payer;
 
 import java.time.ZonedDateTime;
-import java.util.Objects;
 import java.util.Optional;
 
-public class Mandate {
-    private Long id;
-    private final MandateExternalId externalId;
-    private MandateState state;
-    private final GatewayAccount gatewayAccount;
-    private final String returnUrl;
-    private MandateBankStatementReference mandateReference;
-    private final String serviceReference;
-    private final ZonedDateTime createdDate;
-    private Payer payer;
-    private PaymentProviderMandateId paymentProviderId;
+public interface Mandate {
+    Payer getPayer();
 
-    private Mandate(MandateBuilder builder) {
-        this.id = builder.id;
-        this.gatewayAccount = builder.gatewayAccount;
-        this.externalId = builder.externalId;
-        this.mandateReference = builder.mandateReference;
-        this.serviceReference = builder.serviceReference;
-        this.state = builder.state;
-        this.returnUrl = builder.returnUrl;
-        this.createdDate = builder.createdDate;
-        this.payer = builder.payer;
-        this.paymentProviderId = builder.paymentProviderId;
-    }
+    GatewayAccount getGatewayAccount();
 
-    public Payer getPayer() {
-        return payer;
-    }
+    String getReturnUrl();
 
-    public GatewayAccount getGatewayAccount() {
-        return gatewayAccount;
-    }
+    ZonedDateTime getCreatedDate();
 
-    public String getReturnUrl() {
-        return returnUrl;
-    }
+    Long getId();
 
-    public ZonedDateTime getCreatedDate() {
-        return createdDate;
-    }
+    void setId(Long id);
 
-    public Long getId() {
-        return id;
-    }
+    MandateExternalId getExternalId();
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+    MandateState getState();
 
-    public MandateExternalId getExternalId() {
-        return externalId;
-    }
+    void setState(MandateState state);
 
-    public MandateState getState() {
-        return state;
-    }
+    MandateBankStatementReference getMandateBankStatementReference();
 
-    public void setState(MandateState state) {
-        this.state = state;
-    }
+    String getServiceReference();
 
-    public MandateBankStatementReference getMandateReference() {
-        return mandateReference;
-    }
+    Optional<PaymentProviderMandateId> getPaymentProviderMandateId();
 
-    public String getServiceReference() {
-        return serviceReference;
-    }
-
-    public void setMandateReference(MandateBankStatementReference mandateReference) {
-        this.mandateReference = mandateReference;
-    }
-
-    public Optional<PaymentProviderMandateId> getPaymentProviderId() {
-        return Optional.ofNullable(paymentProviderId);
-    }
-
-    public void setPaymentProviderId(PaymentProviderMandateId paymentProviderId) {
-        this.paymentProviderId = paymentProviderId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Mandate mandate = (Mandate) o;
-        return Objects.equals(id, mandate.id) &&
-                Objects.equals(externalId, mandate.externalId) &&
-                state == mandate.state &&
-                Objects.equals(gatewayAccount, mandate.gatewayAccount) &&
-                Objects.equals(returnUrl, mandate.returnUrl) &&
-                Objects.equals(mandateReference, mandate.mandateReference) &&
-                Objects.equals(serviceReference, mandate.serviceReference) &&
-                Objects.equals(createdDate, mandate.createdDate) &&
-                Objects.equals(payer, mandate.payer) &&
-                Objects.equals(paymentProviderId, mandate.paymentProviderId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, externalId, state, gatewayAccount, returnUrl,
-                mandateReference, serviceReference, createdDate, payer, paymentProviderId);
-    }
-
-
-    public static final class MandateBuilder {
-        private Long id;
-        private MandateExternalId externalId;
-        private MandateState state;
-        private GatewayAccount gatewayAccount;
-        private String returnUrl;
-        private MandateBankStatementReference mandateReference;
-        private String serviceReference;
-        private ZonedDateTime createdDate;
-        private Payer payer;
-        private PaymentProviderMandateId paymentProviderId;
-
-        private MandateBuilder() {
-        }
-
-        public static MandateBuilder aMandate() {
-            return new MandateBuilder();
-        }
-
-        public MandateBuilder withId(Long id) {
-            this.id = id;
-            return this;
-        }
-
-        public MandateBuilder withExternalId(MandateExternalId externalId) {
-            this.externalId = externalId;
-            return this;
-        }
-
-        public MandateBuilder withState(MandateState state) {
-            this.state = state;
-            return this;
-        }
-
-        public MandateBuilder withGatewayAccount(GatewayAccount gatewayAccount) {
-            this.gatewayAccount = gatewayAccount;
-            return this;
-        }
-
-        public MandateBuilder withReturnUrl(String returnUrl) {
-            this.returnUrl = returnUrl;
-            return this;
-        }
-
-        public MandateBuilder withMandateReference(MandateBankStatementReference mandateReference) {
-            this.mandateReference = mandateReference;
-            return this;
-        }
-
-        public MandateBuilder withServiceReference(String serviceReference) {
-            this.serviceReference = serviceReference;
-            return this;
-        }
-
-        public MandateBuilder withCreatedDate(ZonedDateTime createdDate) {
-            this.createdDate = createdDate;
-            return this;
-        }
-
-        public MandateBuilder withPayer(Payer payer) {
-            this.payer = payer;
-            return this;
-        }
-
-        public MandateBuilder withPaymentProviderId(PaymentProviderMandateId paymentProviderId) {
-            this.paymentProviderId = paymentProviderId;
-            return this;
-        }
-
-        public Mandate build() {
-            return new Mandate(this);
-        }
-    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateImpl.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateImpl.java
@@ -1,0 +1,201 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
+import uk.gov.pay.directdebit.payers.model.Payer;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
+
+public class MandateImpl implements Mandate {
+    private Long id;
+    private final MandateExternalId externalId;
+    private MandateState state;
+    private final GatewayAccount gatewayAccount;
+    private final String returnUrl;
+    private MandateBankStatementReference mandateBankStatementReference;
+    private final String serviceReference;
+    private final ZonedDateTime createdDate;
+    private Payer payer;
+    private PaymentProviderMandateId paymentProviderMandateId;
+
+    private MandateImpl(MandateBuilder builder) {
+        this.id = builder.id;
+        this.gatewayAccount = builder.gatewayAccount;
+        this.externalId = builder.externalId;
+        this.mandateBankStatementReference = builder.mandateBankStatementReference;
+        this.serviceReference = builder.serviceReference;
+        this.state = builder.state;
+        this.returnUrl = builder.returnUrl;
+        this.createdDate = builder.createdDate;
+        this.payer = builder.payer;
+        this.paymentProviderMandateId = builder.paymentProviderId;
+    }
+
+    @Override
+    public Payer getPayer() {
+        return payer;
+    }
+
+    @Override
+    public GatewayAccount getGatewayAccount() {
+        return gatewayAccount;
+    }
+
+    @Override
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    @Override
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public MandateExternalId getExternalId() {
+        return externalId;
+    }
+
+    @Override
+    public MandateState getState() {
+        return state;
+    }
+
+    @Override
+    public void setState(MandateState state) {
+        this.state = state;
+    }
+
+    @Override
+    public MandateBankStatementReference getMandateBankStatementReference() {
+        return mandateBankStatementReference;
+    }
+
+    @Override
+    public String getServiceReference() {
+        return serviceReference;
+    }
+
+    public void setMandateBankStatementReference(MandateBankStatementReference mandateBankStatementReference) {
+        this.mandateBankStatementReference = mandateBankStatementReference;
+    }
+
+    @Override
+    public Optional<PaymentProviderMandateId> getPaymentProviderMandateId() {
+        return Optional.ofNullable(paymentProviderMandateId);
+    }
+
+    public void setPaymentProviderMandateId(PaymentProviderMandateId paymentProviderMandateId) {
+        this.paymentProviderMandateId = paymentProviderMandateId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MandateImpl mandate = (MandateImpl) o;
+        return Objects.equals(id, mandate.id) &&
+                Objects.equals(externalId, mandate.externalId) &&
+                state == mandate.state &&
+                Objects.equals(gatewayAccount, mandate.gatewayAccount) &&
+                Objects.equals(returnUrl, mandate.returnUrl) &&
+                Objects.equals(mandateBankStatementReference, mandate.mandateBankStatementReference) &&
+                Objects.equals(serviceReference, mandate.serviceReference) &&
+                Objects.equals(createdDate, mandate.createdDate) &&
+                Objects.equals(payer, mandate.payer) &&
+                Objects.equals(paymentProviderMandateId, mandate.paymentProviderMandateId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, externalId, state, gatewayAccount, returnUrl,
+                mandateBankStatementReference, serviceReference, createdDate, payer, paymentProviderMandateId);
+    }
+
+
+    public static final class MandateBuilder {
+        private Long id;
+        private MandateExternalId externalId;
+        private MandateState state;
+        private GatewayAccount gatewayAccount;
+        private String returnUrl;
+        private MandateBankStatementReference mandateBankStatementReference;
+        private String serviceReference;
+        private ZonedDateTime createdDate;
+        private Payer payer;
+        private PaymentProviderMandateId paymentProviderId;
+
+        private MandateBuilder() {
+        }
+
+        public static MandateBuilder aMandate() {
+            return new MandateBuilder();
+        }
+
+        public MandateBuilder withId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public MandateBuilder withExternalId(MandateExternalId externalId) {
+            this.externalId = externalId;
+            return this;
+        }
+
+        public MandateBuilder withState(MandateState state) {
+            this.state = state;
+            return this;
+        }
+
+        public MandateBuilder withGatewayAccount(GatewayAccount gatewayAccount) {
+            this.gatewayAccount = gatewayAccount;
+            return this;
+        }
+
+        public MandateBuilder withReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+        }
+
+        public MandateBuilder withMandateBankStatementReference(MandateBankStatementReference mandateReference) {
+            this.mandateBankStatementReference = mandateReference;
+            return this;
+        }
+
+        public MandateBuilder withServiceReference(String serviceReference) {
+            this.serviceReference = serviceReference;
+            return this;
+        }
+
+        public MandateBuilder withCreatedDate(ZonedDateTime createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public MandateBuilder withPayer(Payer payer) {
+            this.payer = payer;
+            return this;
+        }
+
+        public MandateBuilder withPaymentProviderId(PaymentProviderMandateId paymentProviderId) {
+            this.paymentProviderId = paymentProviderId;
+            return this;
+        }
+
+        public MandateImpl build() {
+            return new MandateImpl(this);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/PaymentProviderMandateIdArgumentFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/PaymentProviderMandateIdArgumentFactory.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import java.sql.Types;
+
+public class PaymentProviderMandateIdArgumentFactory extends AbstractArgumentFactory<PaymentProviderMandateId> {
+
+    public PaymentProviderMandateIdArgumentFactory() {
+        super(Types.VARCHAR);
+    }
+
+    @Override
+    protected Argument build(PaymentProviderMandateId value, ConfigRegistry config) {
+        String paymentProviderMandateId = value == null ? null : value.toString();
+        return (pos, stmt, context) -> stmt.setString(pos, paymentProviderMandateId);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateQueryService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateQueryService.java
@@ -1,14 +1,15 @@
 package uk.gov.pay.directdebit.mandate.services;
 
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Set;
-import javax.inject.Inject;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.exception.MandateNotFoundException;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
 
 public class MandateQueryService {
     private MandateDao mandateDao;

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -46,7 +46,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.createLink;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.nextUrl;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.selfUriFor;
-import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
+import static uk.gov.pay.directdebit.mandate.model.MandateImpl.MandateBuilder.aMandate;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
 
 public class MandateService {
@@ -90,7 +90,7 @@ public class MandateService {
                     Mandate mandate = aMandate()
                             .withGatewayAccount(gatewayAccount)
                             .withExternalId(MandateExternalId.valueOf(RandomIdGenerator.newId()))
-                            .withMandateReference(mandateReference)
+                            .withMandateBankStatementReference(mandateReference)
                             .withServiceReference(createRequest.getReference())
                             .withState(MandateState.CREATED)
                             .withReturnUrl(createRequest.getReturnUrl())
@@ -121,7 +121,7 @@ public class MandateService {
                 mandate.getState().toExternal(),
                 dataLinks,
                 mandate.getServiceReference(),
-                mandate.getMandateReference());
+                mandate.getMandateBankStatementReference());
     }
 
     public TokenExchangeDetails getMandateFor(String token) {
@@ -143,7 +143,7 @@ public class MandateService {
                 accountExternalId,
                 mandate.getState(),
                 mandate.getReturnUrl(),
-                mandate.getMandateReference(),
+                mandate.getMandateBankStatementReference(),
                 mandate.getCreatedDate(),
                 mandate.getPayer(),
                 transaction
@@ -158,7 +158,7 @@ public class MandateService {
                 accountExternalId,
                 mandate.getState(),
                 mandate.getReturnUrl(),
-                mandate.getMandateReference(),
+                mandate.getMandateBankStatementReference(),
                 mandate.getCreatedDate(),
                 mandate.getPayer(),
                 null
@@ -175,7 +175,7 @@ public class MandateService {
                 dataLinks,
                 mandate.getState().toExternal(),
                 mandate.getServiceReference(),
-                mandate.getMandateReference());
+                mandate.getMandateBankStatementReference());
     }
 
     public Mandate findByExternalId(MandateExternalId externalId) {

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
@@ -130,7 +130,7 @@ public class MandateStateUpdateService {
 
     private Mandate confirmedDetailsFor(Mandate mandate) {
         updateStateFor(mandate, DIRECT_DEBIT_DETAILS_CONFIRMED);
-        mandateDao.updateMandateReference(mandate.getId(), mandate.getMandateReference());
+        mandateDao.updateReferenceAndPaymentProviderId(mandate);
         return mandate;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -42,7 +42,7 @@ public class UserNotificationService {
     public void sendMandateFailedEmailFor(Mandate mandate) {
         adminUsersClient.sendEmail(EmailTemplate.MANDATE_FAILED, mandate,
                 ImmutableMap.of(
-                        MANDATE_REFERENCE_KEY, mandate.getMandateReference().toString(),
+                        MANDATE_REFERENCE_KEY, mandate.getMandateBankStatementReference().toString(),
                         DD_GUARANTEE_KEY, directDebitConfig.getLinks().getDirectDebitGuaranteeUrl()
                 )
         );
@@ -58,7 +58,7 @@ public class UserNotificationService {
 
         adminUsersClient.sendEmail(template, mandate,
                 ImmutableMap.<String, String>builder()
-                        .put(MANDATE_REFERENCE_KEY, mandate.getMandateReference().toString())
+                        .put(MANDATE_REFERENCE_KEY, mandate.getMandateBankStatementReference().toString())
                         .put(BANK_ACCOUNT_LAST_DIGITS_KEY, mandate.getPayer().getAccountNumberLastTwoDigits())
                         .put(STATEMENT_NAME_KEY, sunName.get().toString())
                         .put(DD_GUARANTEE_KEY, directDebitConfig.getLinks().getDirectDebitGuaranteeUrl())
@@ -69,7 +69,7 @@ public class UserNotificationService {
     public void sendMandateCancelledEmailFor(Mandate mandate) {
         adminUsersClient.sendEmail(EmailTemplate.MANDATE_CANCELLED, mandate,
                 ImmutableMap.of(
-                        MANDATE_REFERENCE_KEY, mandate.getMandateReference().toString(),
+                        MANDATE_REFERENCE_KEY, mandate.getMandateBankStatementReference().toString(),
                         DD_GUARANTEE_KEY, directDebitConfig.getLinks().getDirectDebitGuaranteeUrl()
                 )
         );
@@ -95,7 +95,7 @@ public class UserNotificationService {
                 ImmutableMap.<String, String>builder()
                         .put(AMOUNT_KEY, formatToPounds(transaction.getAmount()))
                         .put(COLLECTION_DATE_KEY, DATE_TIME_FORMATTER.format(earliestChargeDate))
-                        .put(MANDATE_REFERENCE_KEY, mandate.getMandateReference().toString())
+                        .put(MANDATE_REFERENCE_KEY, mandate.getMandateBankStatementReference().toString())
                         .put(BANK_ACCOUNT_LAST_DIGITS_KEY, mandate.getPayer().getAccountNumberLastTwoDigits())
                         .put(STATEMENT_NAME_KEY, sunName.get().toString())
                         .put(DD_GUARANTEE_KEY, directDebitConfig.getLinks().getDirectDebitGuaranteeUrl())

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/TransactionMapper.java
@@ -6,8 +6,8 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
-import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
+import uk.gov.pay.directdebit.mandate.model.MandateImpl;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.model.Payer;
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
+import static uk.gov.pay.directdebit.mandate.model.MandateImpl.MandateBuilder.aMandate;
 
 public class TransactionMapper implements RowMapper<Transaction> {
 
@@ -92,11 +92,11 @@ public class TransactionMapper implements RowMapper<Transaction> {
             gatewayAccount.setOrganisation(GoCardlessOrganisationId.valueOf(organisation));
         }
 
-        Mandate mandate = aMandate()
+        MandateImpl mandate = aMandate()
                 .withId(resultSet.getLong(MANDATE_ID_COLUMN))
                 .withGatewayAccount(gatewayAccount)
                 .withExternalId(MandateExternalId.valueOf(resultSet.getString(MANDATE_EXTERNAL_ID_COLUMN)))
-                .withMandateReference(MandateBankStatementReference.valueOf(resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN)))
+                .withMandateBankStatementReference(MandateBankStatementReference.valueOf(resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN)))
                 .withServiceReference(resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN))
                 .withState(MandateState.valueOf(resultSet.getString(MANDATE_STATE_COLUMN)))
                 .withReturnUrl(resultSet.getString(MANDATE_RETURN_URL_COLUMN))

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Transaction.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.directdebit.payments.model;
 
-import java.time.ZonedDateTime;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+
+import java.time.ZonedDateTime;
 
 public class Transaction {
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/TransactionResource.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateImpl;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequest;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequestValidator;

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/TransactionService.java
@@ -11,6 +11,7 @@ import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountNotFoundEx
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateImpl;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequest;

--- a/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
@@ -52,7 +52,7 @@ public class TokenResponse {
                 mandate.getExternalId(),
                 mandate.getGatewayAccount().getId(),
                 mandate.getGatewayAccount().getExternalId(),
-                mandate.getMandateReference(),
+                mandate.getMandateBankStatementReference(),
                 mandate.getReturnUrl(),
                 mandate.getState().toString()
         );

--- a/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
@@ -10,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.common.model.subtype.SunName;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
-import uk.gov.pay.directdebit.mandate.model.GoCardlessMandate;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.payers.fixtures.GoCardlessCustomerFixture;
@@ -158,9 +157,9 @@ public class GoCardlessClientFacadeTest {
 
         given(mockGoCardlessClientWrapper.createMandate(mandate.getExternalId(), goCardlessCustomer)).willReturn(mockMandate);
 
-        GoCardlessMandate result = goCardlessClientFacade.createMandate(mandate, goCardlessCustomer);
+        uk.gov.pay.directdebit.mandate.model.Mandate result = goCardlessClientFacade.createMandate(mandate, goCardlessCustomer);
 
-        assertThat(result.getGoCardlessMandateId(), is(goCardlessMandateId));
-        assertThat(result.getGoCardlessReference(), is(goCardlessReference));
+        assertThat(result.getPaymentProviderMandateId().get(), is(goCardlessMandateId));
+        assertThat(result.getMandateBankStatementReference(), is(goCardlessReference));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/junit/TestContext.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/TestContext.java
@@ -5,6 +5,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReferenceArgumentFactory;
+import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventIdArgumentFactory;
 import uk.gov.pay.directdebit.util.DatabaseTestHelper;
@@ -29,6 +30,7 @@ public class TestContext {
         jdbi.registerArgument(new MandateExternalIdArgumentFactory());
         jdbi.registerArgument(new GoCardlessMandateIdArgumentFactory());
         jdbi.registerArgument(new MandateBankStatementReferenceArgumentFactory());
+        jdbi.registerArgument(new PaymentProviderMandateIdArgumentFactory());
         jdbi.registerArgument(new GoCardlessEventIdArgumentFactory());
         this.databaseTestHelper = new DatabaseTestHelper(jdbi);
         this.port = port;

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/GoCardlessMandateDaoIT.java
@@ -49,15 +49,6 @@ public class GoCardlessMandateDaoIT {
     }
 
     @Test
-    public void shouldInsertAGoCardlessMandate() {
-        Long id = mandateDao.insert(testGoCardlessMandate.toEntity());
-        Map<String, Object> mandate = testContext.getDatabaseTestHelper().getGoCardlessMandateById(id);
-        assertThat(mandate.get("id"), is(id));
-        assertThat(mandate.get("mandate_id"), is(mandateFixture.getId()));
-        assertThat(mandate.get("gocardless_mandate_id"), is(GOCARDLESS_MANDATE_ID.toString()));
-    }
-
-    @Test
     public void shouldFindAGoCardlessMandateByMandateId() {
         testGoCardlessMandate.insert(testContext.getJdbi());
         GoCardlessMandate goCardlessMandate = mandateDao.findByMandateId(mandateFixture.getId()).get();

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
+import uk.gov.pay.directdebit.mandate.model.MandateImpl;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
 import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateId;
@@ -32,7 +33,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
+import static uk.gov.pay.directdebit.mandate.model.MandateImpl.MandateBuilder.aMandate;
 import static uk.gov.pay.directdebit.tokens.fixtures.TokenFixture.aTokenFixture;
 import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.isDate;
 
@@ -58,7 +59,7 @@ public class MandateDaoIT {
         Long id = mandateDao.insert(aMandate()
                         .withGatewayAccount(gatewayAccountFixture.toEntity())
                         .withExternalId(MandateExternalId.valueOf(RandomIdGenerator.newId()))
-                        .withMandateReference(MandateBankStatementReference.valueOf("test-reference"))
+                        .withMandateBankStatementReference(MandateBankStatementReference.valueOf("test-reference"))
                         .withState(MandateState.PENDING)
                         .withReturnUrl("https://www.example.com/return_url")
                         .withCreatedDate(createdDate)
@@ -82,7 +83,7 @@ public class MandateDaoIT {
         Long id = mandateDao.insert(aMandate()
                         .withGatewayAccount(gatewayAccountFixture.toEntity())
                         .withExternalId(MandateExternalId.valueOf(RandomIdGenerator.newId()))
-                        .withMandateReference(MandateBankStatementReference.valueOf("test-reference"))
+                        .withMandateBankStatementReference(MandateBankStatementReference.valueOf("test-reference"))
                         .withServiceReference("test-service-reference")
                         .withState(MandateState.PENDING)
                         .withReturnUrl("https://www.example.com/return_url")
@@ -104,7 +105,7 @@ public class MandateDaoIT {
     public void shouldFindAMandateById() {
         PaymentProviderMandateId paymentProviderMandateId = GoCardlessMandateId.valueOf("aGocardlessMandateId");
         MandateFixture mandateFixture = MandateFixture.aMandateFixture()
-                .withMandateReference(MandateBankStatementReference.valueOf("test-reference"))
+                .withMandateBankStatementReference(MandateBankStatementReference.valueOf("test-reference"))
                 .withServiceReference("test-service-reference")
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withPaymentProviderId(paymentProviderMandateId)
@@ -113,10 +114,10 @@ public class MandateDaoIT {
         Mandate mandate = mandateDao.findById(mandateFixture.getId()).get();
         assertThat(mandate.getId(), is(mandateFixture.getId()));
         assertThat(mandate.getExternalId(), is(notNullValue()));
-        assertThat(mandate.getMandateReference(), is(MandateBankStatementReference.valueOf("test-reference")));
+        assertThat(mandate.getMandateBankStatementReference(), is(MandateBankStatementReference.valueOf("test-reference")));
         assertThat(mandate.getServiceReference(), is("test-service-reference"));
         assertThat(mandate.getState(), is(MandateState.CREATED));
-        assertThat(mandate.getPaymentProviderId().get(), is(paymentProviderMandateId));
+        assertThat(mandate.getPaymentProviderMandateId().get(), is(paymentProviderMandateId));
     }
 
     @Test
@@ -128,7 +129,7 @@ public class MandateDaoIT {
     @Test
     public void shouldFindAMandateByTokenId() {
         MandateFixture mandateFixture = MandateFixture.aMandateFixture()
-                .withMandateReference(MandateBankStatementReference.valueOf("test-reference"))
+                .withMandateBankStatementReference(MandateBankStatementReference.valueOf("test-reference"))
                 .withServiceReference("test-service-reference")
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .insert(testContext.getJdbi());
@@ -140,7 +141,7 @@ public class MandateDaoIT {
         Mandate mandate = mandateDao.findByTokenId(token.getToken()).get();
         assertThat(mandate.getId(), is(mandateFixture.getId()));
         assertThat(mandate.getExternalId(), is(mandateFixture.getExternalId()));
-        assertThat(mandate.getMandateReference(), is(MandateBankStatementReference.valueOf("test-reference")));
+        assertThat(mandate.getMandateBankStatementReference(), is(MandateBankStatementReference.valueOf("test-reference")));
         assertThat(mandate.getServiceReference(), is("test-service-reference"));
         assertThat(mandate.getState(), is(MandateState.CREATED));
     }
@@ -154,7 +155,7 @@ public class MandateDaoIT {
     @Test
     public void shouldFindAMandateByExternalId() {
         MandateFixture mandateFixture = MandateFixture.aMandateFixture()
-                .withMandateReference(MandateBankStatementReference.valueOf("test-reference"))
+                .withMandateBankStatementReference(MandateBankStatementReference.valueOf("test-reference"))
                 .withServiceReference("test-service-reference")
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .insert(testContext.getJdbi());
@@ -162,7 +163,7 @@ public class MandateDaoIT {
         Mandate mandate = mandateDao.findByExternalId(mandateFixture.getExternalId()).get();
         assertThat(mandate.getId(), is(mandateFixture.getId()));
         assertThat(mandate.getExternalId(), is(notNullValue()));
-        assertThat(mandate.getMandateReference(), is(MandateBankStatementReference.valueOf("test-reference")));
+        assertThat(mandate.getMandateBankStatementReference(), is(MandateBankStatementReference.valueOf("test-reference")));
         assertThat(mandate.getServiceReference(), is("test-service-reference"));
         assertThat(mandate.getState(), is(MandateState.CREATED));
     }
@@ -183,7 +184,7 @@ public class MandateDaoIT {
         assertThat(numOfUpdatedMandates, is(1));
         assertThat(mandateAfterUpdate.get("id"), is(testMandate.getId()));
         assertThat(mandateAfterUpdate.get("external_id"), is(testMandate.getExternalId().toString()));
-        assertThat(mandateAfterUpdate.get("mandate_reference"), is(testMandate.getMandateReference().toString()));
+        assertThat(mandateAfterUpdate.get("mandate_reference"), is(testMandate.getMandateBankStatementReference().toString()));
         assertThat(mandateAfterUpdate.get("service_reference"), is(testMandate.getServiceReference()));
         assertThat(mandateAfterUpdate.get("state"), is(newState.toString()));
     }
@@ -195,18 +196,25 @@ public class MandateDaoIT {
     }
 
     @Test
-    public void shouldUpdateReferenceAndReturnNumberOfAffectedRows() {
-        Mandate testMandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture)
-                .withMandateReference(MandateBankStatementReference.valueOf("old-reference")).insert(testContext.getJdbi()).toEntity();
-        MandateBankStatementReference newMandateReference = MandateBankStatementReference.valueOf("newReference");
-        int numOfUpdatedMandates = mandateDao.updateMandateReference(testMandate.getId(), newMandateReference);
+    public void shouldUpdateReferenceAndPaymentProviderId() {
+        MandateImpl testMandate = MandateFixture.aMandateFixture()
+                .withGatewayAccountFixture(gatewayAccountFixture)
+                .withMandateBankStatementReference(MandateBankStatementReference.valueOf("old-reference"))
+                .insert(testContext.getJdbi())
+                .toEntity();
+
+        testMandate.setMandateBankStatementReference(MandateBankStatementReference.valueOf("newReference"));
+        testMandate.setPaymentProviderMandateId(GoCardlessMandateId.valueOf("aPaymentProviderId"));
+
+        int numOfUpdatedMandates = mandateDao.updateReferenceAndPaymentProviderId(testMandate);
 
         Map<String, Object> mandateAfterUpdate = testContext.getDatabaseTestHelper().getMandateById(testMandate.getId());
         assertThat(numOfUpdatedMandates, is(1));
         assertThat(mandateAfterUpdate.get("id"), is(testMandate.getId()));
         assertThat(mandateAfterUpdate.get("external_id"), is(testMandate.getExternalId().toString()));
-        assertThat(mandateAfterUpdate.get("mandate_reference"), is(newMandateReference.toString()));
+        assertThat(mandateAfterUpdate.get("mandate_reference"), is(testMandate.getMandateBankStatementReference().toString()));
         assertThat(mandateAfterUpdate.get("state"), is(testMandate.getState().toString()));
+        assertThat(mandateAfterUpdate.get("payment_provider_id"), is(testMandate.getPaymentProviderMandateId().get().toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
@@ -5,8 +5,8 @@ import org.apache.commons.lang3.RandomUtils;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.directdebit.common.fixtures.DbFixture;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
-import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
+import uk.gov.pay.directdebit.mandate.model.MandateImpl;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateId;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
@@ -17,9 +17,9 @@ import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
+import static uk.gov.pay.directdebit.mandate.model.MandateImpl.MandateBuilder.aMandate;
 
-public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
+public class MandateFixture implements DbFixture<MandateFixture, MandateImpl> {
 
     private Long id = RandomUtils.nextLong(1, 99999);
     private MandateExternalId mandateExternalId = MandateExternalId.valueOf(RandomIdGenerator.newId());
@@ -77,7 +77,7 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
         return mandateReference;
     }
 
-    public MandateFixture withMandateReference(MandateBankStatementReference mandateReference) {
+    public MandateFixture withMandateBankStatementReference(MandateBankStatementReference mandateReference) {
         this.mandateReference = mandateReference;
         return this;
     }
@@ -159,13 +159,13 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
     }
 
     @Override
-    public Mandate toEntity() {
+    public MandateImpl toEntity() {
         Payer payer = payerFixture != null ? payerFixture.toEntity() : null;
         return aMandate()
                 .withId(id)
                 .withGatewayAccount(gatewayAccountFixture.toEntity())
                 .withExternalId(mandateExternalId)
-                .withMandateReference(mandateReference)
+                .withMandateBankStatementReference(mandateReference)
                 .withServiceReference(serviceReference)
                 .withState(state)
                 .withReturnUrl(returnUrl)

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateServiceTest.java
@@ -138,19 +138,19 @@ public class MandateStateUpdateServiceTest {
                 .aMandateFixture()
                 .withState(AWAITING_DIRECT_DEBIT_DETAILS)
                 .toEntity();
-        Mandate newMandate = service.confirmedOneOffDirectDebitDetailsFor(oneOffMandate);
+        Mandate confirmedMandate = service.confirmedOneOffDirectDebitDetailsFor(oneOffMandate);
 
-        assertThat(newMandate, is(oneOffMandate));
-        verify(mockedMandateDao).updateMandateReference(newMandate.getId(), oneOffMandate.getMandateReference());
+        assertThat(confirmedMandate, is(oneOffMandate));
+        verify(mockedMandateDao).updateReferenceAndPaymentProviderId(confirmedMandate);
     }
 
     @Test
     public void shouldUpdateMandateStateAndRegisterEventWhenConfirmingDirectDebitDetails_andSendEmail_IfOnDemand() {
-        Mandate newMandate = service.confirmedOnDemandDirectDebitDetailsFor(onDemandMandate);
+        Mandate confirmedMandate = service.confirmedOnDemandDirectDebitDetailsFor(onDemandMandate);
 
-        assertThat(newMandate, is(onDemandMandate));
+        assertThat(confirmedMandate, is(onDemandMandate));
         verify(mockedUserNotificationService).sendOnDemandMandateCreatedEmailFor(onDemandMandate);
-        verify(mockedMandateDao).updateMandateReference(newMandate.getId(), onDemandMandate.getMandateReference());
+        verify(mockedMandateDao).updateReferenceAndPaymentProviderId(confirmedMandate);
 
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -74,7 +74,7 @@ public class UserNotificationServiceTest {
         SunName sunName = SunName.of("test sun Name");
         when(mockSunService.getSunNameFor(mandate)).thenReturn(Optional.of(sunName));
         HashMap<String, String> emailPersonalisation = new HashMap<>();
-        emailPersonalisation.put("mandate reference", mandate.getMandateReference().toString());
+        emailPersonalisation.put("mandate reference", mandate.getMandateBankStatementReference().toString());
         emailPersonalisation.put("bank account last 2 digits", mandate.getPayer().getAccountNumberLastTwoDigits());
         emailPersonalisation.put("statement name", sunName.toString());
         emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
@@ -113,7 +113,7 @@ public class UserNotificationServiceTest {
 
         HashMap<String, String> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put("amount", "123.45");
-        emailPersonalisation.put("mandate reference", mandate.getMandateReference().toString());
+        emailPersonalisation.put("mandate reference", mandate.getMandateBankStatementReference().toString());
         emailPersonalisation.put("collection date", "21/05/2018");
         emailPersonalisation.put("bank account last 2 digits", payerFixture.getAccountNumberLastTwoDigits());
         emailPersonalisation.put("statement name", sunName.toString());
@@ -146,7 +146,7 @@ public class UserNotificationServiceTest {
         when(mockSunService.getSunNameFor(mandate)).thenReturn(Optional.of(sunName));
         HashMap<String, String> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put("amount", "123.45");
-        emailPersonalisation.put("mandate reference", mandate.getMandateReference().toString());
+        emailPersonalisation.put("mandate reference", mandate.getMandateBankStatementReference().toString());
         emailPersonalisation.put("collection date", "21/05/2018");
         emailPersonalisation.put("bank account last 2 digits", payerFixture.getAccountNumberLastTwoDigits());
         emailPersonalisation.put("statement name", sunName.toString());

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -31,7 +31,6 @@ import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerBankAccountFailedException;
 import uk.gov.pay.directdebit.payments.exception.CreateCustomerFailedException;
 import uk.gov.pay.directdebit.payments.exception.CreateMandateFailedException;
-import uk.gov.pay.directdebit.payments.exception.CreatePaymentFailedException;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.TransactionFixture;
 import uk.gov.pay.directdebit.payments.model.Transaction;
@@ -51,7 +50,7 @@ import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFix
 public abstract class GoCardlessServiceTest {
 
     private static final String CUSTOMER_ID = "CU328471";
-    private static final String BANK_ACCOUNT_ID = "BA34983496";
+    static final String BANK_ACCOUNT_ID = "BA34983496";
     static final MandateExternalId MANDATE_ID = MandateExternalId.valueOf("sdkfhsdkjfhjdks");
     private static final String TRANSACTION_ID = "sdkfhsd2jfhjdks";
     static final SortCode SORT_CODE = SortCode.of("123456");
@@ -91,6 +90,8 @@ public abstract class GoCardlessServiceTest {
             .withMandateFixture(mandateFixture)
             .withExternalId(TRANSACTION_ID)
             .toEntity();
+
+
     GoCardlessMandate goCardlessMandate = aGoCardlessMandateFixture().withMandateId(mandateFixture.getId()).toEntity();
     GoCardlessPayment goCardlessPayment = aGoCardlessPaymentFixture().withTransactionId(transaction.getId()).toEntity();
     BankAccountDetails bankAccountDetails = new BankAccountDetails(ACCOUNT_NUMBER, SORT_CODE);
@@ -163,24 +164,6 @@ public abstract class GoCardlessServiceTest {
         assertThat(service.getSunName(mandateFixture.toEntity()), is(Optional.empty()));
     }
 
-    void verifyMandateFailedException() {
-        when(mockedGoCardlessClientFacade.createMandate(mandateFixture.toEntity(), goCardlessCustomer)).thenThrow(new RuntimeException("gocardless said no"));
-
-        thrown.expect(CreateMandateFailedException.class);
-        thrown.expectMessage(format("Failed to create mandate in gocardless, mandate id: %s", MANDATE_ID));
-        thrown.reportMissingExceptionWithMessage("CreateMandateFailedException expected");
-    }
-
-    void verifyCreatePaymentFailedException() {
-        when(mockedGoCardlessClientFacade.createMandate(mandateFixture.toEntity(), goCardlessCustomer)).thenReturn(goCardlessMandate);
-        when(mockedGoCardlessClientFacade.createPayment(transaction, goCardlessMandate)).thenThrow(new RuntimeException("gocardless said no"));
-
-        thrown.expect(CreatePaymentFailedException.class);
-        thrown.expectMessage(format("Failed to create payment in gocardless, mandate id: %s, transaction id: %s",
-                MANDATE_ID, TRANSACTION_ID));
-        thrown.reportMissingExceptionWithMessage("CreatePaymentFailedException expected");
-    }
-
     void verifyCreateCustomerBankAccountFailedException() {
         when(mockedGoCardlessClientFacade.createCustomerBankAccount(MANDATE_ID, goCardlessCustomer, payerFixture.getName(), SORT_CODE, ACCOUNT_NUMBER))
                 .thenThrow(new RuntimeException("oops"));
@@ -191,13 +174,4 @@ public abstract class GoCardlessServiceTest {
         thrown.reportMissingExceptionWithMessage("CreateCustomerBankAccountFailedException expected");
     }
 
-    void verifyCreateCustomerFailedException() {
-        when(mockedGoCardlessClientFacade.createCustomer(MANDATE_ID, payerFixture.toEntity()))
-                .thenThrow(new RuntimeException("ooops"));
-
-        thrown.expect(CreateCustomerFailedException.class);
-        thrown.expectMessage(format("Failed to create customer in gocardless, mandate id: %s, payer id: %s",
-                MANDATE_ID, payerFixture.getExternalId()));
-        thrown.reportMissingExceptionWithMessage("CreateCustomerFailedException expected");
-    }
 }


### PR DESCRIPTION
No longer persist `GoCardlessMandate` when confirming a mandate and prepare for
deletion of `GoCardlessMandate` class, service and Dao. Includes:
- Abstract Mandate interface from existing class Mandate and rename that class
to `MandateImpl`.
- Create `GoCardlessMandateAdaptor` which implements Mandate interface. This class
adapts the gocardless mandate to our model of Mandate.
- Rename Mandate field `mandateReference` to `mandateBankStatementReference` to help
clarify between the other `serviceReference` field.
- No longer persist the gocardlessMandate after confirmation with goCardless.
- Update the `PaymentProviderMandateId` when updating the mandate after confirmation.