### PR TITLE
PP-5298 Add ProviderID and MandateID to Create Payment response

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
@@ -1,6 +1,8 @@
 package uk.gov.pay.directdebit.payments.model;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
+
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 
@@ -12,6 +14,7 @@ public class Payment {
     private PaymentState state;
     private String description;
     private String reference;
+    private PaymentProviderPaymentId providerId;
     private ZonedDateTime createdDate;
     private Mandate mandate;
 
@@ -94,6 +97,10 @@ public class Payment {
         this.mandate = mandate;
     }
 
+    public PaymentProviderPaymentId getProviderId() {
+        return providerId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -105,7 +112,7 @@ public class Payment {
 
         Payment that = (Payment) o;
 
-        if (id != null ? !id.equals(that.id) : that.id != null) {
+        if (!Objects.equals(id, that.id)) {
             return false;
         }
         if (!externalId.equals(that.externalId)) {
@@ -117,11 +124,10 @@ public class Payment {
         if (state != that.state) {
             return false;
         }
-        if (description != null ? !description.equals(that.description)
-                : that.description != null) {
+        if (!Objects.equals(description, that.description)) {
             return false;
         }
-        if (reference != null ? !reference.equals(that.reference) : that.reference != null) {
+        if (!Objects.equals(reference, that.reference)) {
             return false;
         }
         if (!createdDate.equals(that.createdDate)) {

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -40,7 +40,9 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -63,6 +65,8 @@ public class PaymentResourceIT {
     private static final String JSON_RETURN_URL_KEY = "return_url";
     private static final String JSON_AGREEMENT_ID_KEY = "agreement_id";
     private static final String JSON_CHARGE_KEY = "charge_id";
+    private static final String JSON_PROVIDER_ID_KEY = "provider_id";
+    private static final String JSON_MANDATE_ID_KEY = "mandate_id";
     private static final String JSON_STATE_KEY = "state.status";
     private static final long AMOUNT = 6234L;
     private GatewayAccountFixture testGatewayAccount;
@@ -137,6 +141,8 @@ public class PaymentResourceIT {
                 .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
                 .body(JSON_REFERENCE_KEY, is(expectedReference))
                 .body(JSON_DESCRIPTION_KEY, is(expectedDescription))
+                .body(JSON_MANDATE_ID_KEY, is(mandateFixture.getExternalId().toString()))
+                .body("$", not(hasKey(JSON_PROVIDER_ID_KEY)))
                 .contentType(JSON);
 
         String externalTransactionId = response.extract().path(JSON_CHARGE_KEY).toString();
@@ -207,6 +213,7 @@ public class PaymentResourceIT {
                 .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
                 .body(JSON_REFERENCE_KEY, is(expectedReference))
                 .body(JSON_DESCRIPTION_KEY, is(expectedDescription))
+                .body(JSON_MANDATE_ID_KEY, is(mandate.getExternalId().toString()))
                 .contentType(JSON);
 
         String externalTransactionId = response.extract().path(JSON_CHARGE_KEY).toString();


### PR DESCRIPTION
-  Adds logic to return the provider ID and mandate ID in the
   response object upon the creation of a payment

-  Currently does not return provider ID but will do so when
   the provider ID logic is implemented

-  Tests have been updated to ensure that the mandate ID is
   correctly returned