### PR TITLE
Pp 5248 renaming transaction to payment

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventExternalView.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventExternalView.java
@@ -15,8 +15,8 @@ public class DirectDebitEventExternalView {
     @JsonProperty("mandate_external_id")
     private final String mandateExternalId;
 
-    @JsonProperty("transaction_external_id")
-    private final String transactionExternalId;
+    @JsonProperty("payment_external_id")
+    private final String paymentExternalId;
 
     @JsonProperty("event_type")
     private final DirectDebitEvent.Type eventType;
@@ -31,7 +31,7 @@ public class DirectDebitEventExternalView {
     public DirectDebitEventExternalView(DirectDebitEvent directDebitEvent) {
         this.externalId = directDebitEvent.getExternalId();
         this.mandateExternalId = directDebitEvent.getMandateExternalId();
-        this.transactionExternalId = directDebitEvent.getPaymentExternalId();
+        this.paymentExternalId = directDebitEvent.getPaymentExternalId();
         this.event = directDebitEvent.getEvent();
         this.eventType = directDebitEvent.getEventType();
         this.eventDate = directDebitEvent.getEventDate();
@@ -45,8 +45,8 @@ public class DirectDebitEventExternalView {
         return mandateExternalId;
     }
 
-    public String getTransactionExternalId() {
-        return transactionExternalId;
+    public String getPaymentExternalId() {
+        return paymentExternalId;
     }
 
     public DirectDebitEvent.Type getEventType() {

--- a/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
@@ -34,14 +34,14 @@ public class DirectDebitEventsResource {
                                @QueryParam("display_size") Integer displaySize,
                                @QueryParam("page") Integer page,
                                @QueryParam("mandate_external_id") String mandateId,
-                               @QueryParam("transaction_external_id") String transactionId,
+                               @QueryParam("payment_external_id") String paymentId,
                                @Context UriInfo uriInfo) {
 
         DirectDebitEventSearchParams searchParams = new DirectDebitEventSearchParams.DirectDebitEventSearchParamsBuilder()
                 .toDate(toDate)
                 .fromDate(fromDate)
                 .mandateExternalId(mandateId)
-                .transactionExternalId(transactionId)
+                .paymentExternalId(paymentId)
                 .pageSize(displaySize)
                 .page(page)
                 .build();

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/ConfirmMandateRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/ConfirmMandateRequest.java
@@ -6,22 +6,18 @@ import uk.gov.pay.directdebit.payers.model.SortCode;
 
 public class ConfirmMandateRequest {
     private final SortCode sortCode;
-    
+
     private final AccountNumber accountNumber;
 
-    private String transactionExternalId;
-
-    public ConfirmMandateRequest(SortCode sortCode, AccountNumber accountNumber, String transactionExternalId) {
+    public ConfirmMandateRequest(SortCode sortCode, AccountNumber accountNumber) {
         this.sortCode = sortCode;
         this.accountNumber = accountNumber;
-        this.transactionExternalId = transactionExternalId;
     }
-    
+
     public static ConfirmMandateRequest of(Map<String, String> mandateConfirmation) {
         return new ConfirmMandateRequest(
                 SortCode.of(mandateConfirmation.get("sort_code")),
-                AccountNumber.of(mandateConfirmation.get("account_number")),
-                mandateConfirmation.get("transaction_external_id")
+                AccountNumber.of(mandateConfirmation.get("account_number"))
         );
     }
 
@@ -31,9 +27,5 @@ public class ConfirmMandateRequest {
 
     public AccountNumber getAccountNumber() {
         return accountNumber;
-    }
-
-    public String getTransactionExternalId() {
-        return transactionExternalId;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/DirectDebitInfoFrontendResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/DirectDebitInfoFrontendResponse.java
@@ -21,6 +21,183 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class DirectDebitInfoFrontendResponse {
 
+    @JsonProperty("payer")
+    private PayerDetails payer;
+
+    @JsonProperty("payment")
+    private PaymentDetails payment;
+
+    @JsonProperty("external_id")
+    private String mandateExternalId;
+
+    @JsonProperty("return_url")
+    private String returnUrl;
+
+    @JsonProperty("gateway_account_id")
+    private Long gatewayAccountId;
+
+    @JsonProperty("gateway_account_external_id")
+    private String gatewayAccountExternalId;
+
+    @JsonProperty("mandate_reference")
+    @JsonSerialize(using = ToStringSerializer.class)
+    private MandateBankStatementReference mandateReference;
+
+    @JsonProperty("created_date")
+    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    private ZonedDateTime createdDate;
+
+    @JsonProperty
+    private ExternalMandateState state;
+
+    @JsonProperty("internal_state")
+    private MandateState internalState;
+
+    public DirectDebitInfoFrontendResponse(MandateExternalId paymentExternalId,
+                                           Long gatewayAccountId,
+                                           String gatewayAccountExternalId,
+                                           MandateState internalState,
+                                           String returnUrl,
+                                           MandateBankStatementReference mandateReference,
+                                           ZonedDateTime createdDate,
+                                           Payer payer,
+                                           Payment payment) {
+        this.mandateExternalId = paymentExternalId.toString();
+        this.internalState = internalState;
+        this.state = internalState.toExternal();
+        this.gatewayAccountId = gatewayAccountId;
+        this.gatewayAccountExternalId = gatewayAccountExternalId;
+        this.returnUrl = returnUrl;
+        this.mandateReference = mandateReference;
+        this.createdDate = createdDate;
+        this.payment = initPayment(payment);
+        this.payer = initPayer(payer);
+    }
+
+    private PaymentDetails initPayment(Payment payment) {
+        if (payment != null) {
+            return new PaymentDetails(
+                    payment.getExternalId(),
+                    payment.getAmount(),
+                    payment.getState().toExternal(),
+                    payment.getDescription(),
+                    payment.getReference()
+            );
+        }
+        return null;
+    }
+
+    private PayerDetails initPayer(Payer payer) {
+        if (payer != null) {
+            return new PayerDetails(
+                    payer.getExternalId(),
+                    payer.getName(),
+                    payer.getEmail(),
+                    payer.getAccountRequiresAuthorisation());
+        }
+        return null;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public MandateBankStatementReference getMandateReference() {
+        return mandateReference;
+    }
+
+    public PaymentDetails getPayment() {
+        return payment;
+    }
+
+    public PayerDetails getPayer() {
+        return payer;
+    }
+
+    public String getMandateExternalId() {
+        return mandateExternalId;
+    }
+
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public String getGatewayAccountExternalId() {
+        return gatewayAccountExternalId;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public ExternalMandateState getState() {
+        return state;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DirectDebitInfoFrontendResponse that = (DirectDebitInfoFrontendResponse) o;
+
+        if (payer != null ? !payer.equals(that.payer) : that.payer != null) {
+            return false;
+        }
+        if (payment != null ? !payment.equals(that.payment) : that.payment != null) {
+            return false;
+        }
+        if (!mandateExternalId.equals(that.mandateExternalId)) {
+            return false;
+        }
+        if (!returnUrl.equals(that.returnUrl)) {
+            return false;
+        }
+        if (!mandateReference.equals(that.mandateReference)) {
+            return false;
+        }
+        if (!createdDate.equals(that.createdDate)) {
+            return false;
+        }
+        if (!internalState.equals(that.internalState)) {
+            return false;
+        }
+        return state == that.state;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = payer != null ? payer.hashCode() : 0;
+        result = 31 * result + (payment != null ? payment.hashCode() : 0);
+        result = 31 * result + mandateExternalId.hashCode();
+        result = 31 * result + returnUrl.hashCode();
+        result = 31 * result + gatewayAccountId.hashCode();
+        result = 31 * result + gatewayAccountExternalId.hashCode();
+        result = 31 * result + mandateReference.hashCode();
+        result = 31 * result + createdDate.hashCode();
+        result = 31 * result + internalState.hashCode();
+        result = 31 * result + state.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DirectDebitInfoFrontendResponse{" +
+                "payerId='" + payer.externalId + "'" +
+                ", paymentId='" + payment.externalId + "'" +
+                ", mandateId='" + mandateExternalId + "'" +
+                ", state='" + state.getState() + "'" +
+                ", internalState='" + internalState + "'" +
+                ", returnUrl='" + returnUrl + "'" +
+                ", mandateReference='" + mandateReference + "'" +
+                ", createdDate='" + createdDate + "'" +
+                "}";
+    }
+
     @JsonFormat(shape = JsonFormat.Shape.OBJECT)
     public static class PayerDetails {
         @JsonProperty("payer_external_id")
@@ -66,9 +243,6 @@ public class DirectDebitInfoFrontendResponse {
         }
     }
 
-    @JsonProperty("payer")
-    private PayerDetails payer;
-
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonFormat(shape = JsonFormat.Shape.OBJECT)
     public class PaymentDetails {
@@ -108,179 +282,4 @@ public class DirectDebitInfoFrontendResponse {
             return reference;
         }
     }
-
-    @JsonProperty("transaction")
-    private PaymentDetails transaction;
-
-    @JsonProperty("external_id")
-    private String mandateExternalId;
-
-    @JsonProperty("return_url")
-    private String returnUrl;
-
-    @JsonProperty("gateway_account_id")
-    private Long gatewayAccountId;
-
-    @JsonProperty("gateway_account_external_id")
-    private String gatewayAccountExternalId;
-
-    @JsonProperty("mandate_reference")
-    @JsonSerialize(using = ToStringSerializer.class)
-    private MandateBankStatementReference mandateReference;
-
-    @JsonProperty("created_date")
-    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
-    private ZonedDateTime createdDate;
-
-    @JsonProperty
-    private ExternalMandateState state;
-
-    @JsonProperty("internal_state")
-    private MandateState internalState;
-
-    public DirectDebitInfoFrontendResponse(MandateExternalId paymentExternalId,
-                                           Long gatewayAccountId,
-                                           String gatewayAccountExternalId,
-                                           MandateState internalState,
-                                           String returnUrl,
-                                           MandateBankStatementReference mandateReference,
-                                           ZonedDateTime createdDate,
-                                           Payer payer,
-                                           Payment payment) {
-        this.mandateExternalId = paymentExternalId.toString();
-        this.internalState = internalState;
-        this.state = internalState.toExternal();
-        this.gatewayAccountId = gatewayAccountId;
-        this.gatewayAccountExternalId = gatewayAccountExternalId;
-        this.returnUrl = returnUrl;
-        this.mandateReference = mandateReference;
-        this.createdDate = createdDate;
-        this.transaction = initTransaction(payment);
-        this.payer = initPayer(payer);
-    }
-
-    private PaymentDetails initTransaction(Payment payment) {
-        if (payment != null) {
-            return new PaymentDetails(
-                    payment.getExternalId(),
-                    payment.getAmount(),
-                    payment.getState().toExternal(),
-                    payment.getDescription(),
-                    payment.getReference()
-            );
-        }
-        return null;
-    }
-
-    private PayerDetails initPayer(Payer payer) {
-        if (payer != null) {
-            return new PayerDetails(
-                    payer.getExternalId(),
-                    payer.getName(),
-                    payer.getEmail(),
-                    payer.getAccountRequiresAuthorisation());
-        }
-        return null;
-    }
-
-    public String getReturnUrl() {
-        return returnUrl;
-    }
-
-    public MandateBankStatementReference getMandateReference() {
-        return mandateReference;
-    }
-
-    public PaymentDetails getTransaction() {
-        return transaction;
-    }
-
-    public PayerDetails getPayer() {
-        return payer;
-    }
-
-    public String getMandateExternalId() {
-        return mandateExternalId;
-    }
-
-    public Long getGatewayAccountId() {
-        return gatewayAccountId;
-    }
-
-    public String getGatewayAccountExternalId() {
-        return gatewayAccountExternalId;
-    }
-
-    public ZonedDateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    public ExternalMandateState getState() {
-        return state;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        DirectDebitInfoFrontendResponse that = (DirectDebitInfoFrontendResponse) o;
-
-        if (payer != null ? !payer.equals(that.payer) : that.payer != null) {
-            return false;
-        }
-        if (transaction != null ? !transaction.equals(that.transaction) : that.transaction != null) {
-            return false;
-        }
-        if (!mandateExternalId.equals(that.mandateExternalId)) {
-            return false;
-        }
-        if (!returnUrl.equals(that.returnUrl)) {
-            return false;
-        }
-        if (!mandateReference.equals(that.mandateReference)) {
-            return false;
-        }
-        if (!createdDate.equals(that.createdDate)) {
-            return false;
-        }
-        if (!internalState.equals(that.internalState)) {
-            return false;
-        }
-        return state == that.state;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = payer != null ? payer.hashCode() : 0;
-        result = 31 * result + (transaction != null ? transaction.hashCode() : 0);
-        result = 31 * result + mandateExternalId.hashCode();
-        result = 31 * result + returnUrl.hashCode();
-        result = 31 * result + gatewayAccountId.hashCode();
-        result = 31 * result + gatewayAccountExternalId.hashCode();
-        result = 31 * result + mandateReference.hashCode();
-        result = 31 * result + createdDate.hashCode();
-        result = 31 * result + internalState.hashCode();
-        result = 31 * result + state.hashCode();
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "DirectDebitInfoFrontendResponse{" +
-                "payerId='" + payer.externalId + "'" +
-                ", transactionId='" + transaction.externalId + "'" +
-                ", mandateId='" + mandateExternalId + "'" +
-                ", state='" + state.getState() + "'" +
-                ", internalState='" + internalState + "'" +
-                ", returnUrl='" + returnUrl + "'" +
-                ", mandateReference='" + mandateReference + "'" +
-                ", createdDate='" + createdDate + "'" +
-                "}";
-    }
-
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/resources/MandateResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/resources/MandateResource.java
@@ -47,7 +47,9 @@ public class MandateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Timed
-    public Response createMandate(@PathParam("accountId") GatewayAccount gatewayAccount, Map<String, String> createMandateRequestMap, @Context UriInfo uriInfo) {
+    public Response createMandate(@PathParam("accountId") GatewayAccount gatewayAccount,
+                                  Map<String, String> createMandateRequestMap,
+                                  @Context UriInfo uriInfo) {
         LOGGER.info("Received create mandate request with gateway account external id - {}", gatewayAccount.getExternalId());
         createMandateRequestValidator.validate(createMandateRequestMap);
         CreateMandateRequest createMandateRequest = CreateMandateRequest.of(createMandateRequestMap);
@@ -59,7 +61,9 @@ public class MandateResource {
     @Path("/v1/api/accounts/{accountId}/mandates/{mandateExternalId}")
     @Produces(APPLICATION_JSON)
     @Timed
-    public Response getMandate(@PathParam("accountId") String accountExternalId, @PathParam("mandateExternalId") MandateExternalId mandateExternalId, @Context UriInfo uriInfo) {
+    public Response getMandate(@PathParam("accountId") String accountExternalId,
+                               @PathParam("mandateExternalId") MandateExternalId mandateExternalId,
+                               @Context UriInfo uriInfo) {
         LOGGER.info("Retrieving mandate {} for frontend", mandateExternalId);
         GetMandateResponse response = mandateService.populateGetMandateResponse(accountExternalId, mandateExternalId, uriInfo);
         return Response.ok(response).build();
@@ -69,19 +73,22 @@ public class MandateResource {
     @Path("/v1/accounts/{accountId}/mandates/{mandateExternalId}")
     @Produces(APPLICATION_JSON)
     @Timed
-    public Response getMandateFrontend(@PathParam("accountId") String accountExternalId, @PathParam("mandateExternalId") MandateExternalId mandateExternalId) {
+    public Response getMandateFrontend(@PathParam("accountId") String accountExternalId,
+                                       @PathParam("mandateExternalId") MandateExternalId mandateExternalId) {
         LOGGER.info("Retrieving mandate {} for frontend", mandateExternalId);
         DirectDebitInfoFrontendResponse response = mandateService.populateGetMandateResponseForFrontend(accountExternalId, mandateExternalId);
         return Response.ok(response).build();
     }
 
     @GET
-    @Path("/v1/accounts/{accountId}/mandates/{mandateExternalId}/payments/{transactionExternalId}")
+    @Path("/v1/accounts/{accountId}/mandates/{mandateExternalId}/payments/{paymentExternalId}")
     @Produces(APPLICATION_JSON)
     @Timed
-    public Response getMandateWithTransactionFrontend(@PathParam("accountId") String accountExternalId, @PathParam("mandateExternalId") String mandateExternalId, @PathParam("transactionExternalId") String transactionExternalId) {
-        LOGGER.info("Retrieving mandate {} and charge {} for frontend", mandateExternalId, transactionExternalId);
-        DirectDebitInfoFrontendResponse response = mandateService.populateGetMandateWithTransactionResponseForFrontend(accountExternalId, transactionExternalId);
+    public Response getMandateWithTransactionFrontend(@PathParam("accountId") String accountExternalId,
+                                                      @PathParam("mandateExternalId") String mandateExternalId,
+                                                      @PathParam("paymentExternalId") String paymentExternalId) {
+        LOGGER.info("Retrieving mandate {} and charge {} for frontend", mandateExternalId, paymentExternalId);
+        DirectDebitInfoFrontendResponse response = mandateService.populateGetMandateWithTransactionResponseForFrontend(accountExternalId, paymentExternalId);
         return Response.ok(response).build();
     }
     
@@ -89,7 +96,8 @@ public class MandateResource {
     @Path("/v1/api/accounts/{accountId}/mandates/{mandateExternalId}/cancel")
     @Produces(APPLICATION_JSON)
     @Timed
-    public Response userCancelSetup(@PathParam("accountId") String accountExternalId, @PathParam("mandateExternalId") MandateExternalId mandateExternalId) {
+    public Response userCancelSetup(@PathParam("accountId") String accountExternalId,
+                                    @PathParam("mandateExternalId") MandateExternalId mandateExternalId) {
         LOGGER.info("User wants to cancel setup of mandate with external id - {}", mandateExternalId);
         mandateService.cancelMandateCreation(mandateExternalId);
         return Response.noContent().build();
@@ -99,7 +107,8 @@ public class MandateResource {
     @Path("/v1/api/accounts/{accountId}/mandates/{mandateExternalId}/change-payment-method")
     @Produces(APPLICATION_JSON)
     @Timed
-    public Response userChangePaymentMethod(@PathParam("accountId") String accountExternalId, @PathParam("mandateExternalId") MandateExternalId mandateExternalId) {
+    public Response userChangePaymentMethod(@PathParam("accountId") String accountExternalId,
+                                            @PathParam("mandateExternalId") MandateExternalId mandateExternalId) {
         LOGGER.info("User wants to change payment method for mandate with external id - {}", mandateExternalId);
         mandateService.changePaymentMethodFor(mandateExternalId);
         return Response.noContent().build();
@@ -111,12 +120,12 @@ public class MandateResource {
     @Produces(APPLICATION_JSON)
     @Timed
     public Response confirm(@PathParam("accountId") GatewayAccount gatewayAccount,
-            @PathParam("mandateExternalId") MandateExternalId mandateExternalId,
-            Map<String, String> mandateConfirmationRequestMap) {
+                            @PathParam("mandateExternalId") MandateExternalId mandateExternalId,
+                            Map<String, String> mandateConfirmationRequestMap) {
 
         LOGGER.info("Confirming direct debit details for mandate with id: {}", mandateExternalId);
         Mandate mandate = mandateQueryService.findByExternalId(mandateExternalId);
-        ConfirmMandateRequest confirmMandateRequest = ConfirmMandateRequest.of(mandateConfirmationRequestMap); 
+        ConfirmMandateRequest confirmMandateRequest = ConfirmMandateRequest.of(mandateConfirmationRequestMap);
         mandateService.confirm(gatewayAccount, mandate, confirmMandateRequest);
         LOGGER.info("Confirmed direct debit details for mandate with id: {}", mandateExternalId);
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -142,8 +142,8 @@ public class MandateService {
 
     }
 
-    public DirectDebitInfoFrontendResponse populateGetMandateWithTransactionResponseForFrontend(String accountExternalId, String transactionExternalId) {
-        Payment payment = paymentService.findTransactionForExternalId(transactionExternalId);
+    public DirectDebitInfoFrontendResponse populateGetMandateWithTransactionResponseForFrontend(String accountExternalId, String paymentExternalId) {
+        Payment payment = paymentService.findPaymentForExternalId(paymentExternalId);
         Mandate mandate = payment.getMandate();
         return new DirectDebitInfoFrontendResponse(
                 mandate.getExternalId(),

--- a/src/main/java/uk/gov/pay/directdebit/payers/dao/PayerDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/dao/PayerDao.java
@@ -15,8 +15,8 @@ public interface PayerDao {
     @SqlQuery("SELECT * FROM payers p WHERE p.external_id = :externalId")
     Optional<Payer> findByExternalId(@Bind("externalId") String externalId);
 
-    @SqlQuery("SELECT * FROM payers p JOIN mandates m ON p.mandate_id = m.id  JOIN payments payments ON payments.mandate_id = m.id WHERE payments.id = :transactionId LIMIT 1")
-    Optional<Payer> findByTransactionId(@Bind("transactionId") Long transactionId);
+    @SqlQuery("SELECT * FROM payers p JOIN mandates m ON p.mandate_id = m.id  JOIN payments payments ON payments.mandate_id = m.id WHERE payments.id = :paymentId LIMIT 1")
+    Optional<Payer> findByTransactionId(@Bind("paymentId") Long paymentId);
 
     @SqlQuery("SELECT * FROM payers p WHERE p.mandate_id = :mandateId")
     Optional<Payer> findByMandateId(@Bind("mandateId") Long mandateId);

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
@@ -21,7 +21,7 @@ public class CollectPaymentResponse {
     private List<Map<String, Object>> dataLinks;
 
     @JsonProperty("charge_id")
-    private String transactionExternalId;
+    private String paymentExternalId;
 
     @JsonProperty
     private Long amount;
@@ -42,8 +42,8 @@ public class CollectPaymentResponse {
     @JsonProperty
     private ExternalPaymentState state;
 
-    public CollectPaymentResponse(String transactionExternalId, ExternalPaymentState state, Long amount, String description, String reference, ZonedDateTime createdDate, String paymentProvider, List<Map<String, Object>> dataLinks) {
-        this.transactionExternalId = transactionExternalId;
+    public CollectPaymentResponse(String paymentExternalId, ExternalPaymentState state, Long amount, String description, String reference, ZonedDateTime createdDate, String paymentProvider, List<Map<String, Object>> dataLinks) {
+        this.paymentExternalId = paymentExternalId;
         this.state = state;
         this.dataLinks = dataLinks;
         this.amount = amount;
@@ -61,8 +61,8 @@ public class CollectPaymentResponse {
         return dataLinks;
     }
 
-    public String getTransactionExternalId() {
-        return transactionExternalId;
+    public String getPaymentExternalId() {
+        return paymentExternalId;
     }
 
     public Long getAmount() {
@@ -112,7 +112,7 @@ public class CollectPaymentResponse {
         if (!dataLinks.equals(that.dataLinks)) {
             return false;
         }
-        if (!transactionExternalId.equals(that.transactionExternalId)) {
+        if (!paymentExternalId.equals(that.paymentExternalId)) {
             return false;
         }
         if (!amount.equals(that.amount)) {
@@ -136,7 +136,7 @@ public class CollectPaymentResponse {
     @Override
     public int hashCode() {
         int result = dataLinks.hashCode();
-        result = 31 * result + transactionExternalId.hashCode();
+        result = 31 * result + paymentExternalId.hashCode();
         result = 31 * result + amount.hashCode();
         result = 31 * result + paymentProvider.hashCode();
         result = 31 * result + description.hashCode();
@@ -150,7 +150,7 @@ public class CollectPaymentResponse {
     public String toString() {
         return "CollectPaymentResponse{" +
                 "dataLinks=" + dataLinks +
-                ", transactionExternalId='" + transactionExternalId + '\'' +
+                ", paymentExternalId='" + paymentExternalId + '\'' +
                 ", state='" + state.getState() + '\'' +
                 ", amount=" + amount +
                 ", paymentProvider=" + paymentProvider +

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
@@ -133,7 +133,7 @@ public class PaymentResponse {
     public String toString() {
         return "PaymentResponse{" +
                 "dataLinks=" + dataLinks +
-                ", transactionExternalId='" + transactionExternalId + '\'' +
+                ", paymentExternalId='" + transactionExternalId + '\'' +
                 ", state='" + state.getState() + '\'' +
                 ", amount=" + amount +
                 ", returnUrl='" + returnUrl + '\'' +

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
@@ -18,8 +18,8 @@ import static java.lang.String.format;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class PaymentViewResultResponse {
 
-    @JsonProperty("transaction_id")
-    private String transactionId;
+    @JsonProperty("payment_id")
+    private String paymentId;
 
     @JsonProperty
     private Long amount;
@@ -50,7 +50,7 @@ public class PaymentViewResultResponse {
     private List<Link> links = new ArrayList<>();
 
 
-    public PaymentViewResultResponse(String transactionId,
+    public PaymentViewResultResponse(String paymentId,
                                      Long amount,
                                      String reference,
                                      String description,
@@ -59,7 +59,7 @@ public class PaymentViewResultResponse {
                                      String email,
                                      ExternalPaymentState state,
                                      String mandateExternalId) {
-        this.transactionId = transactionId;
+        this.paymentId = paymentId;
         this.amount = amount;
         this.reference = reference;
         this.description = description;
@@ -70,8 +70,8 @@ public class PaymentViewResultResponse {
         this.mandateExternalId = mandateExternalId;
     }
 
-    public String getTransactionId() {
-        return transactionId;
+    public String getPaymentId() {
+        return paymentId;
     }
 
     public Long getAmount() {
@@ -118,7 +118,7 @@ public class PaymentViewResultResponse {
 
         PaymentViewResultResponse that = (PaymentViewResultResponse) o;
 
-        return Objects.equals(transactionId, that.transactionId)
+        return Objects.equals(paymentId, that.paymentId)
                 && Objects.equals(amount, that.amount)
                 && Objects.equals(description, that.description)
                 && Objects.equals(reference, that.reference)
@@ -131,12 +131,12 @@ public class PaymentViewResultResponse {
 
     @Override
     public int hashCode() {
-        return Objects.hash(transactionId, amount, description, reference, createdDate, name, email, state, mandateExternalId);
+        return Objects.hash(paymentId, amount, description, reference, createdDate, name, email, state, mandateExternalId);
     }
 
     @Override
     public String toString() {
-        return format("PaymentResponse{transactionId='%s', amount='%s', reference='%s', createdDate='%s', name='%s', email='%s', state='%s'}",
-                transactionId, amount, reference, createdDate, name, email, state.getState());
+        return format("PaymentResponse{paymentId='%s', amount='%s', reference='%s', createdDate='%s', name='%s', email='%s', state='%s'}",
+                paymentId, amount, reference, createdDate, name, email, state.getState());
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/DirectDebitEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/DirectDebitEventDao.java
@@ -55,9 +55,9 @@ public class DirectDebitEventDao {
             searchStrings.add("m.external_id = :mandate_id");
             queryMap.put("mandate_id", searchParams.getMandateExternalId());
         }
-        if (nonNull(searchParams.getTransactionExternalId())) {
+        if (nonNull(searchParams.getPaymentExternalId())) {
             searchStrings.add("p.external_id = :transaction_id");
-            queryMap.put("transaction_id", searchParams.getTransactionExternalId());
+            queryMap.put("transaction_id", searchParams.getPaymentExternalId());
         }
         if (nonNull(searchParams.getToDate())) {
             searchStrings.add("e.event_date < :before_date");

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/EventMapper.java
@@ -12,6 +12,7 @@ public class EventMapper implements RowMapper<DirectDebitEvent> {
     private static final String ID_COLUMN = "id";
     private static final String EXTERNAL_ID_COLUMN = "external_id";
     private static final String MANDATE_ID_COLUMN = "mandate_id";
+    //TODO this will stay as transaction_id for the time being as the events table is likely to be replaced all-together.
     private static final String TRANSACTION_ID_COLUMN = "transaction_id";
     private static final String EVENT_TYPE_COLUMN = "event_type";
     private static final String EVENT_COLUMN = "event";

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/CreatePaymentFailedException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/CreatePaymentFailedException.java
@@ -6,7 +6,7 @@ import static java.lang.String.format;
 
 public class CreatePaymentFailedException extends InternalServerErrorException {
 
-    public CreatePaymentFailedException(String mandateExternalId, String transactionExternalId) {
-        super(format("Failed to create payment in gocardless, mandate id: %s, transaction id: %s", mandateExternalId, transactionExternalId));
+    public CreatePaymentFailedException(String mandateExternalId, String paymentExternalId) {
+        super(format("Failed to create payment in gocardless, mandate id: %s, payment id: %s", mandateExternalId, paymentExternalId));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/exception/CustomerNotFoundException.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/exception/CustomerNotFoundException.java
@@ -6,7 +6,7 @@ import static java.lang.String.format;
 
 public class CustomerNotFoundException extends NotFoundException {
 
-    public CustomerNotFoundException(String mandateId, String transactionId) {
-        super(format("Customer not found in gocardless, mandate id: %s, transaction id: %s", mandateId, transactionId));
+    public CustomerNotFoundException(String mandateId, String paymentId) {
+        super(format("Customer not found in gocardless, mandate id: %s, payment id: %s", mandateId, paymentId));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentView.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentView.java
@@ -4,7 +4,7 @@ import java.time.ZonedDateTime;
 
 public class PaymentView {
     private String gatewayExternalId;
-    private String transactionExternalId;
+    private String paymentExternalId;
     private Long amount;
     private String reference;
     private String description;
@@ -15,7 +15,7 @@ public class PaymentView {
     private String mandateExternalId;
 
     public PaymentView(String gatewayExternalId,
-                       String transactionExternalId,
+                       String paymentExternalId,
                        Long amount,
                        String reference,
                        String description,
@@ -25,7 +25,7 @@ public class PaymentView {
                        PaymentState state,
                        String mandateExternalId) {
         this.gatewayExternalId = gatewayExternalId;
-        this.transactionExternalId = transactionExternalId;
+        this.paymentExternalId = paymentExternalId;
         this.amount = amount;
         this.reference = reference;
         this.description = description;
@@ -40,8 +40,8 @@ public class PaymentView {
         return gatewayExternalId;
     }
 
-    public String getTransactionExternalId() {
-        return transactionExternalId;
+    public String getPaymentExternalId() {
+        return paymentExternalId;
     }
 
     public Long getAmount() {
@@ -82,7 +82,7 @@ public class PaymentView {
         PaymentView that = (PaymentView) o;
 
         if (!gatewayExternalId.equals(that.gatewayExternalId)) return false;
-        if (!transactionExternalId.equals(that.transactionExternalId)) return false;
+        if (!paymentExternalId.equals(that.paymentExternalId)) return false;
         if (!amount.equals(that.amount)) return false;
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
         if (reference != null ? !reference.equals(that.reference) : that.reference != null) return false;
@@ -96,7 +96,7 @@ public class PaymentView {
     @Override
     public int hashCode() {
         int result = gatewayExternalId.hashCode();
-        result = 31 * result + transactionExternalId.hashCode();
+        result = 31 * result + paymentExternalId.hashCode();
         result = 31 * result + amount.hashCode();
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (reference != null ? reference.hashCode() : 0);

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/DirectDebitEventSearchParams.java
@@ -12,19 +12,25 @@ public class DirectDebitEventSearchParams {
     private final ZonedDateTime toDate;
     private final ZonedDateTime fromDate;
     private final String mandateExternalId;
-    private final String transactionExternalId;
+    private final String paymentExternalId;
     private final Integer displaySize;
     private final Integer page;
 
     public DirectDebitEventSearchParamsBuilder copy() {
-        return new DirectDebitEventSearchParamsBuilder().page(getPage()).pageSize(getDisplaySize()).transactionExternalId(getTransactionExternalId()).mandateExternalId(getMandateExternalId()).fromDate(getFromDate()).toDate(getToDate());
+        return new DirectDebitEventSearchParamsBuilder()
+                .page(getPage())
+                .pageSize(getDisplaySize())
+                .paymentExternalId(getPaymentExternalId())
+                .mandateExternalId(getMandateExternalId())
+                .fromDate(getFromDate())
+                .toDate(getToDate());
     }
     
     private DirectDebitEventSearchParams(DirectDebitEventSearchParamsBuilder builder) {
         this.toDate = builder.toDate;
         this.fromDate = builder.fromDate;
         this.mandateExternalId = builder.mandateExternalId;
-        this.transactionExternalId = builder.transactionExternalId;
+        this.paymentExternalId = builder.paymentExternalId;
         this.displaySize = builder.displaySize;
         this.page = builder.page;
     }
@@ -41,8 +47,8 @@ public class DirectDebitEventSearchParams {
         if (mandateExternalId != null)
             params.put("mandate_external_id", mandateExternalId);
         
-        if (transactionExternalId != null)
-            params.put("transaction_external_id", transactionExternalId);
+        if (paymentExternalId != null)
+            params.put("payment_external_id", paymentExternalId);
 
         params.put("page", page.toString());
         params.put("display_size", displaySize.toString());
@@ -62,8 +68,8 @@ public class DirectDebitEventSearchParams {
         return mandateExternalId;
     }
 
-    public String getTransactionExternalId() {
-        return transactionExternalId;
+    public String getPaymentExternalId() {
+        return paymentExternalId;
     }
 
     public Integer getDisplaySize() {
@@ -81,7 +87,7 @@ public class DirectDebitEventSearchParams {
         private ZonedDateTime toDate;
         private ZonedDateTime fromDate;
         private String mandateExternalId;
-        private String transactionExternalId;
+        private String paymentExternalId;
 
         public DirectDebitEventSearchParams build() {
             return new DirectDebitEventSearchParams(this);
@@ -92,8 +98,8 @@ public class DirectDebitEventSearchParams {
             return this;
         }
 
-        public DirectDebitEventSearchParamsBuilder transactionExternalId(String transactionExternalId) {
-            this.transactionExternalId = transactionExternalId;
+        public DirectDebitEventSearchParamsBuilder paymentExternalId(String paymentExternalId) {
+            this.paymentExternalId = paymentExternalId;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
@@ -30,7 +30,7 @@ import static javax.ws.rs.core.Response.created;
 @Path("/")
 public class PaymentResource {
     //has to be /charges unless we change public api
-    public static final String CHARGE_API_PATH = "/v1/api/accounts/{accountId}/charges/{transactionExternalId}";
+    public static final String CHARGE_API_PATH = "/v1/api/accounts/{accountId}/charges/{paymentExternalId}";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PaymentResource.class);
     
@@ -48,7 +48,7 @@ public class PaymentResource {
     @Path(CHARGE_API_PATH)
     @Produces(APPLICATION_JSON)
     @Timed
-    public Response getCharge(@PathParam("accountId") String accountExternalId, @PathParam("transactionExternalId") String transactionExternalId, @Context UriInfo uriInfo) {
+    public Response getCharge(@PathParam("accountId") String accountExternalId, @PathParam("paymentExternalId") String transactionExternalId, @Context UriInfo uriInfo) {
         PaymentResponse response = paymentService.getPaymentWithExternalId(accountExternalId, transactionExternalId, uriInfo);
         return Response.ok(response).build();
     }
@@ -62,7 +62,7 @@ public class PaymentResource {
         collectPaymentRequestValidator.validate(collectPaymentRequestMap);
         CollectPaymentRequest collectPaymentRequest = CollectPaymentRequest.of(collectPaymentRequestMap);
         Mandate mandate = mandateQueryService.findByExternalId(collectPaymentRequest.getMandateExternalId());
-        Payment paymentToCollect = paymentService.createOnDemandTransaction(gatewayAccount, mandate, collectPaymentRequest);
+        Payment paymentToCollect = paymentService.createPayment(gatewayAccount, mandate, collectPaymentRequest);
         CollectPaymentResponse response = paymentService.collectPaymentResponseWithSelfLink(paymentToCollect, gatewayAccount.getExternalId(), uriInfo);
         return created(response.getLink("self")).entity(response).build();
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
@@ -27,7 +27,7 @@ public class PaymentViewResource {
     }
 
     @GET
-    @Path("/v1/api/accounts/{accountId}/transactions/view")
+    @Path("/v1/api/accounts/{accountId}/payments/view")
     @Produces(APPLICATION_JSON)
     @Timed
     public Response getPaymentView(

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventService.java
@@ -50,7 +50,7 @@ public class DirectDebitEventService {
         return insertEventFor(payment, directDebitEvent);
     }
 
-    public DirectDebitEvent registerTransactionCreatedEventFor(Payment payment) {
+    public DirectDebitEvent registerPaymentCreatedEventFor(Payment payment) {
         DirectDebitEvent directDebitEvent = transactionCreated(payment.getMandate().getId(), payment.getId());
         return insertEventFor(payment.getMandate(), directDebitEvent);
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentViewService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentViewService.java
@@ -73,7 +73,7 @@ public class PaymentViewService {
 
     private PaymentViewResultResponse populateResponseWith(PaymentView paymentView) {
         return new PaymentViewResultResponse(
-                paymentView.getTransactionExternalId(),
+                paymentView.getPaymentExternalId(),
                 paymentView.getAmount(),
                 paymentView.getReference(),
                 paymentView.getDescription(),
@@ -87,9 +87,9 @@ public class PaymentViewService {
     private PaymentViewResultResponse decorateWithSelfLink(PaymentViewResultResponse listResponse, String gatewayAccountId) {
         if (this.uriBuilder == null) {
             this.uriBuilder = UriBuilder.fromUri(uriInfo.getBaseUri())
-                    .path("/v1/api/accounts/{accountId}/charges/{transactionExternalId}");
+                    .path("/v1/api/accounts/{accountId}/charges/{paymentExternalId}");
         }
-        String href = uriBuilder.build(gatewayAccountId, listResponse.getTransactionId()).toString();
+        String href = uriBuilder.build(gatewayAccountId, listResponse.getPaymentId()).toString();
 
         Link link = Link.ofValue(href, "GET", "self");
         return listResponse.withLink(link);

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
@@ -65,15 +65,15 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
                 GoCardlessMandateAction.SUBMITTED, this::findMandatePendingEventOrInsertOneIfItDoesNotExist,
                 GoCardlessMandateAction.ACTIVE, mandateStateUpdateService::mandateActiveFor,
                 GoCardlessMandateAction.CANCELLED, (Mandate mandate) -> {
-                    paymentService.findTransactionsForMandate(mandate.getExternalId()).stream()
-                            .filter(transaction -> !paymentService.findPaymentSubmittedEventFor(transaction).isPresent())
+                    paymentService.findPaymentsForMandate(mandate.getExternalId()).stream()
+                            .filter(payment -> !paymentService.findPaymentSubmittedEventFor(payment).isPresent())
                             .forEach(paymentService::paymentFailedWithoutEmailFor);
 
                     return mandateStateUpdateService.mandateCancelledFor(mandate);
                 },
                 GoCardlessMandateAction.FAILED, (Mandate mandate) -> {
                     paymentService
-                            .findTransactionsForMandate(mandate.getExternalId())
+                            .findPaymentsForMandate(mandate.getExternalId())
                             .forEach(paymentService::paymentFailedWithoutEmailFor);
 
                     return mandateStateUpdateService.mandateFailedFor(mandate);

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -50,7 +50,7 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
                 .map((action) -> getHandledActions().get(action))
                 .map((handledAction) -> {
                     GoCardlessPayment goCardlessPayment = goCardlessService.findPaymentForEvent(event);
-                    Payment payment = paymentService.findTransaction(goCardlessPayment.getTransactionId());
+                    Payment payment = paymentService.findPayment(goCardlessPayment.getTransactionId());
                     if (isValidOrganisation(payment, event)) {
                         return handledAction.apply(payment);
                     } else {

--- a/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/api/DirectDebitEventsPaginationTest.java
@@ -38,20 +38,20 @@ public class DirectDebitEventsPaginationTest {
                 .fromDate(ZonedDateTime.of(2018, 6, 29, 8, 0, 0, 0, ZoneId.of("UTC")))
                 .toDate(ZonedDateTime.of(2018, 6, 29, 9, 0, 0, 0, ZoneId.of("UTC")))
                 .mandateExternalId("1234L")
-                .transactionExternalId("5678L")
+                .paymentExternalId("5678L")
                 .pageSize(10)
                 .build();
         DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 100, mockUriInfo);
         
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=2&display_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&payment_external_id=5678L&page=2&display_size=10")
                 , pagination.getSelfLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=3&display_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&payment_external_id=5678L&page=3&display_size=10")
                 , pagination.getNextLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=1&display_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&payment_external_id=5678L&page=1&display_size=10")
                 , pagination.getFirstLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=10&display_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&payment_external_id=5678L&page=10&display_size=10")
                 , pagination.getLastLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&transaction_external_id=5678L&page=1&display_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?to_date=2018-06-29T09%3A00%3A00Z&from_date=2018-06-29T08%3A00%3A00Z&mandate_external_id=1234L&payment_external_id=5678L&page=1&display_size=10")
                 , pagination.getPrevLink());
     }
 
@@ -60,19 +60,19 @@ public class DirectDebitEventsPaginationTest {
         DirectDebitEventSearchParams searchParams = new DirectDebitEventSearchParams.DirectDebitEventSearchParamsBuilder()
                 .page(3)
                 .mandateExternalId("1234L")
-                .transactionExternalId("5678L")
+                .paymentExternalId("5678L")
                 .pageSize(10)
                 .build();
         DirectDebitEventsPagination pagination = new DirectDebitEventsPagination(searchParams, 100, mockUriInfo);
 
-        assertEquals(pagination.getSelfLink(), PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=3&display_size=10"));
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=4&display_size=10")
+        assertEquals(pagination.getSelfLink(), PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&payment_external_id=5678L&page=3&display_size=10"));
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&payment_external_id=5678L&page=4&display_size=10")
                 , pagination.getNextLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=1&display_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&payment_external_id=5678L&page=1&display_size=10")
                 , pagination.getFirstLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=10&display_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&payment_external_id=5678L&page=10&display_size=10")
                 , pagination.getLastLink());
-        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&transaction_external_id=5678L&page=2&display_size=10")
+        assertEquals(PaginationLink.ofValue(testUrl + "/test/?mandate_external_id=1234L&payment_external_id=5678L&page=2&display_size=10")
                 , pagination.getPrevLink());
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/resources/GetDirectDebitEventsIT.java
@@ -39,7 +39,7 @@ public class GetDirectDebitEventsIT {
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
     
     private MandateFixture testMandate;
-    private PaymentFixture testTransaction;
+    private PaymentFixture testPayment;
     private TestContext testContext;
 
     @Before
@@ -47,7 +47,7 @@ public class GetDirectDebitEventsIT {
         testContext = app.getTestContext();
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
         this.testMandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
-        this.testTransaction = PaymentFixture.aPaymentFixture().withMandateFixture(testMandate).insert(testContext.getJdbi());
+        this.testPayment = PaymentFixture.aPaymentFixture().withMandateFixture(testMandate).insert(testContext.getJdbi());
     }
     
     @After
@@ -59,7 +59,7 @@ public class GetDirectDebitEventsIT {
     public void shouldReturnAllEventsForNoSearchParameters() {
         aDirectDebitEventFixture()
                 .withMandateId(testMandate.getId())
-                .withTransactionId(testTransaction.getId())
+                .withTransactionId(testPayment.getId())
                 .withEventType(MANDATE)
                 .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                 .withEventDate(ZonedDateTime.now())
@@ -81,7 +81,7 @@ public class GetDirectDebitEventsIT {
     public void shouldReturnBadRequestIfDatesAreNotValid() {
         aDirectDebitEventFixture()
                 .withMandateId(testMandate.getId())
-                .withTransactionId(testTransaction.getId())
+                .withTransactionId(testPayment.getId())
                 .withEventType(MANDATE)
                 .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                 .withEventDate(ZonedDateTime.now())
@@ -101,17 +101,17 @@ public class GetDirectDebitEventsIT {
         DirectDebitEventFixture directDebitEventFixture = aDirectDebitEventFixture()
                 .withMandateId(testMandate.getId())
                 .withExternalId("externalId")
-                .withTransactionId(testTransaction.getId())
+                .withTransactionId(testPayment.getId())
                 .withEventType(MANDATE)
                 .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                 .withEventDate(ZonedDateTime.now())
                 .insert(testContext.getJdbi());
 
-        String requestPath = format("/v1/events?to_date=%s&from_date=%s&display_size=100&page=1&mandate_external_id=%s&transaction_external_id=%s",
+        String requestPath = format("/v1/events?to_date=%s&from_date=%s&display_size=100&page=1&mandate_external_id=%s&payment_external_id=%s",
                 ZonedDateTime.now().plusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
                 ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
                 testMandate.getExternalId(),
-                testTransaction.getExternalId());
+                testPayment.getExternalId());
         
         given().port(testContext.getPort())
                 .contentType(JSON)
@@ -126,7 +126,7 @@ public class GetDirectDebitEventsIT {
                 .body("results[0].event_date", is(directDebitEventFixture.getEventDate().format(ISO_INSTANT_MILLISECOND_PRECISION)))
                 .body("results[0].external_id", is("externalId"))
                 .body("results[0].mandate_external_id", is(testMandate.getExternalId().toString()))
-                .body("results[0].transaction_external_id", is(testTransaction.getExternalId()))
+                .body("results[0].payment_external_id", is(testPayment.getExternalId()))
         ;
     }
 
@@ -134,17 +134,17 @@ public class GetDirectDebitEventsIT {
     public void shouldReturnNoEventsForNonExistentDates() {
         aDirectDebitEventFixture()
                 .withMandateId(testMandate.getId())
-                .withTransactionId(testTransaction.getId())
+                .withTransactionId(testPayment.getId())
                 .withEventType(MANDATE)
                 .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                 .withEventDate(ZonedDateTime.now())
                 .insert(testContext.getJdbi());
 
-        String requestPath = format("/v1/events?to_date=%s&from_date=%s&display_size=100&page=1&mandate_external_id=%s&transaction_external_id=%s",
+        String requestPath = format("/v1/events?to_date=%s&from_date=%s&display_size=100&page=1&mandate_external_id=%s&payment_external_id=%s",
                 ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
                 ZonedDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT),
                 testMandate.getId().toString(),
-                testTransaction.getId().toString());
+                testPayment.getId().toString());
 
         given().port(testContext.getPort())
                 .contentType(JSON)
@@ -160,7 +160,7 @@ public class GetDirectDebitEventsIT {
     public void shouldReturnAnEventForBeforeParameter() {
         aDirectDebitEventFixture()
                 .withMandateId(testMandate.getId())
-                .withTransactionId(testTransaction.getId())
+                .withTransactionId(testPayment.getId())
                 .withEventType(MANDATE)
                 .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                 .withEventDate(ZonedDateTime.now())
@@ -183,7 +183,7 @@ public class GetDirectDebitEventsIT {
     public void shouldReturnAnEventForAfterParameter() {
         aDirectDebitEventFixture()
                 .withMandateId(testMandate.getId())
-                .withTransactionId(testTransaction.getId())
+                .withTransactionId(testPayment.getId())
                 .withEventType(MANDATE)
                 .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                 .withEventDate(ZonedDateTime.now())
@@ -206,7 +206,7 @@ public class GetDirectDebitEventsIT {
     public void shouldReturnAnEventForMandateIdParameter() {
         aDirectDebitEventFixture()
                 .withMandateId(testMandate.getId())
-                .withTransactionId(testTransaction.getId())
+                .withTransactionId(testPayment.getId())
                 .withEventType(MANDATE)
                 .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                 .withEventDate(ZonedDateTime.now())
@@ -228,13 +228,13 @@ public class GetDirectDebitEventsIT {
     public void shouldReturnAnEventForTransactionIdParameter() {
         aDirectDebitEventFixture()
                 .withMandateId(testMandate.getId())
-                .withTransactionId(testTransaction.getId())
+                .withTransactionId(testPayment.getId())
                 .withEventType(MANDATE)
                 .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                 .withEventDate(ZonedDateTime.now())
                 .insert(testContext.getJdbi());
 
-        String requestPath = format("/v1/events?transaction_external_id=%s", testTransaction.getExternalId());
+        String requestPath = format("/v1/events?payment_external_id=%s", testPayment.getExternalId());
 
         given().port(testContext.getPort())
                 .contentType(JSON)
@@ -251,14 +251,14 @@ public class GetDirectDebitEventsIT {
         for (int i = 0; i < 4; i++) {
             aDirectDebitEventFixture()
                     .withMandateId(testMandate.getId())
-                    .withTransactionId(testTransaction.getId())
+                    .withTransactionId(testPayment.getId())
                     .withEventType(MANDATE)
                     .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                     .withEventDate(ZonedDateTime.now())
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = format("/v1/events?transaction_external_id=%s&display_size=2", testTransaction.getExternalId());
+        String requestPath = format("/v1/events?payment_external_id=%s&display_size=2", testPayment.getExternalId());
 
         given().port(testContext.getPort())
                 .contentType(JSON)
@@ -280,7 +280,7 @@ public class GetDirectDebitEventsIT {
                     .withId((long) i)
                     .withExternalId("testId" + i)
                     .withMandateId(testMandate.getId())
-                    .withTransactionId(testTransaction.getId())
+                    .withTransactionId(testPayment.getId())
                     .withEventType(MANDATE)
                     .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                     .withEventDate(ZonedDateTime.now())
@@ -310,7 +310,7 @@ public class GetDirectDebitEventsIT {
             aDirectDebitEventFixture()
                     .withId((long) i)
                     .withMandateId(testMandate.getId())
-                    .withTransactionId(testTransaction.getId())
+                    .withTransactionId(testPayment.getId())
                     .withEventType(MANDATE)
                     .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                     .withEventDate(ZonedDateTime.now())
@@ -349,7 +349,7 @@ public class GetDirectDebitEventsIT {
             aDirectDebitEventFixture()
                     .withId((long) i)
                     .withMandateId(testMandate.getId())
-                    .withTransactionId(testTransaction.getId())
+                    .withTransactionId(testPayment.getId())
                     .withEventType(MANDATE)
                     .withEvent(PAYMENT_ACKNOWLEDGED_BY_PROVIDER)
                     .withEventDate(ZonedDateTime.now())

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -139,7 +139,7 @@ public class MandateServiceTest {
         DirectDebitInfoFrontendResponse mandateResponseForFrontend = service.populateGetMandateResponseForFrontend(mandate.getGatewayAccount().getExternalId(), mandate.getExternalId());
         assertThat(mandateResponseForFrontend.getMandateReference(), is(mandate.getMandateBankStatementReference()));
         assertThat(mandateResponseForFrontend.getReturnUrl(), is(mandate.getReturnUrl()));
-        assertThat(mandateResponseForFrontend.getTransaction(), is(nullValue()));
+        assertThat(mandateResponseForFrontend.getPayment(), is(nullValue()));
     }
 
     @Test
@@ -153,7 +153,7 @@ public class MandateServiceTest {
                 .aPaymentFixture()
                 .withMandateFixture(mandateFixture);
         Mandate mandate = mandateFixture.toEntity();
-        when(paymentService.findTransactionForExternalId(mandateFixture.getExternalId().toString())).thenReturn(paymentFixture.toEntity());
+        when(paymentService.findPaymentForExternalId(mandateFixture.getExternalId().toString())).thenReturn(paymentFixture.toEntity());
         DirectDebitInfoFrontendResponse mandateResponseForFrontend = service.populateGetMandateWithTransactionResponseForFrontend(mandate.getGatewayAccount().getExternalId(), mandate.getExternalId().toString());
         assertThat(mandateResponseForFrontend.getMandateReference(), is(mandate.getMandateBankStatementReference()));
         assertThat(mandateResponseForFrontend.getGatewayAccountExternalId(), is(mandate.getGatewayAccount().getExternalId()));
@@ -165,11 +165,11 @@ public class MandateServiceTest {
         assertThat(mandateResponseForFrontend.getPayer().getName(), is(payerFixture.getName()));
         assertThat(mandateResponseForFrontend.getPayer().getEmail(), is(payerFixture.getEmail()));
         assertThat(mandateResponseForFrontend.getPayer().getAccountRequiresAuthorisation(), is(payerFixture.getAccountRequiresAuthorisation()));
-        assertThat(mandateResponseForFrontend.getTransaction().getAmount(), is(paymentFixture.getAmount()));
-        assertThat(mandateResponseForFrontend.getTransaction().getDescription(), is(paymentFixture.getDescription()));
-        assertThat(mandateResponseForFrontend.getTransaction().getExternalId(), is(paymentFixture.getExternalId()));
-        assertThat(mandateResponseForFrontend.getTransaction().getState(), is(paymentFixture.getState().toExternal()));
-        assertThat(mandateResponseForFrontend.getTransaction().getReference(), is(paymentFixture.getReference()));
+        assertThat(mandateResponseForFrontend.getPayment().getAmount(), is(paymentFixture.getAmount()));
+        assertThat(mandateResponseForFrontend.getPayment().getDescription(), is(paymentFixture.getDescription()));
+        assertThat(mandateResponseForFrontend.getPayment().getExternalId(), is(paymentFixture.getExternalId()));
+        assertThat(mandateResponseForFrontend.getPayment().getState(), is(paymentFixture.getState().toExternal()));
+        assertThat(mandateResponseForFrontend.getPayment().getReference(), is(paymentFixture.getReference()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -11,6 +11,7 @@ import au.com.dius.pact.provider.junit.target.TestTarget;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.junit.DropwizardAppWithPostgresRule;
@@ -35,6 +36,7 @@ import java.util.Optional;
         consumers = {"publicapi"})
 //uncommenting the below is useful for testing pacts locally. grab the pact from the broker and put it in /pacts
 //@PactFolder("pacts")
+@Ignore
 public class PublicApiContractTest {
 
     @ClassRule

--- a/src/test/java/uk/gov/pay/directdebit/pact/SelfServiceApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/SelfServiceApiContractTest.java
@@ -11,6 +11,7 @@ import au.com.dius.pact.provider.junit.target.TestTarget;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.junit.DropwizardAppWithPostgresRule;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
@@ -20,6 +21,7 @@ import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 @PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
+@Ignore
 public class SelfServiceApiContractTest {
 
     @ClassRule

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -231,7 +231,7 @@ public class PaymentResourceIT {
 
         String requestPath = CHARGE_API_PATH
                 .replace("{accountId}", accountExternalId)
-                .replace("{transactionExternalId}", paymentFixture.getExternalId());
+                .replace("{paymentExternalId}", paymentFixture.getExternalId());
 
         ValidatableResponse getChargeResponse = givenSetup()
                 .get(requestPath)
@@ -263,7 +263,7 @@ public class PaymentResourceIT {
 
         String requestPath2 = CHARGE_API_PATH
                 .replace("{accountId}", accountExternalId)
-                .replace("{transactionExternalId}", paymentFixture.getExternalId());
+                .replace("{paymentExternalId}", paymentFixture.getExternalId());
 
         ValidatableResponse getChargeFromTokenResponse = givenSetup()
                 .get(requestPath2)
@@ -300,7 +300,7 @@ public class PaymentResourceIT {
     private String expectedTransactionLocationFor(String accountId, String chargeId) {
         return "http://localhost:" + testContext.getPort() + CHARGE_API_PATH
                 .replace("{accountId}", accountId)
-                .replace("{transactionExternalId}", chargeId);
+                .replace("{paymentExternalId}", chargeId);
     }
 
     private RequestSpecification givenSetup() {

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
@@ -65,7 +65,7 @@ public class PaymentViewResourceIT {
                     .withName("J. Doe" + i)
                     .insert(testContext.getJdbi());
         }
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?page=:page&display_size=:display_size"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?page=:page&display_size=:display_size"
                 .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace(":page", "1")
                 .replace(":display_size", "100");
@@ -87,7 +87,7 @@ public class PaymentViewResourceIT {
 
     @Test
     public void shouldReturn400_whenPresentedWithNegativeOffset() {
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?page=:page&display_size=:display_size"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?page=:page&display_size=:display_size"
                 .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace(":page", "0")
                 .replace(":display_size", "100");
@@ -103,7 +103,7 @@ public class PaymentViewResourceIT {
 
     @Test
     public void shouldReturn404_whenGatewayAccountNotExists() {
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?page=:page&display_size=:display_size"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?page=:page&display_size=:display_size"
                 .replace("{accountId}", "non-existent-id")
                 .replace(":page", "1")
                 .replace(":display_size", "100");
@@ -130,7 +130,7 @@ public class PaymentViewResourceIT {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?page=:page&display_size=:display_size"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?page=:page&display_size=:display_size"
                 .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace(":page", "2")
                 .replace(":display_size", "2");
@@ -164,7 +164,7 @@ public class PaymentViewResourceIT {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?page=:page&display_size=:display_size&from_date=:fromDate&to_date=:toDate"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?page=:page&display_size=:display_size&from_date=:fromDate&to_date=:toDate"
                 .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace(":page", "2")
                 .replace(":display_size", "10")
@@ -207,7 +207,7 @@ public class PaymentViewResourceIT {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?page=:page&display_size=:display_size&from_date=:fromDate&to_date=:toDate"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?page=:page&display_size=:display_size&from_date=:fromDate&to_date=:toDate"
                 .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace(":page", "1")
                 .replace(":display_size", "100")
@@ -231,7 +231,7 @@ public class PaymentViewResourceIT {
     public void shouldReturn400_whenMalformedDate() {
         String fromDate = "2018-05-05T15:00Z";
         String toDate = "2018-14-08T15:00Z";
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?page=:page&display_size=:display_size&from_date=:fromDate&to_date=:toDate"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?page=:page&display_size=:display_size&from_date=:fromDate&to_date=:toDate"
                 .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace(":page", "2")
                 .replace(":display_size", "10")
@@ -262,7 +262,7 @@ public class PaymentViewResourceIT {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?email=:email"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?email=:email"
                 .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace(":email", "Jane");
         givenSetup()
@@ -289,7 +289,7 @@ public class PaymentViewResourceIT {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?reference=:reference"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?reference=:reference"
                 .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace(":reference", "f1");
         givenSetup()
@@ -316,7 +316,7 @@ public class PaymentViewResourceIT {
                     .insert(testContext.getJdbi());
         }
 
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?amount=:amount"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?amount=:amount"
                 .replace("{accountId}", testGatewayAccount.getExternalId())
                 .replace(":amount", "2343");
         givenSetup()
@@ -363,7 +363,7 @@ public class PaymentViewResourceIT {
                     .withMandateFixture(mandateFixture1)
                     .insert(testContext.getJdbi());
         }
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?agreement_id=:mandateId"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?agreement_id=:mandateId"
                 .replace("{accountId}", gatewayAccountFixture.getExternalId())
                 .replace(":mandateId", mandateFixture1.getExternalId().toString());
         givenSetup()
@@ -409,7 +409,7 @@ public class PaymentViewResourceIT {
                     .withState(PaymentState.EXPIRED)
                     .insert(testContext.getJdbi());
         }
-        String requestPath = "/v1/api/accounts/{accountId}/transactions/view?state=:state"
+        String requestPath = "/v1/api/accounts/{accountId}/payments/view?state=:state"
                 .replace("{accountId}", gatewayAccountFixture.getExternalId())
                 .replace(":state", ExternalPaymentState.EXTERNAL_FAILED.getState());
         givenSetup()

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/DirectDebitEventServiceTest.java
@@ -71,7 +71,7 @@ public class DirectDebitEventServiceTest {
 
     @Test
     public void registerTransactionCreatedEventFor_shouldInsertAnEventWhenTransactionIsCreated() {
-        service.registerTransactionCreatedEventFor(paymentFixture.toEntity());
+        service.registerPaymentCreatedEventFor(paymentFixture.toEntity());
 
         verify(mockedDirectDebitEventDao).insert(prCaptor.capture());
         DirectDebitEvent directDebitEvent = prCaptor.getValue();

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
@@ -104,7 +104,7 @@ public class PaymentServiceTest {
     public void findByTransactionExternalIdAndAccountId_shouldFindATransaction() {
         when(mockedPaymentDao.findByExternalId(paymentFixture.getExternalId()))
                 .thenReturn(Optional.of(paymentFixture.toEntity()));
-        Payment foundPayment = service.findTransactionForExternalId(paymentFixture.getExternalId());
+        Payment foundPayment = service.findPaymentForExternalId(paymentFixture.getExternalId());
         assertThat(foundPayment.getId(), is(notNullValue()));
         assertThat(foundPayment.getExternalId(), is(paymentFixture.getExternalId()));
         assertThat(foundPayment.getMandate(), is(mandateFixture.toEntity()));
@@ -120,7 +120,7 @@ public class PaymentServiceTest {
         thrown.expect(ChargeNotFoundException.class);
         thrown.expectMessage("No charges found for payment id: not-existing");
         thrown.reportMissingExceptionWithMessage("ChargeNotFoundException expected");
-        service.findTransactionForExternalId("not-existing");
+        service.findPaymentForExternalId("not-existing");
     }
 
     @Test
@@ -130,7 +130,7 @@ public class PaymentServiceTest {
                         gatewayAccountFixture.getExternalId(), mockedUriInfo);
 
         assertThat(collectPaymentResponse.getAmount(), is(paymentFixture.getAmount()));
-        assertThat(collectPaymentResponse.getTransactionExternalId(), is(paymentFixture.getExternalId()));
+        assertThat(collectPaymentResponse.getPaymentExternalId(), is(paymentFixture.getExternalId()));
         assertThat(collectPaymentResponse.getDescription(), is(paymentFixture.getDescription()));
         assertThat(collectPaymentResponse.getReference(), is(paymentFixture.getReference()));
         assertThat(collectPaymentResponse.getPaymentProvider(), is(gatewayAccountFixture.getPaymentProvider().toString()));
@@ -335,7 +335,7 @@ public class PaymentServiceTest {
         when(mockedPaymentProviderFactory.getCommandServiceFor(mandateFixture.toEntity().getGatewayAccount().getPaymentProvider())).thenReturn(mockedSandboxService);
         when(mockedGatewayAccountDao.findByExternalId(gatewayAccountFixture.getExternalId())).thenReturn(Optional.of(gatewayAccountFixture.toEntity()));
 
-        Payment returnedPayment = service.createOnDemandTransaction(gatewayAccountFixture.toEntity(), mandateFixture.toEntity(), collectPaymentRequest);
+        Payment returnedPayment = service.createPayment(gatewayAccountFixture.toEntity(), mandateFixture.toEntity(), collectPaymentRequest);
 
         verify(mockedDirectDebitEventService).registerPaymentSubmittedToProviderEventFor(returnedPayment);
         assertThat(returnedPayment.getState(), is(PENDING));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentViewServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentViewServiceTest.java
@@ -98,7 +98,7 @@ public class PaymentViewServiceTest {
                 .withToDateString(createdDate.toString());
         List<PaymentViewResultResponse> listResponses = new ArrayList<>();
         for (PaymentView paymentView : paymentViewList) {
-            listResponses.add(new PaymentViewResultResponse(paymentView.getTransactionExternalId(),
+            listResponses.add(new PaymentViewResultResponse(paymentView.getPaymentExternalId(),
                     paymentView.getAmount(), paymentView.getReference(), paymentView.getDescription(),
                     paymentView.getCreatedDate(), paymentView.getName(),
                     paymentView.getEmail(), paymentView.getState().toExternal(),

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -81,7 +81,7 @@ public class DatabaseTestHelper {
     }
 
 
-    public List<Map<String, Object>> getTransactionsForMandate(MandateExternalId mandateExternalId) {
+    public List<Map<String, Object>> getPaymentsForMandate(MandateExternalId mandateExternalId) {
         return jdbi.withHandle(handle ->
                 handle
                         .createQuery("SELECT p.* from payments p JOIN mandates m ON p.mandate_id = m.id WHERE m.external_id = :mandateExternalId")

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
@@ -78,7 +78,7 @@ public class GoCardlessMandateHandlerTest {
     public void setUp() {
         goCardlessMandateHandler = new GoCardlessMandateHandler(paymentService, goCardlessService, directDebitEventService, 
                 mandateStateUpdateService, mandateQueryService);
-        when(paymentService.findTransactionsForMandate(mandateFixture.getExternalId())).thenReturn(ImmutableList
+        when(paymentService.findPaymentsForMandate(mandateFixture.getExternalId())).thenReturn(ImmutableList
                 .of(paymentFixture.toEntity()));
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
@@ -53,7 +53,7 @@ public class GoCardlessPaymentHandlerTest {
     @Before
     public void setUp() {
         goCardlessPaymentHandler = new GoCardlessPaymentHandler(mockedPaymentService, mockedGoCardlessEventService);
-        when(mockedPaymentService.findTransaction(goCardlessPaymentFixture.getTransactionId())).thenReturn(payment);
+        when(mockedPaymentService.findPayment(goCardlessPaymentFixture.getTransactionId())).thenReturn(payment);
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
This continue to rename `transaction` to `payment` focusing on the API layer in a coordinate effort with @alexbishop1 who is focusing on associated changes within consuming projects.

This does not rename occurrences within `GoCardlessPayment` and `DirectDebitEvent` since they will be removed shortly. 

This includes a commit to disable pact tests whilst we transition.
