### PR TITLE
PP-5248 Revert temporary transaction API readditions

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventExternalView.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/api/DirectDebitEventExternalView.java
@@ -18,9 +18,6 @@ public class DirectDebitEventExternalView {
     @JsonProperty("payment_external_id")
     private final String paymentExternalId;
 
-    @JsonProperty("transaction_external_id")
-    private final String transactionExternalId;
-
     @JsonProperty("event_type")
     private final DirectDebitEvent.Type eventType;
 
@@ -35,7 +32,6 @@ public class DirectDebitEventExternalView {
         this.externalId = directDebitEvent.getExternalId();
         this.mandateExternalId = directDebitEvent.getMandateExternalId();
         this.paymentExternalId = directDebitEvent.getPaymentExternalId();
-        this.transactionExternalId = directDebitEvent.getPaymentExternalId();
         this.event = directDebitEvent.getEvent();
         this.eventType = directDebitEvent.getEventType();
         this.eventDate = directDebitEvent.getEventDate();

--- a/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/resources/DirectDebitEventsResource.java
@@ -35,10 +35,7 @@ public class DirectDebitEventsResource {
                                @QueryParam("page") Integer page,
                                @QueryParam("mandate_external_id") String mandateId,
                                @QueryParam("payment_external_id") String paymentId,
-                               @QueryParam("transaction_external_id") String transactionId,
                                @Context UriInfo uriInfo) {
-
-        paymentId = paymentId == null ? transactionId : paymentId;
 
         DirectDebitEventSearchParams searchParams = new DirectDebitEventSearchParams.DirectDebitEventSearchParamsBuilder()
                 .toDate(toDate)

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateRequest.java
@@ -15,8 +15,7 @@ public class CreateMandateRequest {
     @JsonProperty("return_url")
     private String returnUrl;
 
-    //TODO disabling this temporarily to sort out failing pacts, re-enable later.
-    //@NotNull(message = "Field [service_reference] cannot be null")
+    @NotNull(message = "Field [service_reference] cannot be null")
     @Length(min = 1, max = 255, message = "Field [service_reference] must have a size between {min} and {max}")
     @JsonProperty("service_reference")
     private String reference;

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
@@ -21,9 +21,6 @@ public class PaymentViewResultResponse {
     @JsonProperty("payment_id")
     private String paymentId;
 
-    @JsonProperty("transaction_id")
-    private String transactionId; // TODO: temporary
-
     @JsonProperty
     private Long amount;
 
@@ -63,7 +60,6 @@ public class PaymentViewResultResponse {
                                      ExternalPaymentState state,
                                      String mandateExternalId) {
         this.paymentId = paymentId;
-        this.transactionId = paymentId;
         this.amount = amount;
         this.reference = reference;
         this.description = description;

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResource.java
@@ -57,37 +57,4 @@ public class PaymentViewResource {
                 .withUriInfo(uriInfo)
                 .getPaymentViewResponse(searchParams)).build();
     }
-
-    // TODO: temporary
-    @GET
-    @Path("/v1/api/accounts/{accountId}/transactions/view")
-    @Produces(APPLICATION_JSON)
-    @Timed
-    public Response getTransactionView(
-            @PathParam("accountId") String accountExternalId,
-            @QueryParam("page") Long pageNumber,
-            @QueryParam("display_size") Long displaySize,
-            @QueryParam("from_date") String fromDate,
-            @QueryParam("to_date") String toDate,
-            @QueryParam("email") String email,
-            @QueryParam("reference") String reference,
-            @QueryParam("amount") Long amount,
-            @QueryParam("agreement_id") String mandateId,
-            @QueryParam("state") String state,
-            @Context UriInfo uriInfo) {
-
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(accountExternalId)
-                .withPage(pageNumber)
-                .withDisplaySize(displaySize)
-                .withFromDateString(fromDate)
-                .withToDateString(toDate)
-                .withEmail(email)
-                .withReference(reference)
-                .withAmount(amount)
-                .withMandateId(mandateId)
-                .withState(state);
-        return Response.ok().entity(paymentViewService
-                .withUriInfo(uriInfo)
-                .getPaymentViewResponse(searchParams)).build();
-    }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -105,8 +105,7 @@ public class MandateResourceIT {
     @Parameters({
             "null, test-service-ref, Field [return_url] cannot be null",
             " , test-service-ref, Field [return_url] must have a size between 1 and 255",
-            //TODO Re-enable once pact tests are passing and validation is re-enabled.
-            //"http://example, null, Field [service_reference] cannot be null",
+            "http://example, null, Field [service_reference] cannot be null",
             "http://example, , Field [service_reference] must have a size between 1 and 255"
     })
     public void createMandateValidationFailures(@Nullable String returnUrl, 

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -70,22 +70,8 @@ public class PublicApiContractTest {
                 .insert(app.getTestContext().getJdbi());
     }
 
-    @State("three transaction records exist") // TODO: make go bye-bye
-    public void threeTransactionRecordsExist(Map<String, String> params) {
-        testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
-        MandateFixture testMandate = MandateFixture.aMandateFixture()
-                .withGatewayAccountFixture(testGatewayAccount)
-                .withExternalId(MandateExternalId.valueOf(params.get("agreement_id")));
-        testMandate.insert(app.getTestContext().getJdbi());
-        PayerFixture testPayer = PayerFixture.aPayerFixture().withMandateId(testMandate.getId());
-        testPayer.insert(app.getTestContext().getJdbi());
-        for (int x = 0; x < 3; x++) {
-            PaymentFixture.aPaymentFixture().withMandateFixture(testMandate).insert(app.getTestContext().getJdbi());
-        }
-    }
-
     @State("three payment records exist")
-    public void threePaymentRecordsExist(Map<String, String> params) {
+    public void threeTransactionRecordsExist(Map<String, String> params) {
         testGatewayAccount.withExternalId(params.get("gateway_account_id")).insert(app.getTestContext().getJdbi());
         MandateFixture testMandate = MandateFixture.aMandateFixture()
                 .withGatewayAccountFixture(testGatewayAccount)
@@ -100,10 +86,8 @@ public class PublicApiContractTest {
 
     @State("a direct debit event exists")
     public void aDirectDebitEventExists(Map<String, String> params) {
-        String paymentExternalId = params.get("payment_external_id") != null
-                ? params.get("payment_external_id")
-                : params.getOrDefault("transaction_external_id", RandomIdGenerator.newId());
 
+        String paymentExternalId = params.getOrDefault("payment_external_id", RandomIdGenerator.newId());
         MandateExternalId mandateExternalId = MandateExternalId.valueOf(params.getOrDefault("mandate_external_id", RandomIdGenerator.newId()));
 
         GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()


### PR DESCRIPTION
- This reverts commit f32f1db96f31fb14ae8d0ef76cb7892ba93135b7.
- This reverts commit da9fc1aaf449ae845e9a647a3628a7a62469fa48.
- This reverts commit 9447edd9e8738abf8d10579adabecdf2abee6844.
- This reverts commit abc577693f4acdfbbd48eddb6f93e57599c254db.

with @AlexBishop1

## WHAT YOU DID
In order to make pact tests work after being disabled we temporarily added some transaction API elements back. Now that Pacts are enabled and passing we are reverting those changes which should conclude the work to change `transaction` to `payment`.

with @alexbishop1 