### PR TITLE
PP-5298 Include details for payment state in responses

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/DirectDebitInfoFrontendResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/DirectDebitInfoFrontendResponse.java
@@ -10,7 +10,7 @@ import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.model.Payer;
-import uk.gov.pay.directdebit.payments.api.ExternalPaymentState;
+import uk.gov.pay.directdebit.payments.api.ExternalPaymentStateWithDetails;
 import uk.gov.pay.directdebit.payments.model.Payment;
 
 import java.time.ZonedDateTime;
@@ -79,7 +79,8 @@ public class DirectDebitInfoFrontendResponse {
             return new PaymentDetails(
                     payment.getExternalId(),
                     payment.getAmount(),
-                    payment.getState().toExternal(),
+                    // TODO: should extract state details (go cardless cause details) from events table somehow
+                    new ExternalPaymentStateWithDetails(payment.getState().toExternal(), "example_details"),
                     payment.getDescription(),
                     payment.getReference()
             );
@@ -249,12 +250,12 @@ public class DirectDebitInfoFrontendResponse {
         @JsonProperty("external_id")
         private String externalId;
         private Long amount;
-        private ExternalPaymentState state;
+        private ExternalPaymentStateWithDetails state;
         private String description;
         private String reference;
 
         public PaymentDetails(String externalId, Long amount,
-                              ExternalPaymentState state, String description, String reference) {
+                              ExternalPaymentStateWithDetails state, String description, String reference) {
             this.externalId = externalId;
             this.amount = amount;
             this.state = state;
@@ -270,7 +271,7 @@ public class DirectDebitInfoFrontendResponse {
             return amount;
         }
 
-        public ExternalPaymentState getState() {
+        public ExternalPaymentStateWithDetails getState() {
             return state;
         }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
@@ -53,7 +53,7 @@ public class CollectPaymentResponse {
     private ZonedDateTime createdDate;
 
     @JsonProperty
-    private ExternalPaymentState state;
+    private ExternalPaymentStateWithDetails state;
 
     public CollectPaymentResponse(CollectPaymentResponseBuilder builder) {
         this.paymentExternalId = builder.paymentExternalId;
@@ -103,7 +103,8 @@ public class CollectPaymentResponse {
     public static CollectPaymentResponse from(Payment payment, List<Map<String, Object>> dataLinks) {
         return aCollectPaymentResponse()
                 .withPaymentExternalId(payment.getExternalId())
-                .withState(payment.getState().toExternal())
+                // TODO: should extract state details (go cardless cause details) from events table somehow
+                .withState(new ExternalPaymentStateWithDetails(payment.getState().toExternal(), "example_details"))
                 .withAmount(payment.getAmount())
                 .withMandateId(payment.getMandate().getExternalId())
                 .withDescription(payment.getDescription())
@@ -163,7 +164,7 @@ public class CollectPaymentResponse {
         private String reference;
         private PaymentProviderPaymentId providerId;
         private ZonedDateTime createdDate;
-        private ExternalPaymentState state;
+        private ExternalPaymentStateWithDetails state;
 
         private CollectPaymentResponseBuilder() {
         }
@@ -212,7 +213,7 @@ public class CollectPaymentResponse {
             return this;
         }
 
-        public CollectPaymentResponseBuilder withState(ExternalPaymentState state) {
+        public CollectPaymentResponseBuilder withState(ExternalPaymentStateWithDetails state) {
             this.state = state;
             return this;
         }

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentState.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentState.java
@@ -15,7 +15,9 @@ public enum ExternalPaymentState {
     EXTERNAL_EXPIRED("expired", true),
     EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE("cancelled", true, "P0060", "User not eligible for Direct Debit");
 
+    @JsonProperty("status")
     private final String value;
+    
     private final boolean finished;
     private final String code;
     private final String message;
@@ -33,22 +35,31 @@ public enum ExternalPaymentState {
         this.code = code;
         this.message = message;
     }
-
-    @JsonProperty("status")
+    
     public String getState() {
         return value;
     }
-
     public boolean isFinished() {
         return finished;
     }
 
+    
     public String getCode() {
         return code;
     }
 
     public String getMessage() {
         return message;
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalPaymentState{" +
+                "value='" + value + '\'' +
+                ", finished=" + finished +
+                ", code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                '}';
     }
 }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentStateWithDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentStateWithDetails.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.directdebit.payments.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ExternalPaymentStateWithDetails {
+    @JsonUnwrapped
+    private final ExternalPaymentState paymentState;
+
+    private final String details;
+
+    public ExternalPaymentStateWithDetails(ExternalPaymentState paymentState, String details) {
+        this.paymentState = paymentState;
+        this.details = details;
+    }
+
+    public ExternalPaymentState getPaymentState() {
+        return paymentState;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalPaymentStateWithDetails{" +
+                "paymentState=" + paymentState +
+                ", details='" + details + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExternalPaymentStateWithDetails that = (ExternalPaymentStateWithDetails) o;
+        return paymentState == that.paymentState &&
+                Objects.equals(details, that.details);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(paymentState, details);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
@@ -41,9 +41,9 @@ public class PaymentResponse {
     private ZonedDateTime createdDate;
 
     @JsonProperty
-    private ExternalPaymentState state;
+    private ExternalPaymentStateWithDetails state;
 
-    public PaymentResponse(String transactionExternalId, ExternalPaymentState state, Long amount, String returnUrl, String description, String reference, ZonedDateTime createdDate, List<Map<String, Object>> dataLinks) {
+    public PaymentResponse(String transactionExternalId, ExternalPaymentStateWithDetails state, Long amount, String returnUrl, String description, String reference, ZonedDateTime createdDate, List<Map<String, Object>> dataLinks) {
         this.transactionExternalId = transactionExternalId;
         this.state = state;
         this.dataLinks = dataLinks;
@@ -90,7 +90,8 @@ public class PaymentResponse {
     public static PaymentResponse from(Payment payment, List<Map<String, Object>> dataLinks) {
         return new PaymentResponse(
                 payment.getExternalId(),
-                payment.getState().toExternal(),
+                // TODO: should extract state details (go cardless cause details) from events table somehow
+                new ExternalPaymentStateWithDetails(payment.getState().toExternal(), "example_details"),
                 payment.getAmount(),
                 payment.getMandate().getReturnUrl(),
                 payment.getDescription(),
@@ -134,7 +135,7 @@ public class PaymentResponse {
         return "PaymentResponse{" +
                 "dataLinks=" + dataLinks +
                 ", paymentExternalId='" + transactionExternalId + '\'' +
-                ", state='" + state.getState() + '\'' +
+                ", state='" + state + '\'' +
                 ", amount=" + amount +
                 ", returnUrl='" + returnUrl + '\'' +
                 ", reference='" + reference + '\'' +

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
@@ -44,7 +44,7 @@ public class PaymentViewResultResponse {
     private String email;
 
     @JsonProperty
-    private ExternalPaymentState state;
+    private ExternalPaymentStateWithDetails state;
 
     @JsonProperty
     private List<Link> links = new ArrayList<>();
@@ -57,7 +57,7 @@ public class PaymentViewResultResponse {
                                      ZonedDateTime createdDate,
                                      String name,
                                      String email,
-                                     ExternalPaymentState state,
+                                     ExternalPaymentStateWithDetails state,
                                      String mandateExternalId) {
         this.paymentId = paymentId;
         this.amount = amount;
@@ -98,7 +98,7 @@ public class PaymentViewResultResponse {
         return email;
     }
 
-    public ExternalPaymentState getState() {
+    public ExternalPaymentStateWithDetails getState() {
         return state;
     }
 
@@ -137,6 +137,6 @@ public class PaymentViewResultResponse {
     @Override
     public String toString() {
         return format("PaymentResponse{paymentId='%s', amount='%s', reference='%s', createdDate='%s', name='%s', email='%s', state='%s'}",
-                paymentId, amount, reference, createdDate, name, email, state.getState());
+                paymentId, amount, reference, createdDate, name, email, state);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentViewService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentViewService.java
@@ -2,6 +2,7 @@ package uk.gov.pay.directdebit.payments.services;
 
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountNotFoundException;
+import uk.gov.pay.directdebit.payments.api.ExternalPaymentStateWithDetails;
 import uk.gov.pay.directdebit.payments.api.PaymentViewResponse;
 import uk.gov.pay.directdebit.payments.api.PaymentViewResultResponse;
 import uk.gov.pay.directdebit.payments.api.PaymentViewValidator;
@@ -80,7 +81,8 @@ public class PaymentViewService {
                 paymentView.getCreatedDate(),
                 paymentView.getName(),
                 paymentView.getEmail(),
-                paymentView.getState().toExternal(),
+                // TODO: should extract state details (go cardless cause details) from events table somehow
+                new ExternalPaymentStateWithDetails(paymentView.getState().toExternal(), "example_details"),
                 paymentView.getMandateExternalId());
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -30,6 +30,7 @@ import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
+import uk.gov.pay.directdebit.payments.api.ExternalPaymentStateWithDetails;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentFixture;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
@@ -167,7 +168,7 @@ public class MandateServiceTest {
         assertThat(mandateResponseForFrontend.getPayment().getAmount(), is(paymentFixture.getAmount()));
         assertThat(mandateResponseForFrontend.getPayment().getDescription(), is(paymentFixture.getDescription()));
         assertThat(mandateResponseForFrontend.getPayment().getExternalId(), is(paymentFixture.getExternalId()));
-        assertThat(mandateResponseForFrontend.getPayment().getState(), is(paymentFixture.getState().toExternal()));
+        assertThat(mandateResponseForFrontend.getPayment().getState(), is(new ExternalPaymentStateWithDetails(paymentFixture.getState().toExternal(), "example_details")));
         assertThat(mandateResponseForFrontend.getPayment().getReference(), is(paymentFixture.getReference()));
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentResponseTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentResponseTest.java
@@ -17,9 +17,10 @@ public class PaymentResponseTest {
         String returnUrl = "http://bla.bla";
         String description = "desc";
         String reference = "ref";
+        var state = new ExternalPaymentStateWithDetails(ExternalPaymentState.EXTERNAL_STARTED, "test_details");
         PaymentResponse paymentResponse = new PaymentResponse(
                 transactionId,
-                ExternalPaymentState.EXTERNAL_STARTED,
+                state,
                 amount,
                 returnUrl,
                 description,

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -67,7 +67,9 @@ public class PaymentResourceIT {
     private static final String JSON_CHARGE_KEY = "charge_id";
     private static final String JSON_PROVIDER_ID_KEY = "provider_id";
     private static final String JSON_MANDATE_ID_KEY = "mandate_id";
-    private static final String JSON_STATE_KEY = "state.status";
+    private static final String JSON_STATE_STATUS_KEY = "state.status";
+    private static final String JSON_STATE_FINISHED_KEY = "state.finished";
+    private static final String JSON_STATE_DETAILS_KEY = "state.details";
     private static final long AMOUNT = 6234L;
     private GatewayAccountFixture testGatewayAccount;
 
@@ -249,7 +251,9 @@ public class PaymentResourceIT {
                 .body(JSON_AMOUNT_KEY, isNumber(paymentFixture.getAmount()))
                 .body(JSON_REFERENCE_KEY, is(paymentFixture.getReference()))
                 .body(JSON_DESCRIPTION_KEY, is(paymentFixture.getDescription()))
-                .body(JSON_STATE_KEY, is(paymentFixture.getState().toExternal().getState()))
+                .body(JSON_STATE_STATUS_KEY, is(paymentFixture.getState().toExternal().getState()))
+                .body(JSON_STATE_FINISHED_KEY, is(false))
+                .body(JSON_STATE_DETAILS_KEY, is("example_details"))
                 .body(JSON_RETURN_URL_KEY, is(mandateFixture.getReturnUrl()));
 
 
@@ -281,7 +285,8 @@ public class PaymentResourceIT {
                 .body(JSON_AMOUNT_KEY, isNumber(paymentFixture.getAmount()))
                 .body(JSON_REFERENCE_KEY, is(paymentFixture.getReference()))
                 .body(JSON_DESCRIPTION_KEY, is(paymentFixture.getDescription()))
-                .body(JSON_STATE_KEY, is(paymentFixture.getState().toExternal().getState()))
+                .body(JSON_STATE_STATUS_KEY, is(paymentFixture.getState().toExternal().getState()))
+                .body(JSON_STATE_DETAILS_KEY, is("example_details"))
                 .body(JSON_RETURN_URL_KEY, is(mandateFixture.getReturnUrl()));
 
         String newChargeToken = testContext.getDatabaseTestHelper().getTokenByTransactionExternalId(paymentFixture.getExternalId());

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
@@ -420,7 +420,8 @@ public class PaymentViewResourceIT {
                 .body("count", is(6))
                 .body("results", hasSize(6))
                 .body("results[0].state.finished", is(true))
-                .body("results[0].state.status", is("failed"));
+                .body("results[0].state.status", is("failed"))
+                .body("results[0].state.details", is("example_details"));
     }
 
     private RequestSpecification givenSetup() {

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentViewServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentViewServiceTest.java
@@ -14,13 +14,13 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.payers.model.Payer;
+import uk.gov.pay.directdebit.payments.api.ExternalPaymentStateWithDetails;
 import uk.gov.pay.directdebit.payments.api.PaymentViewResponse;
-import uk.gov.pay.directdebit.payments.api.PaymentViewResultResponse;
 import uk.gov.pay.directdebit.payments.dao.PaymentViewDao;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
+import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.PaymentView;
-import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
 
 import javax.ws.rs.core.UriBuilder;
@@ -96,21 +96,15 @@ public class PaymentViewServiceTest {
                 .withDisplaySize(100L)
                 .withFromDateString(createdDate.toString())
                 .withToDateString(createdDate.toString());
-        List<PaymentViewResultResponse> listResponses = new ArrayList<>();
-        for (PaymentView paymentView : paymentViewList) {
-            listResponses.add(new PaymentViewResultResponse(paymentView.getPaymentExternalId(),
-                    paymentView.getAmount(), paymentView.getReference(), paymentView.getDescription(),
-                    paymentView.getCreatedDate(), paymentView.getName(),
-                    paymentView.getEmail(), paymentView.getState().toExternal(),
-                    paymentView.getMandateExternalId()));
-        }
+        
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(gatewayAccount));
         when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);
         when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(4L);
         PaymentViewResponse response = paymentViewService.getPaymentViewResponse(searchParams);
         assertThat(response.getPaymentViewResponses().get(3).getAmount(), is(1003L));
         assertThat(response.getPaymentViewResponses().get(1).getName(), is("John Doe1"));
-        assertThat(response.getPaymentViewResponses().get(0).getState(), is((PaymentState.NEW.toExternal())));
+        assertThat(response.getPaymentViewResponses().get(0).getState(),
+                is(new ExternalPaymentStateWithDetails(PaymentState.NEW.toExternal(), "example_details")));
         assertThat(response.getPaymentViewResponses().get(2).getCreatedDate(), is(createdDate));
     }
 


### PR DESCRIPTION
Include a "details" field in the state object for Payment responses.
This will contain the "details[cause]" obtained from a Go Cardless event.

Currently this is always set to a hardcoded value and needs to be wired
up to an actual value retrieved from the database when event processing
is implemented properly.

Co-authored-by: Rory Malcolm <rory.malcolm@digital.cabinet-office.gov.uk>
