### PR TITLE
PP-5278 Don't allow mandate creation if GoCardless account isn't linked

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -25,8 +25,10 @@ import uk.gov.pay.directdebit.common.exception.BadRequestExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.ConflictExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.InternalServerErrorExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.JsonMappingExceptionMapper;
+import uk.gov.pay.directdebit.common.exception.NoAccessTokenExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.NotFoundExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.PreconditionFailedExceptionMapper;
+import uk.gov.pay.directdebit.common.exception.UnlinkedGCMerchantAccountExceptionMapper;
 import uk.gov.pay.directdebit.common.proxy.CustomInetSocketAddressProxySelector;
 import uk.gov.pay.directdebit.events.resources.DirectDebitEventsResource;
 import uk.gov.pay.directdebit.gatewayaccounts.GatewayAccountParamConverterProvider;
@@ -122,7 +124,8 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
         environment.jersey().register(new InternalServerErrorExceptionMapper());
         environment.jersey().register(new PreconditionFailedExceptionMapper());
         environment.jersey().register(new JsonMappingExceptionMapper());
-
+        environment.jersey().register(new NoAccessTokenExceptionMapper());
+        environment.jersey().register(new UnlinkedGCMerchantAccountExceptionMapper());
         initialiseMetrics(configuration, environment);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactory.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.common.clients;
 import com.gocardless.GoCardlessClient;
 import com.google.common.collect.Maps;
 import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
+import uk.gov.pay.directdebit.common.exception.NoAccessTokenException;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
 import uk.gov.pay.directdebit.webhook.gocardless.config.GoCardlessFactory;
 
@@ -20,8 +21,8 @@ public class GoCardlessClientFactory {
     }
 
     public GoCardlessClientFacade getClientFor(Optional<PaymentProviderAccessToken> maybeAccessToken) {
-        //backward compatibility for now, will use the token in the config if it's not there
-        PaymentProviderAccessToken accessToken = maybeAccessToken.orElse(PaymentProviderAccessToken.of(configuration.getGoCardless().getAccessToken()));
+        PaymentProviderAccessToken accessToken = maybeAccessToken
+                .orElseThrow(() -> new NoAccessTokenException("No access token"));
         return clients.computeIfAbsent(accessToken, token -> {
             GoCardlessClientWrapper clientWrapper = new GoCardlessClientWrapper(createGoCardlessClient(token));
             return new GoCardlessClientFacade(clientWrapper);

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/NoAccessTokenException.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/NoAccessTokenException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.directdebit.common.exception;
+
+public class NoAccessTokenException extends RuntimeException {
+    public NoAccessTokenException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/NoAccessTokenExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/NoAccessTokenExceptionMapper.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.directdebit.common.exception;
+
+import uk.gov.pay.commons.model.ErrorIdentifier;
+import uk.gov.pay.directdebit.common.model.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class NoAccessTokenExceptionMapper implements ExceptionMapper<NoAccessTokenException> {
+    @Override
+    public Response toResponse(NoAccessTokenException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GO_CARDLESS_ACCOUNT_NOT_LINKED,
+                exception.getMessage());
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(errorResponse).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/UnlinkedGCMerchantAccountException.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/UnlinkedGCMerchantAccountException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.directdebit.common.exception;
+
+public class UnlinkedGCMerchantAccountException extends RuntimeException {
+    public UnlinkedGCMerchantAccountException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/UnlinkedGCMerchantAccountExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/UnlinkedGCMerchantAccountExceptionMapper.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.directdebit.common.exception;
+
+import uk.gov.pay.commons.model.ErrorIdentifier;
+import uk.gov.pay.directdebit.common.model.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class UnlinkedGCMerchantAccountExceptionMapper implements ExceptionMapper<UnlinkedGCMerchantAccountException> {
+    @Override
+    public Response toResponse(UnlinkedGCMerchantAccountException e) {
+        ErrorResponse errorResponse =
+                new ErrorResponse(ErrorIdentifier.GO_CARDLESS_ACCOUNT_NOT_LINKED, e.getMessage());
+        return Response.status(Response.Status.FORBIDDEN).entity(errorResponse).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/config/GoCardlessFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/config/GoCardlessFactory.java
@@ -9,10 +9,7 @@ import uk.gov.pay.directdebit.webhook.gocardless.support.WebhookVerifier;
 import javax.validation.constraints.NotNull;
 
 public class GoCardlessFactory extends Configuration {
-
-    @JsonProperty
-    private String accessToken;
-
+    
     @JsonProperty
     private String webhookSecret;
 
@@ -27,11 +24,7 @@ public class GoCardlessFactory extends Configuration {
     public Boolean isCallingStubs() {
         return clientUrl != null;
     }
-
-    public String getAccessToken() {
-        return accessToken;
-    }
-
+    
     public String getWebhookSecret() {
         return webhookSecret;
     }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -36,7 +36,6 @@ graphite:
 goCardless:
   # For initial integration we will use sandbox access token.
   # When in live mode: access token should be removed from the config and we should use partner integration instead.
-  accessToken: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ACCESS_TOKEN:-}
   clientUrl: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_URL:-}
   webhookSecret: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_WEBHOOK_SECRET:-change-me}
   environment: ${GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ENVIRONMENT:-sandbox}

--- a/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFactoryTest.java
@@ -25,7 +25,6 @@ public class GoCardlessClientFactoryTest {
 
     @Before
     public void setUp() {
-        when(mockedDirectDebitConfig.getGoCardless().getAccessToken()).thenReturn("aaa");
         when(mockedDirectDebitConfig.getGoCardless().getEnvironment()).thenReturn(GoCardlessClient.Environment.SANDBOX);
         goCardlessClientFactory = new GoCardlessClientFactory(mockedDirectDebitConfig);
     }
@@ -37,16 +36,5 @@ public class GoCardlessClientFactoryTest {
         GoCardlessClientFacade secondClient = goCardlessClientFactory
                 .getClientFor(Optional.of(PaymentProviderAccessToken.of("accessToken")));
         assertThat(firstClient, is(secondClient));
-    }
-
-
-    //backward compatibility, please remove once all gateway accounts have an access token
-    @Test
-    public void shouldCreateAClient_ifNoAccessTokenIsDefined() {
-        GoCardlessClientFacade client = goCardlessClientFactory
-                .getClientFor(Optional.empty());
-        GoCardlessClientFacade clientWithConfigAccessToken = goCardlessClientFactory
-                .getClientFor(Optional.of(PaymentProviderAccessToken.of("aaa")));
-        assertThat(client, is(clientWithConfigAccessToken));
     }
 }

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -23,7 +23,6 @@ graphite:
   port: 8092
 
 goCardless:
-  accessToken: accesstoken
   webhookSecret: ElfJ-3tF9I_zutNVK2lBABQrw-BgAhkZKIlvmbgk
   environment: sandbox
   clientUrl: http://localhost:10107


### PR DESCRIPTION
- Introduces new exceptions to be thrown if a mandate is created by a user who does not have a linked GoCardless account

- Removes access token from config files to ensure that access token is never used as a fallback