### PR TITLE
PP-5246 Use SandboxMandateId within SandboxEvent

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/dao/SandboxEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/SandboxEventDao.java
@@ -1,12 +1,15 @@
 package uk.gov.pay.directdebit.events.dao;
 
+import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.events.model.SandboxEvent;
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateIdArgumentFactory;
 
 @RegisterRowMapper(SandboxEventMapper.class)
+@RegisterArgumentFactory(SandboxMandateIdArgumentFactory.class)
 public interface SandboxEventDao {
     
     @SqlUpdate("INSERT INTO sandbox_events(created_at, mandate_id, payment_id, event_action, event_cause) " +

--- a/src/main/java/uk/gov/pay/directdebit/events/dao/SandboxEventMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/SandboxEventMapper.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.directdebit.events.dao;
 
+import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.directdebit.events.model.SandboxEvent;
-
-import org.jdbi.v3.core.mapper.RowMapper;
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -13,11 +13,16 @@ public class SandboxEventMapper implements RowMapper<SandboxEvent> {
 
     @Override
     public SandboxEvent map(ResultSet rs, StatementContext ctx) throws SQLException {
-        return new SandboxEvent(
-                rs.getString("mandate_id"),
-                rs.getString("payment_id"),
-                rs.getString("event_action"),
-                rs.getString("event_cause"),
-                ZonedDateTime.parse(rs.getString("created_at")));
+        var builder = SandboxEvent.SandboxEventBuilder.aSandboxEvent()
+                .withCreatedAt(ZonedDateTime.parse(rs.getString("created_at")))
+                .withEventCause(rs.getString("event_cause"))
+                .withEventAction(rs.getString("event_action"))
+                .withEventAction(rs.getString("payment_id"));
+
+        if (rs.getString("mandate_id") == null) {
+            builder.withMandateId(SandboxMandateId.valueOf(rs.getString("mandate_id")));
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/model/SandboxEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/model/SandboxEvent.java
@@ -1,29 +1,32 @@
 package uk.gov.pay.directdebit.events.model;
 
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
+
 import java.time.ZonedDateTime;
+import java.util.Optional;
 
 public class SandboxEvent {
     
-    private final String mandateId;
+    private final SandboxMandateId mandateId;
     private final String paymentId;
     private final String eventAction;
     private final String eventCause;
     private final ZonedDateTime createdAt;
     
-    public SandboxEvent(String mandateId, String paymentId, String eventAction, String eventCause, ZonedDateTime createdAt) {
-        this.mandateId = mandateId;
-        this.paymentId = paymentId;
-        this.eventAction = eventAction;
-        this.eventCause = eventCause;
-        this.createdAt = createdAt;
+    private SandboxEvent(SandboxEventBuilder builder) {
+        this.mandateId = builder.mandateId;
+        this.paymentId = builder.paymentId;
+        this.eventAction = builder.eventAction;
+        this.eventCause = builder.eventCause;
+        this.createdAt = builder.createdAt;
     }
 
-    public String getMandateId() {
-        return mandateId;
+    public Optional<SandboxMandateId> getMandateId() {
+        return Optional.ofNullable(mandateId);
     }
 
-    public String getPaymentId() {
-        return paymentId;
+    public Optional<String> getPaymentId() {
+        return Optional.ofNullable(paymentId);
     }
 
     public String getEventAction() {
@@ -36,5 +39,50 @@ public class SandboxEvent {
 
     public ZonedDateTime getCreatedAt() {
         return createdAt;
+    }
+
+
+    public static final class SandboxEventBuilder {
+        private SandboxMandateId mandateId;
+        private String paymentId;
+        private String eventAction;
+        private String eventCause;
+        private ZonedDateTime createdAt;
+
+        private SandboxEventBuilder() {
+        }
+
+        public static SandboxEventBuilder aSandboxEvent() {
+            return new SandboxEventBuilder();
+        }
+
+        public SandboxEventBuilder withMandateId(SandboxMandateId mandateId) {
+            this.mandateId = mandateId;
+            return this;
+        }
+
+        public SandboxEventBuilder withPaymentId(String paymentId) {
+            this.paymentId = paymentId;
+            return this;
+        }
+
+        public SandboxEventBuilder withEventAction(String eventAction) {
+            this.eventAction = eventAction;
+            return this;
+        }
+
+        public SandboxEventBuilder withEventCause(String eventCause) {
+            this.eventCause = eventCause;
+            return this;
+        }
+
+        public SandboxEventBuilder withCreatedAt(ZonedDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public SandboxEvent build() {
+            return new SandboxEvent(this);
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/services/SandboxEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/services/SandboxEventService.java
@@ -4,13 +4,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.events.dao.SandboxEventDao;
 import uk.gov.pay.directdebit.events.model.SandboxEvent;
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 
 import javax.inject.Inject;
 
 public class SandboxEventService {
 
-    private final SandboxEventDao sandBoxEventDao;
     private static final Logger LOGGER = LoggerFactory.getLogger(SandboxEventService.class);
+    private final SandboxEventDao sandBoxEventDao;
 
     @Inject
     public SandboxEventService(SandboxEventDao sandBoxEventDao) {
@@ -19,6 +20,9 @@ public class SandboxEventService {
 
     public void insertEvent(SandboxEvent sandboxEvent) {
         sandBoxEventDao.insert(sandboxEvent);
-        LOGGER.info("Inserted Sandbox event with mandate id {} ", sandboxEvent.getMandateId());
+        LOGGER.info("Inserted Sandbox event with mandate id {} ",
+                sandboxEvent.getMandateId()
+                        .map(SandboxMandateId::toString)
+                        .orElse("No mandate Id available on the sandbox event"));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/SandboxMandateIdArgumentFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/SandboxMandateIdArgumentFactory.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import java.sql.Types;
+
+public class SandboxMandateIdArgumentFactory extends AbstractArgumentFactory<SandboxMandateId> {
+
+    public SandboxMandateIdArgumentFactory() {
+        super(Types.VARCHAR);
+    }
+
+    @Override
+    protected Argument build(SandboxMandateId value, ConfigRegistry config) {
+        String sandboxMandateId = value == null ? null : value.toString();
+        return (pos, stmt, context) -> stmt.setString(pos, sandboxMandateId);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
@@ -2,6 +2,7 @@ package uk.gov.pay.directdebit.webhook.sandbox.resources;
 
 import com.codahale.metrics.annotation.Timed;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.events.model.SandboxEvent;
 import uk.gov.pay.directdebit.payments.model.Transaction;
@@ -50,11 +51,13 @@ public class WebhookSandboxResource {
     }
 
     private SandboxEvent createSandboxEventFromTransaction(Transaction transaction){
-        return new SandboxEvent(
-                transaction.getMandate().getId().toString(),
-                transaction.getId().toString(),
-                SandboxEventAction.PAID_OUT.toString(),
-                SandboxEventCause.PAID_OUT_CAUSE.toString(),
-                ZonedDateTime.now());
+
+        return SandboxEvent.SandboxEventBuilder.aSandboxEvent()
+                .withPaymentId(transaction.getId().toString())
+                .withEventAction(SandboxEventAction.PAID_OUT.toString())
+                .withEventCause(SandboxEventCause.PAID_OUT_CAUSE.toString())
+                .withCreatedAt(ZonedDateTime.now())
+                .withMandateId(SandboxMandateId.valueOf(transaction.getMandate().getId().toString()))
+                .build();
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/SandboxEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/SandboxEventDaoIT.java
@@ -11,6 +11,7 @@ import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -25,13 +26,12 @@ import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.isDate;
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
 public class SandboxEventDaoIT {
 
+    private static final ZonedDateTime CREATED_AT = ZonedDateTime.parse("2017-12-30T12:30:40Z");
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
     private SandboxEventDao sandboxEventDao;
-
     @DropwizardTestContext
     private TestContext testContext;
-    private static final ZonedDateTime CREATED_AT = ZonedDateTime.parse("2017-12-30T12:30:40Z");
 
     @Before
     public void setup() {
@@ -40,10 +40,16 @@ public class SandboxEventDaoIT {
 
     @Test
     public void shouldInsertAnEvent() throws IOException {
-        SandboxEvent sandboxEvent = new SandboxEvent("aMandateId", "aPaymentId",
-                "anEventAction", "anEventCause", CREATED_AT);
+        SandboxEvent sandboxEvent = SandboxEvent.SandboxEventBuilder.aSandboxEvent()
+                .withMandateId(SandboxMandateId.valueOf("aMandateId"))
+                .withPaymentId("aPaymentId")
+                .withEventAction("anEventAction")
+                .withEventCause("anEventCause")
+                .withCreatedAt(CREATED_AT)
+                .build();
 
         Long id = sandboxEventDao.insert(sandboxEvent);
+
         Map<String, Object> foundSandboxEvent = testContext.getDatabaseTestHelper().getSandboxEventById(id);
         assertThat(foundSandboxEvent.get("id"), is(id));
         assertThat(foundSandboxEvent.get("mandate_id"), is("aMandateId"));


### PR DESCRIPTION
 PP-5246 Use SandboxMandateId within SandboxEvent
    
    - Change `mandateId` type from `String` to `SandboxMandateId`
    - Make return type of getPaymentId and getMandateId optional
    
    with @RoryMalcolm