### PR TITLE
PP-5428 Add tests for state in PaymentResourceIT

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentState.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentState.java
@@ -16,28 +16,28 @@ public enum ExternalPaymentState {
     EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE("cancelled", true, "P0060", "User not eligible for Direct Debit");
 
     @JsonProperty("status")
-    private final String value;
+    private final String status;
     
     private final boolean finished;
     private final String code;
     private final String message;
 
-    ExternalPaymentState(String value, boolean finished) {
-        this.value = value;
+    ExternalPaymentState(String status, boolean finished) {
+        this.status = status;
         this.finished = finished;
         this.code = null;
         this.message = null;
     }
 
-    ExternalPaymentState(String value, boolean finished, String code, String message) {
-        this.value = value;
+    ExternalPaymentState(String status, boolean finished, String code, String message) {
+        this.status = status;
         this.finished = finished;
         this.code = code;
         this.message = message;
     }
     
-    public String getState() {
-        return value;
+    public String getStatus() {
+        return status;
     }
     public boolean isFinished() {
         return finished;
@@ -55,7 +55,7 @@ public enum ExternalPaymentState {
     @Override
     public String toString() {
         return "ExternalPaymentState{" +
-                "value='" + value + '\'' +
+                "status='" + status + '\'' +
                 ", finished=" + finished +
                 ", code='" + code + '\'' +
                 ", message='" + message + '\'' +

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
@@ -49,15 +49,15 @@ public class PaymentViewSearchParams {
     static {
         // see uk.gov.pay.directdebit.payments.model.PaymentState for mappings
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_STARTED.getState(), NEW.toSingleQuoteString());
+                .put(ExternalPaymentState.EXTERNAL_STARTED.getStatus(), NEW.toSingleQuoteString());
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_PENDING.getState(), PENDING.toSingleQuoteString());
+                .put(ExternalPaymentState.EXTERNAL_PENDING.getStatus(), PENDING.toSingleQuoteString());
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE.getState(), USER_CANCEL_NOT_ELIGIBLE.toSingleQuoteString());
+                .put(ExternalPaymentState.EXTERNAL_CANCELLED_USER_NOT_ELIGIBLE.getStatus(), USER_CANCEL_NOT_ELIGIBLE.toSingleQuoteString());
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_SUCCESS.getState(), SUCCESS.toSingleQuoteString());
+                .put(ExternalPaymentState.EXTERNAL_SUCCESS.getStatus(), SUCCESS.toSingleQuoteString());
         externalPaymentToInternalStateQueryMap
-                .put(ExternalPaymentState.EXTERNAL_FAILED.getState(), FAILED.toSingleQuoteString() + ", " + CANCELLED.toSingleQuoteString() + ", " + EXPIRED.toSingleQuoteString());
+                .put(ExternalPaymentState.EXTERNAL_FAILED.getStatus(), FAILED.toSingleQuoteString() + ", " + CANCELLED.toSingleQuoteString() + ", " + EXPIRED.toSingleQuoteString());
     }
 
     public PaymentViewSearchParams(String gatewayExternalId) {

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -205,7 +205,7 @@ public class MandateResourceIT {
                 .body("payment." + JSON_AMOUNT_KEY, isNumber(paymentFixture.getAmount()))
                 .body("payment." + JSON_REFERENCE_KEY, is(paymentFixture.getReference()))
                 .body("payment." + JSON_DESCRIPTION_KEY, is(paymentFixture.getDescription()))
-                .body("payment." + JSON_STATE_KEY, is(paymentFixture.getState().toExternal().getState()))
+                .body("payment." + JSON_STATE_KEY, is(paymentFixture.getState().toExternal().getStatus()))
                 .body("payer.payer_external_id", is(payerFixture.getExternalId()))
                 .body("payer.account_holder_name", is(payerFixture.getName()))
                 .body("payer.email", is(payerFixture.getEmail()))

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -144,7 +144,8 @@ public class PaymentResourceIT {
                 .body(JSON_REFERENCE_KEY, is(expectedReference))
                 .body(JSON_DESCRIPTION_KEY, is(expectedDescription))
                 .body(JSON_MANDATE_ID_KEY, is(mandateFixture.getExternalId().toString()))
-                .body("$", not(hasKey(JSON_PROVIDER_ID_KEY)))
+                .body(JSON_STATE_STATUS_KEY, is("pending"))
+                .body(JSON_STATE_FINISHED_KEY, is(false))
                 .contentType(JSON);
 
         String externalTransactionId = response.extract().path(JSON_CHARGE_KEY).toString();
@@ -216,6 +217,8 @@ public class PaymentResourceIT {
                 .body(JSON_REFERENCE_KEY, is(expectedReference))
                 .body(JSON_DESCRIPTION_KEY, is(expectedDescription))
                 .body(JSON_MANDATE_ID_KEY, is(mandate.getExternalId().toString()))
+                .body(JSON_STATE_STATUS_KEY, is("pending"))
+                .body(JSON_STATE_FINISHED_KEY, is(false))
                 .contentType(JSON);
 
         String externalTransactionId = response.extract().path(JSON_CHARGE_KEY).toString();
@@ -228,7 +231,7 @@ public class PaymentResourceIT {
     }
 
     @Test
-    public void shouldRetrieveATransaction_fromPublicApiEndpoint() {
+    public void shouldRetrieveAPayment_fromPublicApiEndpoint() {
 
         String accountExternalId = testGatewayAccount.getExternalId();
 
@@ -251,7 +254,7 @@ public class PaymentResourceIT {
                 .body(JSON_AMOUNT_KEY, isNumber(paymentFixture.getAmount()))
                 .body(JSON_REFERENCE_KEY, is(paymentFixture.getReference()))
                 .body(JSON_DESCRIPTION_KEY, is(paymentFixture.getDescription()))
-                .body(JSON_STATE_STATUS_KEY, is(paymentFixture.getState().toExternal().getState()))
+                .body(JSON_STATE_STATUS_KEY, is(paymentFixture.getState().toExternal().getStatus()))
                 .body(JSON_STATE_FINISHED_KEY, is(false))
                 .body(JSON_STATE_DETAILS_KEY, is("example_details"))
                 .body(JSON_RETURN_URL_KEY, is(mandateFixture.getReturnUrl()));
@@ -285,7 +288,7 @@ public class PaymentResourceIT {
                 .body(JSON_AMOUNT_KEY, isNumber(paymentFixture.getAmount()))
                 .body(JSON_REFERENCE_KEY, is(paymentFixture.getReference()))
                 .body(JSON_DESCRIPTION_KEY, is(paymentFixture.getDescription()))
-                .body(JSON_STATE_STATUS_KEY, is(paymentFixture.getState().toExternal().getState()))
+                .body(JSON_STATE_STATUS_KEY, is(paymentFixture.getState().toExternal().getStatus()))
                 .body(JSON_STATE_DETAILS_KEY, is("example_details"))
                 .body(JSON_RETURN_URL_KEY, is(mandateFixture.getReturnUrl()));
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentViewResourceIT.java
@@ -411,7 +411,7 @@ public class PaymentViewResourceIT {
         }
         String requestPath = "/v1/api/accounts/{accountId}/payments/view?state=:state"
                 .replace("{accountId}", gatewayAccountFixture.getExternalId())
-                .replace(":state", ExternalPaymentState.EXTERNAL_FAILED.getState());
+                .replace(":state", ExternalPaymentState.EXTERNAL_FAILED.getStatus());
         givenSetup()
                 .get(requestPath)
                 .then()


### PR DESCRIPTION
- Check returned state when collecting payments within PaymentResourceIT
- Fix ExternalPaymentState to avoid returning erroneous and superfluous 'state'
element.

with @AlexBishop1
