### PR TITLE
PP-5428 Persist and retrieve PaymentProviderPaymentId  on Payment

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentDao.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.dao.mapper.PaymentMapper;
 import uk.gov.pay.directdebit.payments.model.Payment;
+import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 
 import java.time.ZonedDateTime;
@@ -22,6 +23,7 @@ import java.util.Set;
 
 @RegisterRowMapper(PaymentMapper.class)
 @RegisterArgumentFactory(MandateExternalIdArgumentFactory.class)
+@RegisterArgumentFactory(PaymentProviderPaymentIdArgumentFactory.class)
 public interface PaymentDao {
 
     String joinQuery = "SELECT" +
@@ -33,6 +35,7 @@ public interface PaymentDao {
             "  p.description AS transaction_description," +
             "  p.reference AS transaction_reference," +
             "  p.created_date AS transaction_created_date," +
+            "  p.payment_provider_id AS payment_provider_id," +
             "  m.id AS mandate_id," +
             "  m.external_id AS mandate_external_id," +
             "  m.mandate_reference AS mandate_mandate_reference," +
@@ -80,7 +83,8 @@ public interface PaymentDao {
     @SqlUpdate("UPDATE payments p SET state = :state WHERE p.id = :id")
     int updateState(@Bind("id") Long id, @Bind("state") PaymentState paymentState);
 
-    @SqlUpdate("INSERT INTO payments(mandate_id, external_id, amount, state, description, reference, created_date) VALUES (:mandate.id, :externalId, :amount, :state, :description, :reference, :createdDate)")
+    @SqlUpdate("INSERT INTO payments(mandate_id, external_id, amount, state, description, reference, created_date, payment_provider_id)" +
+            "VALUES (:mandate.id, :externalId, :amount, :state, :description, :reference, :createdDate, :providerId)")
     @GetGeneratedKeys
     Long insert(@BindBean Payment payment);
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
@@ -18,7 +18,8 @@ public class Payment {
     private ZonedDateTime createdDate;
     private Mandate mandate;
 
-    public Payment(Long id, String externalId, Long amount, PaymentState state, String description, String reference, Mandate mandate, ZonedDateTime createdDate) {
+    public Payment(Long id, String externalId, Long amount, PaymentState state, String description, String reference,
+                   Mandate mandate, ZonedDateTime createdDate, PaymentProviderPaymentId paymentProviderPaymentId) {
         this.id = id;
         this.externalId = externalId;
         this.amount = amount;
@@ -27,10 +28,11 @@ public class Payment {
         this.reference = reference;
         this.createdDate = createdDate;
         this.mandate = mandate;
+        this.providerId = paymentProviderPaymentId;
     }
 
     public Payment(Long amount, PaymentState state, String description, String reference, Mandate mandate, ZonedDateTime createdDate) {
-        this(null, RandomIdGenerator.newId(), amount, state, description, reference, mandate, createdDate);
+        this(null, RandomIdGenerator.newId(), amount, state, description, reference, mandate, createdDate, null);
     }
 
     public Long getId() {

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentProviderPaymentIdArgumentFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentProviderPaymentIdArgumentFactory.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.directdebit.payments.model;
+
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import java.sql.Types;
+
+public class PaymentProviderPaymentIdArgumentFactory extends AbstractArgumentFactory<PaymentProviderPaymentId> {
+
+    public PaymentProviderPaymentIdArgumentFactory() {
+        super(Types.VARCHAR);
+    }
+
+    @Override
+    protected Argument build(PaymentProviderPaymentId value, ConfigRegistry config) {
+        String paymentProviderPaymentId = value == null ? null : value.toString();
+        return (pos, stmt, context) -> stmt.setString(pos, paymentProviderPaymentId);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/junit/TestContext.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/TestContext.java
@@ -8,6 +8,7 @@ import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReferenceArgumen
 import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventIdArgumentFactory;
+import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentIdArgumentFactory;
 import uk.gov.pay.directdebit.util.DatabaseTestHelper;
 
 public class TestContext {
@@ -31,6 +32,7 @@ public class TestContext {
         jdbi.registerArgument(new GoCardlessMandateIdArgumentFactory());
         jdbi.registerArgument(new MandateBankStatementReferenceArgumentFactory());
         jdbi.registerArgument(new PaymentProviderMandateIdArgumentFactory());
+        jdbi.registerArgument(new PaymentProviderPaymentIdArgumentFactory());
         jdbi.registerArgument(new GoCardlessEventIdArgumentFactory());
         this.databaseTestHelper = new DatabaseTestHelper(jdbi);
         this.port = port;

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentFixture.java
@@ -9,7 +9,9 @@ import uk.gov.pay.directdebit.common.fixtures.DbFixture;
 import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.payments.model.Payment;
+import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentId;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
 
 public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
 
@@ -21,6 +23,7 @@ public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
     private String reference = RandomStringUtils.randomAlphanumeric(10);
     private String description = RandomStringUtils.randomAlphanumeric(20);
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
+    private PaymentProviderPaymentId paymentProviderId = SandboxPaymentId.valueOf(RandomStringUtils.randomAlphanumeric(20));
     private PaymentFixture() {
     }
 
@@ -101,6 +104,11 @@ public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
         return this;
     }
 
+    public PaymentFixture withPaymentProviderId(PaymentProviderPaymentId paymentProviderId) {
+        this.paymentProviderId = paymentProviderId;
+        return this;
+    }
+
     @Override
     public PaymentFixture insert(Jdbi jdbi) {
         jdbi.withHandle(h ->
@@ -114,9 +122,10 @@ public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
                                 "        state,\n" +
                                 "        reference,\n" +
                                 "        description,\n" +
-                                "        created_date\n" +
+                                "        created_date,\n" +
+                                "        payment_provider_id\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?)\n",
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
                         id,
                         mandateFixture.getId(),
                         externalId,
@@ -124,7 +133,8 @@ public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
                         state,
                         reference,
                         description,
-                        createdDate
+                        createdDate,
+                        paymentProviderId
                 )
         );
         return this;
@@ -132,7 +142,7 @@ public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
 
     @Override
     public Payment toEntity() {
-        return new Payment(id, externalId, amount, state, description, reference, mandateFixture.toEntity(), createdDate);
+        return new Payment(id, externalId, amount, state, description, reference, mandateFixture.toEntity(), createdDate, paymentProviderId);
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -58,7 +58,7 @@ public class DatabaseTestHelper {
         );
     }
 
-    public Map<String, Object> getTransactionById(Long id) {
+    public Map<String, Object> getPaymentById(Long id) {
         return jdbi.withHandle(handle ->
                 handle
                         .createQuery("SELECT * from payments p WHERE p.id = :id")

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
@@ -167,7 +167,7 @@ public class WebhookGoCardlessResourceIT {
         assertThat(secondEvent.get("resource_type"), is("PAYMENTS"));
         assertThat(secondEvent.get("action"), is("paid_out"));
 
-        Map<String, Object> transaction = testContext.getDatabaseTestHelper().getTransactionById(paymentFixture.getId());
+        Map<String, Object> transaction = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
         MatcherAssert.assertThat(transaction.get("state"), is("SUCCESS"));
     }
 
@@ -235,7 +235,7 @@ public class WebhookGoCardlessResourceIT {
         Map<String, Object> mandate = testContext.getDatabaseTestHelper().getMandateById(mandateFixture.getId());
         MatcherAssert.assertThat(mandate.get("state"), is("FAILED"));
 
-        Map<String, Object> transaction = testContext.getDatabaseTestHelper().getTransactionById(paymentFixture.getId());
+        Map<String, Object> transaction = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
         MatcherAssert.assertThat(transaction.get("state"), is("FAILED"));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResourceIT.java
@@ -44,7 +44,7 @@ public class WebhookSandboxResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode());
 
-        Map<String, Object> transaction = testContext.getDatabaseTestHelper().getTransactionById(transactionId);
+        Map<String, Object> transaction = testContext.getDatabaseTestHelper().getPaymentById(transactionId);
         assertThat(transaction.get("state"), is("SUCCESS"));
     }
 


### PR DESCRIPTION
- Add to PaymentDao, PaymentMapper and associated tests and fixtures.
- Includes some renaming of `transaction` to `payment` mostly for test variable names.
with @AlexBishop1