### PR TITLE
PP-5298 Rename fields for collect payment

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequest.java
@@ -6,9 +6,9 @@ import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import java.util.Map;
 
 public class CollectPaymentRequest implements CollectRequest {
-    @JsonProperty("agreement_id")
+    @JsonProperty("mandate_id")
     private MandateExternalId mandateExternalId;
-    
+
     @JsonProperty("amount")
     private Long amount;
 
@@ -19,7 +19,7 @@ public class CollectPaymentRequest implements CollectRequest {
     private String reference;
 
     public CollectPaymentRequest(MandateExternalId mandateExternalId, Long amount, String description,
-            String reference) {
+                                 String reference) {
         this.mandateExternalId = mandateExternalId;
         this.amount = amount;
         this.description = description;
@@ -27,8 +27,12 @@ public class CollectPaymentRequest implements CollectRequest {
     }
 
     public static CollectPaymentRequest of(Map<String, String> collectPaymentRequest) {
+        var mandateExternalId = collectPaymentRequest.containsKey("mandate_id") ?
+                MandateExternalId.valueOf(collectPaymentRequest.get("mandate_id")) :
+                MandateExternalId.valueOf(collectPaymentRequest.get("agreement_id"));
+        
         return new CollectPaymentRequest(
-                MandateExternalId.valueOf(collectPaymentRequest.get("agreement_id")),
+                mandateExternalId,
                 Long.valueOf(collectPaymentRequest.get("amount")),
                 collectPaymentRequest.get("description"),
                 collectPaymentRequest.get("reference")

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidator.java
@@ -28,7 +28,8 @@ public class CollectPaymentRequestValidator extends ApiValidation {
                     })
                     .put(DESCRIPTION_KEY, ApiValidation::isNotNullOrEmpty)
                     .put(REFERENCE_KEY, ApiValidation::isNotNullOrEmpty)
-                    .put(AGREEMENT_ID_KEY, ApiValidation::isNotNullOrEmpty)
+                    // TODO: re-add validation when field rename to mandate_id completed. Disabled for backwards compatibility in the meantime
+//                    .put(AGREEMENT_ID_KEY, ApiValidation::isNotNullOrEmpty)
                     .build();
 
     private final static String[] requiredFields = {AMOUNT_KEY, DESCRIPTION_KEY, REFERENCE_KEY, AGREEMENT_ID_KEY};

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
@@ -25,7 +25,11 @@ public class CollectPaymentResponse {
     @JsonProperty("links")
     private List<Map<String, Object>> dataLinks;
 
+    // TODO - added for backwards compatibility while field is renamed
     @JsonProperty("charge_id")
+    private String chargeId;
+    
+    @JsonProperty("payment_id")
     private String paymentExternalId;
 
     @JsonProperty
@@ -57,6 +61,8 @@ public class CollectPaymentResponse {
 
     public CollectPaymentResponse(CollectPaymentResponseBuilder builder) {
         this.paymentExternalId = builder.paymentExternalId;
+        // TODO - added for backwards compatibility while field is renamed
+        this.chargeId = builder.paymentExternalId;
         this.state = builder.state;
         this.dataLinks = builder.dataLinks;
         this.amount = builder.amount;


### PR DESCRIPTION
- Accept "mandate_id" as well as "agreement_id" for a collect payment
  request so that the field can be renamed.
- Return "payment_id" as well as "charge_id" for the response so that
  the field can be renamed.

