### PR TITLE
PP-5246 Drop gocardless_mandates table

### DIFF
--- a/src/main/resources/migrations/00053_drop_gocardless_mandates_table.sql
+++ b/src/main/resources/migrations/00053_drop_gocardless_mandates_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE gocardless_mandates;

--- a/src/main/resources/migrations/00054_alter_table_mandates_add_payment_provider_id_index.sql
+++ b/src/main/resources/migrations/00054_alter_table_mandates_add_payment_provider_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX payment_provider_id_idx ON mandates(payment_provider_id);


### PR DESCRIPTION
- Drop `gocardless_mandates` table
- Add index for `payment_provider_id` to the `mandates` table
