### PR TITLE
PP-5301 Refactor PaymentResponse to include new fields

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentResponse.java
@@ -12,10 +12,7 @@ import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentId;
 
-import java.net.URI;
 import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;

--- a/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentResponseTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentResponseTest.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.directdebit.payments.api;
 
 import org.junit.Test;
+import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertFalse;
+import static uk.gov.pay.directdebit.payments.api.PaymentResponse.PaymentResponseBuilder.aPaymentResponse;
 
 
 public class PaymentResponseTest {
@@ -14,20 +16,19 @@ public class PaymentResponseTest {
     public void shouldNotStringifyPIIFields() {
         String transactionId = "id";
         Long amount = 10L;
-        String returnUrl = "http://bla.bla";
         String description = "desc";
         String reference = "ref";
+        MandateExternalId mandateExternalId = MandateExternalId.valueOf("mandateid");
         var state = new ExternalPaymentStateWithDetails(ExternalPaymentState.EXTERNAL_STARTED, "test_details");
-        PaymentResponse paymentResponse = new PaymentResponse(
-                transactionId,
-                state,
-                amount,
-                returnUrl,
-                description,
-                reference,
-                ZonedDateTime.now(),
-                new ArrayList<>()
-        );
+        var paymentResponse = aPaymentResponse()
+                .withCreatedDate(ZonedDateTime.now())
+                .withState(state)
+                .withDescription(description)
+                .withReference(reference)
+                .withAmount(amount)
+                .withTransactionExternalId(transactionId)
+                .withMandateId(mandateExternalId)
+                .build();
         assertFalse(paymentResponse.toString().contains(description));
     }
 }


### PR DESCRIPTION
- PaymentResponse included a number of fields that were no longer
  being used, and did not included a field that was (MandateId)
- This refactor adds those to keep compatibility