### PR TITLE
Revert "Bump pact-jvm-provider-junit_2.12 from 3.6.7 to 3.6.8"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>
-            <version>3.6.8</version>
+            <version>3.6.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Pact tests began failing on master after this upgrade was merged.

Reverts alphagov/pay-direct-debit-connector#509