### PR TITLE
PP-5298 Disable validation for agreement id

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidator.java
@@ -32,13 +32,18 @@ public class CollectPaymentRequestValidator extends ApiValidation {
 //                    .put(AGREEMENT_ID_KEY, ApiValidation::isNotNullOrEmpty)
                     .build();
 
-    private final static String[] requiredFields = {AMOUNT_KEY, DESCRIPTION_KEY, REFERENCE_KEY, AGREEMENT_ID_KEY};
+    private final static String[] requiredFields = {
+            AMOUNT_KEY,
+            DESCRIPTION_KEY,
+            REFERENCE_KEY
+//            AGREEMENT_ID_KEY
+    };
 
     private final static Map<String, FieldSize> fieldSizes =
             ImmutableMap.<String, FieldSize>builder()
                     .put(DESCRIPTION_KEY, new FieldSize(0, 255))
                     .put(REFERENCE_KEY, new FieldSize(0, 255))
-                    .put(AGREEMENT_ID_KEY, new FieldSize(0, 26))
+//                    .put(AGREEMENT_ID_KEY, new FieldSize(0, 26))
                     .build();
 
     public CollectPaymentRequestValidator() {

--- a/src/test/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidatorTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.payments.api;
 
 import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -25,6 +26,7 @@ public class CollectPaymentRequestValidatorTest {
     }
 
     @Test
+    @Ignore
     public void shouldThrowMissingMandatoryFieldsExceptionIfMissingRequiredFields() {
         Map<String, String> request = new HashMap<>();
         thrown.expect(MissingMandatoryFieldsException.class);
@@ -94,6 +96,7 @@ public class CollectPaymentRequestValidatorTest {
     }
 
     @Test
+    @Ignore
     public void shouldThrowInvalidSizeFieldsExceptionIfAgreementIdFieldHasInvalidSize() {
         Map<String, String> request = generateValidRequest();
         request.put("agreement_id", RandomStringUtils.randomAlphanumeric(27));


### PR DESCRIPTION
Disabled validation for the agreement_id field on a collect payment
request so that the renamed mandate_id field can be used