### PR TITLE
PP-5299: Generate mandate bank ref on sandbox confirmation

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.directdebit.payments.services;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.common.model.subtype.SunName;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateIdAndBankReference;
 import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
@@ -33,7 +35,7 @@ public class SandboxService implements DirectDebitPaymentProvider,
         LOGGER.info("Confirming on demand mandate for sandbox, mandate with id: {}", mandate.getExternalId());
         return new PaymentProviderMandateIdAndBankReference(
                 SandboxMandateId.valueOf(mandate.getExternalId().toString()),
-                mandate.getMandateBankStatementReference());
+                MandateBankStatementReference.valueOf(RandomStringUtils.randomAlphanumeric(18)));
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
@@ -24,6 +24,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
@@ -46,14 +47,14 @@ public class SandboxServiceTest {
     public void confirmMandate_shouldReturnPaymentProviderIdAndBankStatementReference() {
         MandateFixture mandateFixture = aMandateFixture()
                 .withExternalId(MandateExternalId.valueOf("anExternalId"))
-                .withMandateBankStatementReference(MandateBankStatementReference.valueOf("aBankReference"))
+                .withMandateBankStatementReference(null)
                 .withGatewayAccountFixture(gatewayAccountFixture);
         BankAccountDetails bankAccountDetails = new BankAccountDetails(AccountNumber.of("12345678"), SortCode.of("123456"));
 
         var confirmMandateResponse = service.confirmMandate(mandateFixture.toEntity(), bankAccountDetails);
 
         assertThat(confirmMandateResponse.getPaymentProviderMandateId().toString(), is(mandateFixture.getExternalId().toString()));
-        assertThat(confirmMandateResponse.getMandateBankStatementReference(), is(mandateFixture.getMandateReference()));
+        assertThat(confirmMandateResponse.getMandateBankStatementReference(), is(notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
This used to be generated on creation of the mandate but it is more appropriate
to generate it on the confirmation as that mimicks what a real direct debit
payment provider would do.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
