### PR TITLE
PP-5298 Remove old fields for collect payment request

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequest.java
@@ -27,12 +27,8 @@ public class CollectPaymentRequest implements CollectRequest {
     }
 
     public static CollectPaymentRequest of(Map<String, String> collectPaymentRequest) {
-        var mandateExternalId = collectPaymentRequest.containsKey("mandate_id") ?
-                MandateExternalId.valueOf(collectPaymentRequest.get("mandate_id")) :
-                MandateExternalId.valueOf(collectPaymentRequest.get("agreement_id"));
-        
         return new CollectPaymentRequest(
-                mandateExternalId,
+                MandateExternalId.valueOf(collectPaymentRequest.get("mandate_id")),
                 Long.valueOf(collectPaymentRequest.get("amount")),
                 collectPaymentRequest.get("description"),
                 collectPaymentRequest.get("reference")

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidator.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.directdebit.payments.api;
 
-import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.directdebit.common.validation.ApiValidation;
 import uk.gov.pay.directdebit.common.validation.FieldSize;
 
@@ -12,39 +11,36 @@ public class CollectPaymentRequestValidator extends ApiValidation {
     private final static String AMOUNT_KEY = "amount";
     private final static String DESCRIPTION_KEY = "description";
     private final static String REFERENCE_KEY = "reference";
-    private final static String AGREEMENT_ID_KEY = "agreement_id";
+    private final static String MANDATE_ID_KEY = "mandate_id";
 
     private final static int MIN_AMOUNT_IN_PENCE = 1;
     private final static int MAX_AMOUNT_IN_PENCE = 5000_00;
 
     private final static Map<String, Function<String, Boolean>> validators =
-            ImmutableMap.<String, Function<String, Boolean>>builder()
-                    .put(AMOUNT_KEY, (amount) -> {
+            Map.of(
+                    AMOUNT_KEY, (amount) -> {
                         if (!isNumeric(amount)) {
                             return false;
                         }
                         Integer amountValue = Integer.valueOf(amount);
                         return MIN_AMOUNT_IN_PENCE <= amountValue && MAX_AMOUNT_IN_PENCE >= amountValue;
-                    })
-                    .put(DESCRIPTION_KEY, ApiValidation::isNotNullOrEmpty)
-                    .put(REFERENCE_KEY, ApiValidation::isNotNullOrEmpty)
-                    // TODO: re-add validation when field rename to mandate_id completed. Disabled for backwards compatibility in the meantime
-//                    .put(AGREEMENT_ID_KEY, ApiValidation::isNotNullOrEmpty)
-                    .build();
+                    },
+                    DESCRIPTION_KEY, ApiValidation::isNotNullOrEmpty,
+                    REFERENCE_KEY, ApiValidation::isNotNullOrEmpty,
+                    MANDATE_ID_KEY, ApiValidation::isNotNullOrEmpty);
 
     private final static String[] requiredFields = {
             AMOUNT_KEY,
             DESCRIPTION_KEY,
-            REFERENCE_KEY
-//            AGREEMENT_ID_KEY
+            REFERENCE_KEY,
+            MANDATE_ID_KEY
     };
 
     private final static Map<String, FieldSize> fieldSizes =
-            ImmutableMap.<String, FieldSize>builder()
-                    .put(DESCRIPTION_KEY, new FieldSize(0, 255))
-                    .put(REFERENCE_KEY, new FieldSize(0, 255))
-//                    .put(AGREEMENT_ID_KEY, new FieldSize(0, 26))
-                    .build();
+            Map.of(
+                    DESCRIPTION_KEY, new FieldSize(0, 255),
+                    REFERENCE_KEY, new FieldSize(0, 255),
+                    MANDATE_ID_KEY, new FieldSize(0, 26));
 
     public CollectPaymentRequestValidator() {
         super(requiredFields, fieldSizes, validators);

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
@@ -24,10 +24,6 @@ import static uk.gov.pay.directdebit.payments.api.CollectPaymentResponse.Collect
 public class CollectPaymentResponse {
     @JsonProperty("links")
     private List<Map<String, Object>> dataLinks;
-
-    // TODO - added for backwards compatibility while field is renamed
-    @JsonProperty("charge_id")
-    private String chargeId;
     
     @JsonProperty("payment_id")
     private String paymentExternalId;
@@ -61,8 +57,6 @@ public class CollectPaymentResponse {
 
     public CollectPaymentResponse(CollectPaymentResponseBuilder builder) {
         this.paymentExternalId = builder.paymentExternalId;
-        // TODO - added for backwards compatibility while field is renamed
-        this.chargeId = builder.paymentExternalId;
         this.state = builder.state;
         this.dataLinks = builder.dataLinks;
         this.amount = builder.amount;

--- a/src/test/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidatorTest.java
@@ -26,11 +26,10 @@ public class CollectPaymentRequestValidatorTest {
     }
 
     @Test
-    @Ignore
     public void shouldThrowMissingMandatoryFieldsExceptionIfMissingRequiredFields() {
         Map<String, String> request = new HashMap<>();
         thrown.expect(MissingMandatoryFieldsException.class);
-        thrown.expectMessage("Field(s) missing: [amount, description, reference, agreement_id]");
+        thrown.expectMessage("Field(s) missing: [amount, description, reference, mandate_id]");
         thrown.reportMissingExceptionWithMessage("MissingMandatoryFieldsException expected");
         collectPaymentRequestValidator.validate(request);
     }
@@ -96,12 +95,11 @@ public class CollectPaymentRequestValidatorTest {
     }
 
     @Test
-    @Ignore
     public void shouldThrowInvalidSizeFieldsExceptionIfAgreementIdFieldHasInvalidSize() {
         Map<String, String> request = generateValidRequest();
-        request.put("agreement_id", RandomStringUtils.randomAlphanumeric(27));
+        request.put("mandate_id", RandomStringUtils.randomAlphanumeric(27));
         thrown.expect(InvalidSizeFieldsException.class);
-        thrown.expectMessage("The size of a field(s) is invalid: [agreement_id]");
+        thrown.expectMessage("The size of a field(s) is invalid: [mandate_id]");
         thrown.reportMissingExceptionWithMessage("InvalidSizeFieldsException expected");
         collectPaymentRequestValidator.validate(request);
     }
@@ -111,7 +109,7 @@ public class CollectPaymentRequestValidatorTest {
         request.put("amount", "10000");
         request.put("description", "A description");
         request.put("reference", "ref123");
-        request.put("agreement_id", "d’accordo");
+        request.put("mandate_id", "d’accordo");
         return request;
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -64,8 +64,8 @@ public class PaymentResourceIT {
     private static final String JSON_DESCRIPTION_KEY = "description";
     private static final String JSON_GATEWAY_ACC_KEY = "gateway_account_id";
     private static final String JSON_RETURN_URL_KEY = "return_url";
-    private static final String JSON_AGREEMENT_ID_KEY = "agreement_id";
     private static final String JSON_CHARGE_KEY = "charge_id";
+    private static final String JSON_PAYMENT_ID_KEY = "payment_id";
     private static final String JSON_PROVIDER_ID_KEY = "provider_id";
     private static final String JSON_MANDATE_ID_KEY = "mandate_id";
     private static final String JSON_STATE_STATUS_KEY = "state.status";
@@ -108,7 +108,7 @@ public class PaymentResourceIT {
                 .put(JSON_REFERENCE_KEY, expectedReference)
                 .put(JSON_DESCRIPTION_KEY, expectedDescription)
                 .put(JSON_GATEWAY_ACC_KEY, accountExternalId)
-                .put(JSON_AGREEMENT_ID_KEY, mandateFixture.getExternalId().toString())
+                .put(JSON_MANDATE_ID_KEY, mandateFixture.getExternalId().toString())
                 .build());
 
         String requestPath = "/v1/api/accounts/{accountId}/charges/collect"
@@ -140,7 +140,7 @@ public class PaymentResourceIT {
                 .post(requestPath)
                 .then()
                 .statusCode(Response.Status.CREATED.getStatusCode())
-                .body(JSON_CHARGE_KEY, is(notNullValue()))
+                .body(JSON_PAYMENT_ID_KEY, is(notNullValue()))
                 .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
                 .body(JSON_REFERENCE_KEY, is(expectedReference))
                 .body(JSON_DESCRIPTION_KEY, is(expectedDescription))
@@ -149,7 +149,7 @@ public class PaymentResourceIT {
                 .body(JSON_STATE_FINISHED_KEY, is(false))
                 .contentType(JSON);
 
-        String externalTransactionId = response.extract().path(JSON_CHARGE_KEY).toString();
+        String externalTransactionId = response.extract().path(JSON_PAYMENT_ID_KEY).toString();
 
         Map<String, Object> createdTransaction = testContext.getDatabaseTestHelper().getTransactionByExternalId(externalTransactionId);
         assertThat(createdTransaction.get("external_id"), is(notNullValue()));
@@ -179,7 +179,7 @@ public class PaymentResourceIT {
                 .put(JSON_REFERENCE_KEY, expectedReference)
                 .put(JSON_DESCRIPTION_KEY, expectedDescription)
                 .put(JSON_GATEWAY_ACC_KEY, accountExternalId)
-                .put(JSON_AGREEMENT_ID_KEY, mandate.getExternalId().toString())
+                .put(JSON_MANDATE_ID_KEY, mandate.getExternalId().toString())
                 .build());
 
         String sunName = "Test SUN Name";
@@ -213,7 +213,7 @@ public class PaymentResourceIT {
                 .post(requestPath)
                 .then()
                 .statusCode(Response.Status.CREATED.getStatusCode())
-                .body(JSON_CHARGE_KEY, is(notNullValue()))
+                .body(JSON_PAYMENT_ID_KEY, is(notNullValue()))
                 .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
                 .body(JSON_REFERENCE_KEY, is(expectedReference))
                 .body(JSON_DESCRIPTION_KEY, is(expectedDescription))
@@ -222,7 +222,7 @@ public class PaymentResourceIT {
                 .body(JSON_STATE_FINISHED_KEY, is(false))
                 .contentType(JSON);
 
-        String externalTransactionId = response.extract().path(JSON_CHARGE_KEY).toString();
+        String externalTransactionId = response.extract().path(JSON_PAYMENT_ID_KEY).toString();
 
         Map<String, Object> createdTransaction = testContext.getDatabaseTestHelper().getTransactionByExternalId(externalTransactionId);
         assertThat(createdTransaction.get("external_id"), is(notNullValue()));


### PR DESCRIPTION
Remove allowing request to contain "agreement_id", now requires "mandate_id".
Remove "charge_id" field from response, now "payment_id" is used.