### PR TITLE
PP-5298 Return payment_provider as lower case

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/json/ToLowerCaseStringSerializer.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/json/ToLowerCaseStringSerializer.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.directdebit.common.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
+import java.io.IOException;
+
+public class ToLowerCaseStringSerializer extends ToStringSerializer {
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeString(value.toString().toLowerCase());
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/CreateMandateResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.pay.directdebit.common.json.ToLowerCaseStringSerializer;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
@@ -48,7 +49,8 @@ public class CreateMandateResponse {
     private String description;
     
     @JsonProperty("payment_provider")
-    private String paymentProvider;
+    @JsonSerialize(using = ToLowerCaseStringSerializer.class)
+    private PaymentProvider paymentProvider;
 
     public CreateMandateResponse(MandateExternalId mandateId,
                                  String returnUrl,
@@ -67,7 +69,7 @@ public class CreateMandateResponse {
         this.serviceReference = serviceReference;
         this.mandateReference = mandateReference;
         this.description = description;
-        this.paymentProvider = paymentProvider.toString().toLowerCase();
+        this.paymentProvider = paymentProvider;
     }
 
     public MandateExternalId getMandateId() {

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.pay.directdebit.common.json.ToLowerCaseStringSerializer;
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentId;
@@ -39,8 +41,9 @@ public class CollectPaymentResponse {
     @JsonProperty("provider_id")
     private PaymentProviderPaymentId providerId;
 
+    @JsonSerialize(using = ToLowerCaseStringSerializer.class)
     @JsonProperty("payment_provider")
-    private String paymentProvider;
+    private PaymentProvider paymentProvider;
 
     @JsonProperty
     private String description;
@@ -68,7 +71,7 @@ public class CollectPaymentResponse {
         this.paymentProvider = builder.paymentProvider;
     }
 
-    public String getPaymentProvider() {
+    public PaymentProvider getPaymentProvider() {
         return paymentProvider;
     }
 
@@ -110,7 +113,7 @@ public class CollectPaymentResponse {
                 .withDescription(payment.getDescription())
                 .withReference(payment.getReference())
                 .withCreatedDate(payment.getCreatedDate())
-                .withPaymentProvider(payment.getMandate().getGatewayAccount().getPaymentProvider().toString())
+                .withPaymentProvider(payment.getMandate().getGatewayAccount().getPaymentProvider())
                 .withDataLinks(dataLinks);
 
         payment.getProviderId().ifPresent(collectPaymentResponseBuilder::withProviderId);
@@ -161,7 +164,7 @@ public class CollectPaymentResponse {
         private String paymentExternalId;
         private Long amount;
         private MandateExternalId mandateId;
-        private String paymentProvider;
+        private PaymentProvider paymentProvider;
         private String description;
         private String reference;
         private PaymentProviderPaymentId providerId;
@@ -195,7 +198,7 @@ public class CollectPaymentResponse {
             return this;
         }
 
-        public CollectPaymentResponseBuilder withPaymentProvider(String paymentProvider) {
+        public CollectPaymentResponseBuilder withPaymentProvider(PaymentProvider paymentProvider) {
             this.paymentProvider = paymentProvider;
             return this;
         }

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -46,6 +46,8 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
 import static uk.gov.pay.directdebit.payments.resources.PaymentResource.CHARGE_API_PATH;
 import static uk.gov.pay.directdebit.util.GoCardlessStubs.stubCreatePayment;
@@ -67,6 +69,7 @@ public class PaymentResourceIT {
     private static final String JSON_PAYMENT_ID_KEY = "payment_id";
     private static final String JSON_PROVIDER_ID_KEY = "provider_id";
     private static final String JSON_MANDATE_ID_KEY = "mandate_id";
+    private static final String JSON_PAYMENT_PROVIDER_KEY = "payment_provider";
     private static final String JSON_STATE_STATUS_KEY = "state.status";
     private static final String JSON_STATE_FINISHED_KEY = "state.finished";
     private static final String JSON_STATE_DETAILS_KEY = "state.details";
@@ -147,6 +150,7 @@ public class PaymentResourceIT {
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
                 .body(JSON_STATE_FINISHED_KEY, is(false))
                 .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
+                .body(JSON_PAYMENT_PROVIDER_KEY, is(SANDBOX.toString().toLowerCase()))
                 .contentType(JSON);
 
         String externalTransactionId = response.extract().path(JSON_PAYMENT_ID_KEY).toString();
@@ -249,6 +253,7 @@ public class PaymentResourceIT {
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
                 .body(JSON_STATE_FINISHED_KEY, is(false))
                 .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
+                .body(JSON_PAYMENT_PROVIDER_KEY, is(GOCARDLESS.toString().toLowerCase()))
                 .contentType(JSON);
 
         String externalTransactionId = response.extract().path(JSON_PAYMENT_ID_KEY).toString();

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
@@ -136,7 +136,7 @@ public class PaymentServiceTest {
         assertThat(collectPaymentResponse.getPaymentExternalId(), is(paymentFixture.getExternalId()));
         assertThat(collectPaymentResponse.getDescription(), is(paymentFixture.getDescription()));
         assertThat(collectPaymentResponse.getReference(), is(paymentFixture.getReference()));
-        assertThat(collectPaymentResponse.getPaymentProvider(), is(gatewayAccountFixture.getPaymentProvider().toString()));
+        assertThat(collectPaymentResponse.getPaymentProvider(), is(gatewayAccountFixture.getPaymentProvider()));
     }
     @Test
     public void shouldCreateATransactionResponseWithLinksFromAValidTransaction() {


### PR DESCRIPTION
Add a ToLowerCaseStringSerializer to serialize a value to a lower case string. Use this in the payment and mandate response models along with the PaymentProvider enum type on the field.