### PR TITLE
PP-5248 Payment.getPaymentProviderPaymentId(): return Optional

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
@@ -107,7 +107,7 @@ public class CollectPaymentResponse {
     }
 
     public static CollectPaymentResponse from(Payment payment, List<Map<String, Object>> dataLinks) {
-        return aCollectPaymentResponse()
+        CollectPaymentResponseBuilder collectPaymentResponseBuilder = aCollectPaymentResponse()
                 .withPaymentExternalId(payment.getExternalId())
                 // TODO: should extract state details (go cardless cause details) from events table somehow
                 .withState(new ExternalPaymentStateWithDetails(payment.getState().toExternal(), "example_details"))
@@ -115,11 +115,13 @@ public class CollectPaymentResponse {
                 .withMandateId(payment.getMandate().getExternalId())
                 .withDescription(payment.getDescription())
                 .withReference(payment.getReference())
-                .withProviderId(payment.getProviderId())
                 .withCreatedDate(payment.getCreatedDate())
                 .withPaymentProvider(payment.getMandate().getGatewayAccount().getPaymentProvider().toString())
-                .withDataLinks(dataLinks)
-                .build();
+                .withDataLinks(dataLinks);
+
+        payment.getProviderId().ifPresent(collectPaymentResponseBuilder::withProviderId);
+
+        return collectPaymentResponseBuilder.build();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.directdebit.payments.model;
 
+import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Optional;
-
-import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
-import uk.gov.pay.directdebit.mandate.model.Mandate;
 
 public class Payment {
 
@@ -104,8 +104,8 @@ public class Payment {
         this.mandate = mandate;
     }
 
-    public PaymentProviderPaymentId getProviderId() {
-        return providerId;
+    public Optional<PaymentProviderPaymentId> getProviderId() {
+        return Optional.ofNullable(providerId);
     }
 
     public Optional<LocalDate> getChargeDate() {

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentDaoIT.java
@@ -1,13 +1,5 @@
 package uk.gov.pay.directdebit.payments.dao;
 
-import java.sql.Date;
-import java.sql.Timestamp;
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +16,14 @@ import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.PaymentStatesGraph;
 import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -110,7 +110,7 @@ public class PaymentDaoIT {
         assertThat(payment.getAmount(), is(AMOUNT));
         assertThat(payment.getState(), is(STATE));
         assertThat(payment.getCreatedDate(), is(testPayment.getCreatedDate()));
-        assertThat(payment.getProviderId(), is(providerId));
+        assertThat(payment.getProviderId().get(), is(providerId));
         assertThat(payment.getChargeDate().get(), is(chargeDate));
     }
 


### PR DESCRIPTION
Make the `Payment.getPaymentProviderPaymentId()` method on `Payment` return an `Optional<PaymentProviderPaymentId>` because there may not always be one.