### PR TITLE
PP-5318 Use WrappedStringValue where appropriate: code reuse FTW

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <hamcrest.version>2.1</hamcrest.version>
         <rest-assured.version>4.0.0</rest-assured.version>
         <mockito.version>2.28.2</mockito.version>
-        <pay-java-commons.version>1.0.20190621120108</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190626120127</pay-java-commons.version>
         <surefire.version>2.22.2</surefire.version>
     </properties>
 

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/GoCardlessOrganisationId.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/model/GoCardlessOrganisationId.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.directdebit.gatewayaccounts.model;
 
-import java.util.Objects;
+import uk.gov.pay.commons.model.WrappedStringValue;
 
 /**
  * An ID that GoCardless assign to a GoCardless account belonging to a
@@ -9,37 +9,16 @@ import java.util.Objects;
  * GoCardless send this to us in webhooks to indicate which account each
  * event relates to
  * <br>
- * "organisation_id" in GoCardless JSON
+ * "organisation" or "organisation_id" in GoCardless JSON
  */
-public class GoCardlessOrganisationId {
-
-    private final String goCardlessOrganisationId;
+public class GoCardlessOrganisationId extends WrappedStringValue {
 
     private GoCardlessOrganisationId(String goCardlessOrganisationId) {
-        this.goCardlessOrganisationId = Objects.requireNonNull(goCardlessOrganisationId);
+        super(goCardlessOrganisationId);
     }
 
-    public static GoCardlessOrganisationId valueOf(String paymentProviderAccessToken) {
-        return new GoCardlessOrganisationId(paymentProviderAccessToken);
+    public static GoCardlessOrganisationId valueOf(String goCardlessOrganisationId) {
+        return new GoCardlessOrganisationId(goCardlessOrganisationId);
     }
 
-    @Override
-    public boolean equals(Object other) {
-        if (other != null && other.getClass() == GoCardlessOrganisationId.class) {
-            GoCardlessOrganisationId that = (GoCardlessOrganisationId) other;
-            return this.goCardlessOrganisationId.equals(that.goCardlessOrganisationId);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return goCardlessOrganisationId.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        return goCardlessOrganisationId;
-    }
-    
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateBankStatementReference.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateBankStatementReference.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.directdebit.mandate.model;
 
-import java.util.Objects;
+import uk.gov.pay.commons.model.WrappedStringValue;
 
 /**
  * Reference for a mandate, which may be shown on the paying user’s bank
@@ -16,35 +16,14 @@ import java.util.Objects;
  * @see <a href="https://developer.gocardless.com/api-reference/#appendix-character-sets">GoCardless character sets</a>
  * @see <a href="https://support.gocardless.com/hc/en-gb/articles/360000962309">GoCardless customer bank statement references</a>
  */
-public class MandateBankStatementReference {
-
-    private final String mandateBankStatementReference;
+public class MandateBankStatementReference extends WrappedStringValue {
 
     private MandateBankStatementReference(String mandateBankStatementReference) {
-        this.mandateBankStatementReference = Objects.requireNonNull(mandateBankStatementReference);
+        super(mandateBankStatementReference);
     }
 
     public static MandateBankStatementReference valueOf(String mandateBankStatementReference) {
         return new MandateBankStatementReference(mandateBankStatementReference);
-    }
-
-    @Override
-    public String toString() {
-        return mandateBankStatementReference;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other != null && other.getClass() == MandateBankStatementReference.class) {
-            MandateBankStatementReference that = (MandateBankStatementReference) other;
-            return this.mandateBankStatementReference.equals(that.mandateBankStatementReference);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return mandateBankStatementReference.hashCode();
     }
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/PaymentProviderMandateId.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/PaymentProviderMandateId.java
@@ -1,31 +1,11 @@
 package uk.gov.pay.directdebit.mandate.model;
 
-import java.util.Objects;
+import uk.gov.pay.commons.model.WrappedStringValue;
 
-public abstract class PaymentProviderMandateId {
-
-    private final String paymentProviderId;
+public abstract class PaymentProviderMandateId extends WrappedStringValue {
 
     PaymentProviderMandateId(String paymentProviderId) {
-        this.paymentProviderId = Objects.requireNonNull(paymentProviderId);
+        super(paymentProviderId);
     }
 
-    @Override
-    public String toString() {
-        return paymentProviderId;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other != null) {
-            PaymentProviderMandateId that = (PaymentProviderMandateId) other;
-            return this.paymentProviderId.equals(that.paymentProviderId);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return paymentProviderId.hashCode();
-    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/subtype/MandateExternalId.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/subtype/MandateExternalId.java
@@ -1,35 +1,15 @@
 package uk.gov.pay.directdebit.mandate.model.subtype;
 
-import java.util.Objects;
+import uk.gov.pay.commons.model.WrappedStringValue;
 
-public class MandateExternalId {
-
-    private final String mandateExternalId;
+public class MandateExternalId extends WrappedStringValue {
 
     private MandateExternalId(String mandateExternalId) {
-        this.mandateExternalId = Objects.requireNonNull(mandateExternalId);
+        super(mandateExternalId);
     }
 
     public static MandateExternalId valueOf(String mandateExternalId) {
         return new MandateExternalId(mandateExternalId);
-    }
-
-    @Override
-    public String toString() {
-        return mandateExternalId;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) return true;
-        if (other == null || getClass() != other.getClass()) return false;
-        MandateExternalId that = (MandateExternalId) other;
-        return mandateExternalId.equals(that.mandateExternalId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(mandateExternalId);
     }
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/AccountNumber.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/AccountNumber.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.payers.model;
 
-import java.util.Objects;
+import uk.gov.pay.commons.model.WrappedStringValue;
+
 import java.util.regex.Pattern;
 
 /**
@@ -9,44 +10,23 @@ import java.util.regex.Pattern;
  * inclusive) but not necessarily valid (in the sense of representing
  * a real bank account)
  */
-public class AccountNumber {
+public class AccountNumber extends WrappedStringValue {
 
     private static final Pattern SIX_TO_EIGHT_ARABIC_NUMERALS = Pattern.compile("[0-9]{6,8}");
 
-    private final String accountNumber;
-
     private AccountNumber(String accountNumber) throws IllegalArgumentException {
-        Objects.requireNonNull(accountNumber);
+        super(accountNumber);
         if (!SIX_TO_EIGHT_ARABIC_NUMERALS.matcher(accountNumber).matches()) {
             throw new IllegalArgumentException("Account number must consist of six to eight Arabic numerals inclusive e.g. \"12345678\"");
         }
-        this.accountNumber = accountNumber;
     }
 
     public static AccountNumber of(String accountNumber) throws IllegalArgumentException {
         return new AccountNumber(accountNumber);
     }
 
-    @Override
-    public boolean equals(Object other) {
-        if (other != null && other.getClass() == AccountNumber.class) {
-            AccountNumber that = (AccountNumber) other;
-            return this.accountNumber.equals(that.accountNumber);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return accountNumber.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        return accountNumber;
-    }
-
     public String getLastTwoDigits() {
+        String accountNumber = toString();
         return accountNumber.substring(accountNumber.length() - 2);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/SortCode.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/SortCode.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.payers.model;
 
-import java.util.Objects;
+import uk.gov.pay.commons.model.WrappedStringValue;
+
 import java.util.regex.Pattern;
 
 /**
@@ -8,41 +9,19 @@ import java.util.regex.Pattern;
  * Guaranteed to be well-formed (six Arabic numerals) but not necessarily
  * valid (in the sense of representing a real bank and branch)
  */
-public class SortCode {
+public class SortCode extends WrappedStringValue {
 
     private static final Pattern SIX_ARABIC_NUMERALS = Pattern.compile("[0-9]{6}");
 
-    private final String sortCode;
-
     private SortCode(String sortCode) throws IllegalArgumentException {
-        Objects.requireNonNull(sortCode);
+        super(sortCode);
         if (!SIX_ARABIC_NUMERALS.matcher(sortCode).matches()) {
             throw new IllegalArgumentException("Sort code must consist of exactly six Arabic numerals e.g. \"123456\"");
         }
-        this.sortCode = sortCode;
     }
 
     public static SortCode of(String sortCode) throws IllegalArgumentException {
         return new SortCode(sortCode);
     }
 
-    @Override
-    public boolean equals(Object other) {
-        if (other != null && other.getClass() == SortCode.class) {
-            SortCode that = (SortCode) other;
-            return this.sortCode.equals(that.sortCode);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return sortCode.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        return sortCode;
-    }
-    
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessEventId.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessEventId.java
@@ -1,41 +1,20 @@
 package uk.gov.pay.directdebit.payments.model;
 
-import java.util.Objects;
+import uk.gov.pay.commons.model.WrappedStringValue;
 
 /**
  * The ID assigned by GoCardless to one of their events e.g. "EV123"
  * 
  * @see <a href="https://developer.gocardless.com/api-reference/#core-endpoints-events">GoCardless Events</a>
  */
-public class GoCardlessEventId {
-
-    private final String goCardlessEventId;
+public class GoCardlessEventId extends WrappedStringValue {
 
     private GoCardlessEventId(String goCardlessEventId) {
-        this.goCardlessEventId = Objects.requireNonNull(goCardlessEventId);
+        super(goCardlessEventId);
     }
 
     public static GoCardlessEventId valueOf(String goCardlessEventId) {
         return new GoCardlessEventId(goCardlessEventId);
-    }
-
-    @Override
-    public String toString() {
-        return goCardlessEventId;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other != null && other.getClass() == GoCardlessEventId.class) {
-            GoCardlessEventId that = (GoCardlessEventId) other;
-            return this.goCardlessEventId.equals(that.goCardlessEventId);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return goCardlessEventId.hashCode();
     }
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentProviderPaymentId.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/PaymentProviderPaymentId.java
@@ -1,31 +1,11 @@
 package uk.gov.pay.directdebit.payments.model;
 
-import java.util.Objects;
+import uk.gov.pay.commons.model.WrappedStringValue;
 
-public abstract class PaymentProviderPaymentId {
-
-    private final String paymentProviderId;
+public abstract class PaymentProviderPaymentId extends WrappedStringValue {
 
     PaymentProviderPaymentId(String paymentProviderId) {
-        this.paymentProviderId = Objects.requireNonNull(paymentProviderId);
+        super(paymentProviderId);
     }
 
-    @Override
-    public String toString() {
-        return paymentProviderId;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other != null) {
-            PaymentProviderPaymentId that = (PaymentProviderPaymentId) other;
-            return this.paymentProviderId.equals(that.paymentProviderId);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return paymentProviderId.hashCode();
-    }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -16,6 +16,7 @@ import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
 import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateId;
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.tokens.fixtures.TokenFixture;
@@ -78,7 +79,7 @@ public class MandateDaoIT {
 
     @Test
     public void shouldFindAMandateById() {
-        PaymentProviderMandateId paymentProviderMandateId = GoCardlessMandateId.valueOf("aGocardlessMandateId");
+        PaymentProviderMandateId paymentProviderMandateId = SandboxMandateId.valueOf("aSandboxMandateId");
         MandateFixture mandateFixture = MandateFixture.aMandateFixture()
                 .withMandateBankStatementReference(MandateBankStatementReference.valueOf("test-reference"))
                 .withServiceReference("test-service-reference")


### PR DESCRIPTION
Make specific types that wrap strings extend `WrappedStringValue` so we don’t have identical implementations of `equals(…)`, `hashCode()` etc.

This change also makes `PaymentProviderMandateId` and `PaymentProviderSandboxId` stricter when it comes to equality: `SandboxMandateId.valueOf("foo")` and `GoCardlessMandateId.valueOf("foo")` will no longer be considered to be equal (which is what we want because they’re not). Fix a test that relied on the buggy behaviour.

This may change the hash codes of some objects but since they’re not shared between application nodes or persisted across application restarts, this is fine.