### PR TITLE
PP-5318 Move GoCardlessEventDao to correct package

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
@@ -7,6 +7,8 @@ import com.google.inject.Singleton;
 import io.dropwizard.setup.Environment;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.directdebit.common.clients.GoCardlessClientFactory;
+import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.events.dao.SandboxEventDao;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.notifications.clients.AdminUsersClient;
@@ -16,10 +18,8 @@ import uk.gov.pay.directdebit.partnerapp.dao.GoCardlessAppConnectAccountTokenDao
 import uk.gov.pay.directdebit.payers.dao.GoCardlessCustomerDao;
 import uk.gov.pay.directdebit.payers.dao.PayerDao;
 import uk.gov.pay.directdebit.payments.dao.DirectDebitEventDao;
-import uk.gov.pay.directdebit.payments.dao.GoCardlessEventDao;
-import uk.gov.pay.directdebit.payments.dao.PaymentViewDao;
-import uk.gov.pay.directdebit.events.dao.SandboxEventDao;
 import uk.gov.pay.directdebit.payments.dao.PaymentDao;
+import uk.gov.pay.directdebit.payments.dao.PaymentViewDao;
 import uk.gov.pay.directdebit.tokens.dao.TokenDao;
 import uk.gov.pay.directdebit.webhook.gocardless.support.WebhookVerifier;
 

--- a/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.directdebit.payments.dao;
+package uk.gov.pay.directdebit.events.dao;
 
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -6,7 +6,6 @@ import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
-import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.dao.mapper.GoCardlessEventMapper;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventService.java
@@ -2,7 +2,7 @@ package uk.gov.pay.directdebit.payments.services;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.directdebit.payments.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 
 import javax.inject.Inject;

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessDirectDebitDirectDebitEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessDirectDebitDirectDebitEventDaoIT.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.directdebit.payments.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
Move `GoCardlessEventDao` from `uk.gov.pay.directdebit.payments.dao` to `uk.gov.pay.directdebit.events.dao`.