### PR TITLE
PP-5248 Make Payment immutable and use builder-based instantiation

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessService.java
@@ -71,9 +71,12 @@ public class GoCardlessService implements DirectDebitPaymentProviderCommandServi
                 .orElseThrow( () -> new GoCardlessMandateNotConfirmed("mandate id", mandate.getExternalId().toString()));
 
         PaymentProviderPaymentIdAndChargeDate providerIdAndChargeDate = createPayment(payment, goCardlessMandateId);
-        payment.setProviderId(providerIdAndChargeDate.getPaymentProviderPaymentId());
-        payment.setChargeDate(providerIdAndChargeDate.getChargeDate());
-        paymentDao.updateProviderIdAndChargeDate(payment);
+        Payment updatePayment = Payment.PaymentBuilder.fromPayment(payment)
+                .withProviderId(providerIdAndChargeDate.getPaymentProviderPaymentId())
+                .withChargeDate(providerIdAndChargeDate.getChargeDate())
+                .build();
+
+        paymentDao.updateProviderIdAndChargeDate(updatePayment);
         return providerIdAndChargeDate.getChargeDate();
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.payments.model;
 
-import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 
 import java.time.LocalDate;
@@ -10,98 +9,60 @@ import java.util.Optional;
 
 public class Payment {
 
-    private Long id;
-    private String externalId;
-    private Long amount;
-    private PaymentState state;
-    private String description;
-    private String reference;
-    private PaymentProviderPaymentId providerId;
-    private ZonedDateTime createdDate;
-    private Mandate mandate;
-    private LocalDate chargeDate;
+    private final Long id;
+    private final String externalId;
+    private final Long amount;
+    private final PaymentState state;
+    private final String description;
+    private final String reference;
+    private final PaymentProviderPaymentId providerId;
+    private final ZonedDateTime createdDate;
+    private final Mandate mandate;
+    private final LocalDate chargeDate;
 
-    public Payment(Long id, String externalId, Long amount, PaymentState state, String description, String reference,
-                   Mandate mandate, ZonedDateTime createdDate, PaymentProviderPaymentId paymentProviderPaymentId,
-                   LocalDate chargeDate) {
-        this.id = id;
-        this.externalId = externalId;
-        this.amount = amount;
-        this.state = state;
-        this.description = description;
-        this.reference = reference;
-        this.createdDate = createdDate;
-        this.mandate = mandate;
-        this.providerId = paymentProviderPaymentId;
-        this.chargeDate = chargeDate;
-    }
-
-    public Payment(Long amount, PaymentState state, String description, String reference, Mandate mandate, ZonedDateTime createdDate) {
-        this(null, RandomIdGenerator.newId(), amount, state, description, reference, mandate, createdDate, null, null);
+    private Payment(PaymentBuilder builder) {
+        this.id = builder.id;
+        this.externalId = Objects.requireNonNull(builder.externalId);
+        this.amount = Objects.requireNonNull(builder.amount);
+        this.state = Objects.requireNonNull(builder.state);
+        this.description = builder.description;
+        this.reference = Objects.requireNonNull(builder.reference);
+        this.createdDate = Objects.requireNonNull(builder.createdDate);
+        this.mandate = Objects.requireNonNull(builder.mandate);
+        this.providerId = builder.providerId;
+        this.chargeDate = builder.chargeDate;
     }
 
     public Long getId() {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getExternalId() {
         return externalId;
-    }
-
-    public void setExternalId(String externalId) {
-        this.externalId = externalId;
     }
 
     public Long getAmount() {
         return amount;
     }
 
-    public void setAmount(Long amount) {
-        this.amount = amount;
-    }
-
     public PaymentState getState() {
         return state;
-    }
-
-    public void setState(PaymentState state) {
-        this.state = state;
     }
 
     public String getDescription() {
         return description;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
     public String getReference() {
         return reference;
-    }
-
-    public void setReference(String reference) {
-        this.reference = reference;
     }
 
     public ZonedDateTime getCreatedDate() {
         return createdDate;
     }
 
-    public void setCreatedDate(ZonedDateTime createdDate) {
-        this.createdDate = createdDate;
-    }
-
     public Mandate getMandate() {
         return mandate;
-    }
-
-    public void setMandate(Mandate mandate) {
-        this.mandate = mandate;
     }
 
     public Optional<PaymentProviderPaymentId> getProviderId() {
@@ -111,15 +72,6 @@ public class Payment {
     public Optional<LocalDate> getChargeDate() {
         return Optional.ofNullable(chargeDate);
     }
-
-    public void setChargeDate(LocalDate chargeDate) {
-        this.chargeDate = chargeDate;
-    }
-
-    public void setProviderId(PaymentProviderPaymentId providerId) {
-        this.providerId = providerId;
-    }
-
 
     @Override
     public boolean equals(Object o) {
@@ -141,5 +93,97 @@ public class Payment {
     @Override
     public int hashCode() {
         return Objects.hash(id, externalId, amount, state, description, reference, providerId, createdDate, mandate, chargeDate);
+    }
+
+
+    public static final class PaymentBuilder {
+        private Long id;
+        private String externalId;
+        private Long amount;
+        private PaymentState state;
+        private String description;
+        private String reference;
+        private PaymentProviderPaymentId providerId;
+        private ZonedDateTime createdDate;
+        private Mandate mandate;
+        private LocalDate chargeDate;
+
+        private PaymentBuilder() {
+        }
+
+        public static PaymentBuilder aPayment() {
+            return new PaymentBuilder();
+        }
+
+        public static PaymentBuilder fromPayment(Payment payment) {
+            var builder = aPayment()
+                    .withAmount(payment.getAmount())
+                    .withCreatedDate(payment.getCreatedDate())
+                    .withDescription(payment.getDescription())
+                    .withExternalId(payment.getExternalId())
+                    .withId(payment.getId())
+                    .withMandate(payment.getMandate())
+                    .withReference(payment.getReference())
+                    .withState(payment.getState());
+
+            payment.getChargeDate().ifPresent(builder::withChargeDate);
+            payment.getProviderId().ifPresent(builder::withProviderId);
+
+            return builder;
+        }
+
+        public PaymentBuilder withId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public PaymentBuilder withExternalId(String externalId) {
+            this.externalId = externalId;
+            return this;
+        }
+
+        public PaymentBuilder withAmount(Long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public PaymentBuilder withState(PaymentState state) {
+            this.state = state;
+            return this;
+        }
+
+        public PaymentBuilder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public PaymentBuilder withReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public PaymentBuilder withProviderId(PaymentProviderPaymentId providerId) {
+            this.providerId = providerId;
+            return this;
+        }
+
+        public PaymentBuilder withCreatedDate(ZonedDateTime createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public PaymentBuilder withMandate(Mandate mandate) {
+            this.mandate = mandate;
+            return this;
+        }
+
+        public PaymentBuilder withChargeDate(LocalDate chargeDate) {
+            this.chargeDate = chargeDate;
+            return this;
+        }
+
+        public Payment build() {
+            return new Payment(this);
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
@@ -62,7 +62,7 @@ public class PaymentResource {
         collectPaymentRequestValidator.validate(collectPaymentRequestMap);
         CollectPaymentRequest collectPaymentRequest = CollectPaymentRequest.of(collectPaymentRequestMap);
         Mandate mandate = mandateQueryService.findByExternalId(collectPaymentRequest.getMandateExternalId());
-        Payment paymentToCollect = paymentService.createPayment(gatewayAccount, mandate, collectPaymentRequest);
+        Payment paymentToCollect = paymentService.createAndCollectPayment(gatewayAccount, mandate, collectPaymentRequest);
         CollectPaymentResponse response = paymentService.collectPaymentResponseWithSelfLink(paymentToCollect, gatewayAccount.getExternalId(), uriInfo);
         return created(response.getLink("self")).entity(response).build();
     }

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
+import static uk.gov.pay.directdebit.payments.model.Payment.PaymentBuilder.fromPayment;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserNotificationServiceTest {
@@ -103,10 +104,10 @@ public class UserNotificationServiceTest {
     }
 
     @Test
-    public void shouldSendOneOffPaymentConfirmedEmail() {
+    public void shouldSendPaymentConfirmedEmail() {
         Mandate mandate = mandateFixture.withPayerFixture(payerFixture).toEntity();
 
-        payment.setMandate(mandate);
+        Payment paymentWithMandate = fromPayment(payment).withMandate(mandate).build();
 
         SunName sunName = SunName.of("test sun Name");
         when(mockSunService.getSunNameFor(mandate)).thenReturn(Optional.of(sunName));
@@ -120,7 +121,7 @@ public class UserNotificationServiceTest {
         emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
 
 
-        userNotificationService.sendOneOffPaymentConfirmedEmailFor(payment, LocalDate.parse("2018-05-21"));
+        userNotificationService.sendOneOffPaymentConfirmedEmailFor(paymentWithMandate, LocalDate.parse("2018-05-21"));
 
         verify(mockAdminUsersClient).sendEmail(EmailTemplate.ONE_OFF_PAYMENT_CONFIRMED, mandate, emailPersonalisation);
     }
@@ -129,10 +130,10 @@ public class UserNotificationServiceTest {
     public void shouldNotSendOneOffPaymentConfirmedEmail_whenSunNameUnavailable() {
         Mandate mandate = mandateFixture.withPayerFixture(payerFixture).toEntity();
 
-        payment.setMandate(mandate);
+        Payment paymentWithMandate = fromPayment(payment).withMandate(mandate).build();
 
         when(mockSunService.getSunNameFor(mandate)).thenReturn(Optional.empty());
-        userNotificationService.sendOneOffPaymentConfirmedEmailFor(payment, LocalDate.parse("2018-05-21"));
+        userNotificationService.sendOneOffPaymentConfirmedEmailFor(paymentWithMandate, LocalDate.parse("2018-05-21"));
         verifyZeroInteractions(mockAdminUsersClient);
     }
 
@@ -140,7 +141,7 @@ public class UserNotificationServiceTest {
     public void shouldSendOnDemandPaymentConfirmedEmail() {
         Mandate mandate = mandateFixture.withPayerFixture(payerFixture).toEntity();
 
-        payment.setMandate(mandate);
+        Payment paymentWithMandate = fromPayment(payment).withMandate(mandate).build();
 
         SunName sunName = SunName.of("test sun Name");
         when(mockSunService.getSunNameFor(mandate)).thenReturn(Optional.of(sunName));
@@ -151,7 +152,7 @@ public class UserNotificationServiceTest {
         emailPersonalisation.put("bank account last 2 digits", payerFixture.getAccountNumberLastTwoDigits());
         emailPersonalisation.put("statement name", sunName.toString());
         emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
-        userNotificationService.sendOnDemandPaymentConfirmedEmailFor(payment, LocalDate.parse("2018-05-21"));
+        userNotificationService.sendOnDemandPaymentConfirmedEmailFor(paymentWithMandate, LocalDate.parse("2018-05-21"));
 
         verify(mockAdminUsersClient).sendEmail(EmailTemplate.ON_DEMAND_PAYMENT_CONFIRMED, mandate, emailPersonalisation);
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentFixture.java
@@ -1,8 +1,5 @@
 package uk.gov.pay.directdebit.payments.fixtures;
 
-import java.time.LocalDate;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.jdbi.v3.core.Jdbi;
@@ -13,6 +10,12 @@ import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentId;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.directdebit.payments.model.Payment.PaymentBuilder.aPayment;
 
 public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
 
@@ -152,8 +155,18 @@ public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
 
     @Override
     public Payment toEntity() {
-        return new Payment(id, externalId, amount, state, description, reference, mandateFixture.toEntity(),
-                createdDate, paymentProviderId, chargeDate);
+        return aPayment()
+                .withId(id)
+                .withExternalId(externalId)
+                .withAmount(amount)
+                .withState(state)
+                .withDescription(description)
+                .withReference(reference)
+                .withMandate(mandateFixture.toEntity())
+                .withCreatedDate(createdDate)
+                .withProviderId(paymentProviderId)
+                .withChargeDate(chargeDate)
+                .build();
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -44,6 +44,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
+import static uk.gov.pay.directdebit.payments.model.Payment.PaymentBuilder.fromPayment;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GoCardlessServiceTest {
@@ -247,7 +248,7 @@ public class GoCardlessServiceTest {
         GoCardlessPaymentId goCardlessPaymentId = GoCardlessPaymentId.valueOf("expectedGoCardlessPaymentId");
         GoCardlessMandateId goCardlessMandateId = GoCardlessMandateId.valueOf("aGoCardlessMandateId");
         LocalDate chargeDateFromGoCardless = LocalDate.of(1969, JULY, 16);
-        
+
         Mandate mandate = mandateFixture
                 .withPaymentProviderId(goCardlessMandateId)
                 .toEntity();
@@ -256,9 +257,11 @@ public class GoCardlessServiceTest {
                 .thenReturn(new PaymentProviderPaymentIdAndChargeDate(goCardlessPaymentId, chargeDateFromGoCardless));
 
         LocalDate actualChargeDate = service.collect(mandate, payment);
-        verify(mockedPaymentDao).updateProviderIdAndChargeDate(payment);
 
-        assertThat(actualChargeDate, Is.is(chargeDateFromGoCardless));
+        Payment paymentWithProviderIdAndChargeDate = fromPayment(payment).withProviderId(goCardlessPaymentId).withChargeDate(chargeDateFromGoCardless).build();
+        verify(mockedPaymentDao).updateProviderIdAndChargeDate(paymentWithProviderIdAndChargeDate);
+
+        assertThat(actualChargeDate, is(chargeDateFromGoCardless));
     }
 
     @Test


### PR DESCRIPTION
Make Payment immutable — modifications are now performed by taking
a copy and using a builder.

Some unused and forgotten one-off payment functionality removed.

with @alexbishop1