### PR TITLE
PP-5248 Return provider ID and charge date from provider service

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -8,12 +8,9 @@ import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
-import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.mandate.dao.mapper.MandateMapper;
-import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
-import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReferenceArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateId;
@@ -99,6 +96,10 @@ public interface MandateDao {
 
     @SqlQuery(query + "WHERE m.external_id = :mandateExternalId")
     Optional<Mandate> findByExternalId(@Bind("mandateExternalId") MandateExternalId mandateExternalId);
+
+    @SqlQuery(query + "WHERE m.external_id = :mandateExternalId AND g.external_id = :gatewayAccountExternalId")
+    Optional<Mandate> findByExternalIdAndGatewayAccountExternalId(@Bind("mandateExternalId") MandateExternalId mandateExternalId,
+                                                                  @Bind("gatewayAccountExternalId") String gatewayAccountExternalId);
 
     @SqlQuery(query + "WHERE m.payment_provider_id = :paymentProviderMandateId")
     Optional<Mandate> findByPaymentProviderMandateId(@Bind("paymentProviderMandateId") PaymentProviderMandateId paymentProviderMandateId);

--- a/src/main/java/uk/gov/pay/directdebit/mandate/exception/MandateNotFoundException.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/exception/MandateNotFoundException.java
@@ -15,4 +15,8 @@ public class MandateNotFoundException extends NotFoundException {
     public MandateNotFoundException(MandateExternalId mandateExternalId) {
         super(format("Couldn't find mandate with id: %s", mandateExternalId));
     }
+
+    public MandateNotFoundException(MandateExternalId mandateExternalId, String gatewayAccountExternalId) {
+        super(format("Couldn't find mandate for gateway account %s with id: %s", gatewayAccountExternalId, mandateExternalId));
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateQueryService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateQueryService.java
@@ -26,6 +26,12 @@ public class MandateQueryService {
                 .orElseThrow(() -> new MandateNotFoundException(externalId));
     }
 
+    public Mandate findByExternalIdAndGatewayAccountExternalId(MandateExternalId mandateExternalId, String gatewayAccountExternalId) {
+        return mandateDao
+                .findByExternalIdAndGatewayAccountExternalId(mandateExternalId, gatewayAccountExternalId)
+                .orElseThrow(() -> new MandateNotFoundException(mandateExternalId, gatewayAccountExternalId));
+    }
+    
     public Mandate findByPaymentProviderMandateId(PaymentProviderMandateId paymentProviderMandateId) {
         return mandateDao
                 .findByPaymentProviderMandateId(paymentProviderMandateId)

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessService.java
@@ -29,7 +29,6 @@ import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentIdAndChargeDate;
 
 import javax.inject.Inject;
-import java.time.LocalDate;
 import java.util.Optional;
 
 public class GoCardlessService implements DirectDebitPaymentProviderCommandService {
@@ -64,7 +63,7 @@ public class GoCardlessService implements DirectDebitPaymentProviderCommandServi
     }
 
     @Override
-    public LocalDate collect(Mandate mandate, Payment payment) {
+    public PaymentProviderPaymentIdAndChargeDate collect(Mandate mandate, Payment payment) {
         LOGGER.info("Collecting payment for GoCardless, mandate with id: {}, payment with id: {}", mandate.getExternalId(), payment.getExternalId());
         var goCardlessMandateId = mandate.getPaymentProviderMandateId()
                 .map(a -> (GoCardlessMandateId) a)
@@ -77,7 +76,7 @@ public class GoCardlessService implements DirectDebitPaymentProviderCommandServi
                 .build();
 
         paymentDao.updateProviderIdAndChargeDate(updatePayment);
-        return providerIdAndChargeDate.getChargeDate();
+        return providerIdAndChargeDate;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitPaymentProviderCommandService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/DirectDebitPaymentProviderCommandService.java
@@ -13,7 +13,7 @@ public interface DirectDebitPaymentProviderCommandService {
 
     PaymentProviderMandateIdAndBankReference confirmMandate(Mandate mandate, BankAccountDetails bankAccountDetails);
 
-    LocalDate collect(Mandate mandate, Payment payment);
+    PaymentProviderPaymentIdAndChargeDate collect(Mandate mandate, Payment payment);
 
     BankAccountValidationResponse validate(Mandate mandate, BankAccountDetails bankAccountDetails);
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/CollectService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/CollectService.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.directdebit.payments.services;
+
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
+import uk.gov.pay.directdebit.payments.api.CollectPaymentRequest;
+import uk.gov.pay.directdebit.payments.model.Payment;
+
+import javax.inject.Inject;
+
+public class CollectService {
+
+    private final MandateQueryService mandateQueryService;
+    private final PaymentService paymentService;
+
+    @Inject
+    public CollectService(MandateQueryService mandateQueryService, PaymentService paymentService) {
+        this.mandateQueryService = mandateQueryService;
+        this.paymentService = paymentService;
+    }
+
+    public Payment collect(GatewayAccount gatewayAccount, CollectPaymentRequest collectPaymentRequest) {
+        Mandate mandate = mandateQueryService.findByExternalIdAndGatewayAccountExternalId(collectPaymentRequest.getMandateExternalId(),
+                gatewayAccount.getExternalId());
+
+        Payment payment = paymentService.createPayment(collectPaymentRequest.getAmount(), collectPaymentRequest.getDescription(),
+                collectPaymentRequest.getReference(), mandate);
+        
+        return paymentService.submitPaymentToProvider(payment);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
@@ -11,6 +11,8 @@ import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProvider;
 import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProviderCommandService;
 import uk.gov.pay.directdebit.payments.model.Payment;
+import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentIdAndChargeDate;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
 
 import javax.inject.Inject;
 import java.time.LocalDate;
@@ -35,9 +37,11 @@ public class SandboxService implements DirectDebitPaymentProvider,
     }
 
     @Override
-    public LocalDate collect(Mandate mandate, Payment payment) {
+    public PaymentProviderPaymentIdAndChargeDate collect(Mandate mandate, Payment payment) {
         LOGGER.info("Collecting payment for sandbox, mandate with id: {}, payment with id: {}", mandate.getExternalId(), payment.getExternalId());
-        return LocalDate.now().plusDays(DAYS_TO_COLLECTION);
+        return new PaymentProviderPaymentIdAndChargeDate(
+                SandboxPaymentId.valueOf(payment.getExternalId()),
+                LocalDate.now().plusDays(DAYS_TO_COLLECTION));
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentFixture.java
@@ -28,7 +28,7 @@ public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
     private String description = RandomStringUtils.randomAlphanumeric(20);
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
     private PaymentProviderPaymentId paymentProviderId = SandboxPaymentId.valueOf(RandomStringUtils.randomAlphanumeric(20));
-    private LocalDate chargeDate = LocalDate.now();
+    private LocalDate chargeDate = LocalDate.now().plusDays(4);
 
     private PaymentFixture() {
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -40,11 +40,8 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.OK;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
@@ -147,6 +144,7 @@ public class PaymentResourceIT {
                 .body(JSON_MANDATE_ID_KEY, is(mandateFixture.getExternalId().toString()))
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
                 .body(JSON_STATE_FINISHED_KEY, is(false))
+                .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
                 .contentType(JSON);
 
         String externalTransactionId = response.extract().path(JSON_PAYMENT_ID_KEY).toString();
@@ -248,6 +246,7 @@ public class PaymentResourceIT {
                 .body(JSON_MANDATE_ID_KEY, is(mandate.getExternalId().toString()))
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
                 .body(JSON_STATE_FINISHED_KEY, is(false))
+                .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
                 .contentType(JSON);
 
         String externalTransactionId = response.extract().path(JSON_PAYMENT_ID_KEY).toString();

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -40,7 +40,9 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -183,7 +185,7 @@ public class PaymentResourceIT {
                 .body("$", not(hasKey(JSON_DESCRIPTION_KEY)))
                 .contentType(JSON);
     }
-    
+
     @Test
     public void shouldCollectAPayment_forGoCardless() throws Exception {
         GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/CollectServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/CollectServiceTest.java
@@ -1,0 +1,72 @@
+package uk.gov.pay.directdebit.payments.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.exception.MandateNotFoundException;
+import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
+import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
+import uk.gov.pay.directdebit.payments.api.CollectPaymentRequest;
+import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
+import uk.gov.pay.directdebit.payments.model.Payment;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CollectServiceTest {
+
+    private static final String GATEWAY_ACCOUNT_EXTERNAL_ID = "xyzzy";
+    private static final MandateExternalId MANDATE_EXTERNAL_ID = MandateExternalId.valueOf("mandy");
+    private static final String DESCRIPTION = "The best payment of all time";
+    private static final String REFERENCE = "ref";
+    private static final long AMOUNT = 12345L;
+
+    @Mock
+    private MandateQueryService mockMandateQueryService;
+
+    @Mock
+    private PaymentService mockPaymentService;
+
+    @Mock
+    private Payment mockCreatedPayment, mockPendingPayment;
+
+    private GatewayAccount gatewayAccount = GatewayAccountFixture.aGatewayAccountFixture().withExternalId(GATEWAY_ACCOUNT_EXTERNAL_ID).toEntity();
+
+    private Mandate mandate = MandateFixture.aMandateFixture().withExternalId(MANDATE_EXTERNAL_ID).toEntity();
+    
+    private CollectPaymentRequest collectPaymentRequest = new CollectPaymentRequest(MANDATE_EXTERNAL_ID, AMOUNT, DESCRIPTION, REFERENCE);
+    
+    private CollectService collectService;
+
+    @Before
+    public void setUp() {
+        this.collectService = new CollectService(mockMandateQueryService, mockPaymentService);
+    }
+
+    @Test
+    public void collectCreatesAndCollectsPaymentReturningPendingPayment() {
+        given(mockMandateQueryService.findByExternalIdAndGatewayAccountExternalId(MANDATE_EXTERNAL_ID, GATEWAY_ACCOUNT_EXTERNAL_ID)).willReturn(mandate);
+        given(mockPaymentService.createPayment(AMOUNT, DESCRIPTION, REFERENCE, mandate)).willReturn(mockCreatedPayment);
+        given(mockPaymentService.submitPaymentToProvider(mockCreatedPayment)).willReturn(mockPendingPayment);
+
+        Payment payment = collectService.collect(gatewayAccount, collectPaymentRequest);
+        
+        assertThat(payment, is(mockPendingPayment));
+    }
+
+    @Test(expected = MandateNotFoundException.class)
+    public void collectThrowsExceptionIfMandateNotFound() {
+        given(mockMandateQueryService.findByExternalIdAndGatewayAccountExternalId(MANDATE_EXTERNAL_ID, GATEWAY_ACCOUNT_EXTERNAL_ID))
+                .willThrow(MandateNotFoundException.class);
+
+        collectService.collect(gatewayAccount, collectPaymentRequest);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessServiceTest.java
@@ -256,12 +256,13 @@ public class GoCardlessServiceTest {
         when(mockedGoCardlessClientFacade.createPayment(payment, goCardlessMandateId))
                 .thenReturn(new PaymentProviderPaymentIdAndChargeDate(goCardlessPaymentId, chargeDateFromGoCardless));
 
-        LocalDate actualChargeDate = service.collect(mandate, payment);
+        PaymentProviderPaymentIdAndChargeDate collectResponse = service.collect(mandate, payment);
 
         Payment paymentWithProviderIdAndChargeDate = fromPayment(payment).withProviderId(goCardlessPaymentId).withChargeDate(chargeDateFromGoCardless).build();
         verify(mockedPaymentDao).updateProviderIdAndChargeDate(paymentWithProviderIdAndChargeDate);
 
-        assertThat(actualChargeDate, is(chargeDateFromGoCardless));
+        assertThat(collectResponse.getChargeDate(), is(chargeDateFromGoCardless));
+        assertThat(collectResponse.getPaymentProviderPaymentId(), is(goCardlessPaymentId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.directdebit.payers.model.SortCode;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentFixture;
 import uk.gov.pay.directdebit.payments.model.Payment;
+import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentIdAndChargeDate;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -60,9 +61,9 @@ public class SandboxServiceTest {
         Mandate mandate = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).toEntity();
         Payment payment = PaymentFixture.aPaymentFixture().withMandateFixture(mandateFixture).toEntity();
 
-        LocalDate chargeDate = service.collect(mandate, payment);
+        PaymentProviderPaymentIdAndChargeDate collectResponse = service.collect(mandate, payment);
 
-        assertThat(chargeDate, is(LocalDateMatchers
+        assertThat(collectResponse.getChargeDate(), is(LocalDateMatchers
                 .within(1, ChronoUnit.DAYS, LocalDate.now().plusDays(4))));
     }
 


### PR DESCRIPTION
This allows us to set the `PaymentProviderId` and `ChargeDate` for all services at a common point for all providers within `PaymentService`. This means that we now persist the provider ID and charge date for sandbox as well as GoCardless (the values are arbitrary for sandbox).

As part of this, untangle creating a payment from collecting a payment in `PaymentService` by introducing a new `CollectService` to orchestrate the overall operation.

This code may be easier to understand by reviewing the individual commits.

with @danworth 