### PR TITLE
PP-5371 Rationalise organisation identifier in GoCardlessEvent

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
@@ -7,6 +7,7 @@ import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.events.dao.mapper.GoCardlessEventMapper;
+import uk.gov.pay.directdebit.events.model.GoCardlessOrganisationIdArgumentFactory;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventIdArgumentFactory;
@@ -15,6 +16,7 @@ import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdArgumentFactory;
 @RegisterArgumentFactory(GoCardlessEventIdArgumentFactory.class)
 @RegisterArgumentFactory(GoCardlessMandateIdArgumentFactory.class)
 @RegisterArgumentFactory(GoCardlessPaymentIdArgumentFactory.class)
+@RegisterArgumentFactory(GoCardlessOrganisationIdArgumentFactory.class)
 @RegisterRowMapper(GoCardlessEventMapper.class)
 public interface GoCardlessEventDao {
 

--- a/src/main/java/uk/gov/pay/directdebit/events/dao/mapper/GoCardlessEventMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/mapper/GoCardlessEventMapper.java
@@ -2,6 +2,7 @@ package uk.gov.pay.directdebit.events.dao.mapper;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventId;
@@ -31,7 +32,7 @@ public class GoCardlessEventMapper implements RowMapper<GoCardlessEvent> {
                 .withDetailsReasonCode(resultSet.getString("details_reason_code"))
                 .withDetailsScheme(resultSet.getString("details_scheme"))
                 .withLinksNewCustomerBankAccount(resultSet.getString("links_new_customer_bank_account"))
-                .withLinksOrganisation(resultSet.getString("links_organisation"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf(resultSet.getString("links_organisation")))
                 .withLinksParentEvent(resultSet.getString("links_parent_event"))
                 .withLinksPayout(resultSet.getString("links_payout"))
                 .withLinksPreviousCustomerBankAccount(resultSet.getString("links_previous_customer_bank_account"))

--- a/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessOrganisationIdArgumentFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessOrganisationIdArgumentFactory.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.directdebit.events.model;
+
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+
+import java.sql.Types;
+
+public class GoCardlessOrganisationIdArgumentFactory extends AbstractArgumentFactory<GoCardlessOrganisationId> {
+
+    public GoCardlessOrganisationIdArgumentFactory() {
+        super(Types.VARCHAR);
+    }
+
+    @Override
+    protected Argument build(GoCardlessOrganisationId value, ConfigRegistry config) {
+        String goCardlessOrganisationId = value == null ? null : value.toString();
+        return (pos, stmt, context) -> stmt.setString(pos, goCardlessOrganisationId);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessEvent.java
@@ -25,7 +25,7 @@ public class GoCardlessEvent {
     private final GoCardlessMandateId linksMandate;
     private final String linksNewCustomerBankAccount;
     private final GoCardlessMandateId linksNewMandate;
-    private final String linksOrganisation;
+    private final GoCardlessOrganisationId linksOrganisation;
     private final String linksParentEvent;
     private final GoCardlessPaymentId linksPayment;
     private final String linksPayout;
@@ -33,7 +33,6 @@ public class GoCardlessEvent {
     private final String linksRefund;
     private final String linksSubscription;
     private final ZonedDateTime createdAt;
-    private final GoCardlessOrganisationId organisationIdentifier;
 
     private GoCardlessEvent(GoCardlessEventBuilder goCardlessEventBuilder) {
         this.id = goCardlessEventBuilder.id;
@@ -59,7 +58,6 @@ public class GoCardlessEvent {
         this.linksRefund = goCardlessEventBuilder.linksRefund;
         this.linksSubscription = goCardlessEventBuilder.linksSubscription;
         this.createdAt = goCardlessEventBuilder.createdAt;
-        this.organisationIdentifier = goCardlessEventBuilder.organisationIdentifier;
     }
     
     //TODO: This method will be removed once we stop creating generic events
@@ -127,7 +125,7 @@ public class GoCardlessEvent {
         return Optional.ofNullable(linksNewMandate);
     }
 
-    public String getLinksOrganisation() {
+    public GoCardlessOrganisationId getLinksOrganisation() {
         return linksOrganisation;
     }
 
@@ -186,8 +184,7 @@ public class GoCardlessEvent {
                 linksPreviousCustomerBankAccount.equals(that.linksPreviousCustomerBankAccount) &&
                 linksRefund.equals(that.linksRefund) &&
                 linksSubscription.equals(that.linksSubscription) &&
-                createdAt.equals(that.createdAt) &&
-                organisationIdentifier.equals(that.organisationIdentifier);
+                createdAt.equals(that.createdAt);
     }
 
     @Override
@@ -196,11 +193,7 @@ public class GoCardlessEvent {
                 detailsDescription, detailsOrigin, detailsReasonCode, detailsScheme, linksMandate,
                 linksNewCustomerBankAccount, linksNewMandate, linksOrganisation, linksParentEvent,
                 linksPayment, linksPayout, linksPreviousCustomerBankAccount, linksRefund, linksSubscription,
-                createdAt, organisationIdentifier);
-    }
-
-    public GoCardlessOrganisationId getOrganisationIdentifier() {
-        return organisationIdentifier;
+                createdAt);
     }
 
     public static final class GoCardlessEventBuilder {
@@ -220,7 +213,7 @@ public class GoCardlessEvent {
         private GoCardlessMandateId linksMandate;
         private String linksNewCustomerBankAccount;
         private GoCardlessMandateId linksNewMandate;
-        private String linksOrganisation;
+        private GoCardlessOrganisationId linksOrganisation;
         private String linksParentEvent;
         private GoCardlessPaymentId linksPayment;
         private String linksPayout;
@@ -312,7 +305,7 @@ public class GoCardlessEvent {
             return this;
         }
 
-        public GoCardlessEventBuilder withLinksOrganisation(String linksOrganisation) {
+        public GoCardlessEventBuilder withLinksOrganisation(GoCardlessOrganisationId linksOrganisation) {
             this.linksOrganisation = linksOrganisation;
             return this;
         }
@@ -349,11 +342,6 @@ public class GoCardlessEvent {
 
         public GoCardlessEventBuilder withCreatedAt(ZonedDateTime createdAt) {
             this.createdAt = createdAt;
-            return this;
-        }
-
-        public GoCardlessEventBuilder withOrganisationIdentifier(GoCardlessOrganisationId organisationIdentifier) {
-            this.organisationIdentifier = organisationIdentifier;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/api/GoCardlessWebhookParser.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/api/GoCardlessWebhookParser.java
@@ -44,8 +44,8 @@ public class GoCardlessWebhookParser {
                         .withAction(eventNode.get("action").asText())
                         .withJson(eventNode.toString())
                         .withCreatedAt(ZonedDateTime.parse(eventNode.get("created_at").asText()))
-                        .withOrganisationIdentifier(getOrganisationField(eventNode));
-                
+                        .withLinksOrganisation(GoCardlessOrganisationId.valueOf(linksNode.get("organisation").asText()));
+
                 if (detailsNode.has("cause")) {
                     goCardlessEventBuilder.withDetailsCause(detailsNode.get("cause").asText());
                 }
@@ -71,9 +71,6 @@ public class GoCardlessWebhookParser {
                 }
                 if (linksNode.has("new_mandate")) {
                     goCardlessEventBuilder.withLinksNewMandate(GoCardlessMandateId.valueOf(linksNode.get("new_mandate").asText()));
-                }
-                if (linksNode.has("organisation")) {
-                    goCardlessEventBuilder.withLinksOrganisation(linksNode.get("organisation").asText());
                 }
                 if (linksNode.has("parent_event")) {
                     goCardlessEventBuilder.withLinksParentEvent(linksNode.get("parent_event").asText());
@@ -112,17 +109,6 @@ public class GoCardlessWebhookParser {
             return events;
         } catch (Exception exc) {
             throw new WebhookParserException("Failed to parse webhooks, body: " + webhookPayload);
-        }
-    }
-
-    private GoCardlessOrganisationId getOrganisationField(JsonNode eventNode) {
-        /* todo: remove the check for missing node after going live
-        Now is used for backward compatibility as when live we will get the organisation in the payload
-        */
-        if (eventNode.get("links").has("organisation")) {
-            return GoCardlessOrganisationId.valueOf(eventNode.get("links").get("organisation").asText());
-        } else {
-            return null;
         }
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
@@ -93,7 +93,7 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
                         return handledAction.apply(mandate);
                     } else {
                         LOGGER.info("Event from GoCardless with goCardlessEventId: {} has unrecognised organisation: {}",
-                                event.getGoCardlessEventId(), event.getOrganisationIdentifier());
+                                event.getGoCardlessEventId(), event.getLinksOrganisation());
                         return null;
                     }
                 }));
@@ -106,7 +106,7 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
 
     private boolean isValidOrganisation(Mandate mandate, GoCardlessEvent event) {
         return mandate.getGatewayAccount().getOrganisation()
-                .map(organisationIdentifier -> organisationIdentifier.equals(event.getOrganisationIdentifier()))
+                .map(organisationIdentifier -> organisationIdentifier.equals(event.getLinksOrganisation()))
                 // TODO: replace true with false after going live. kept now for backwards compatibility with GetDirectDebitEventsIT
                 .orElse(true);
     }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -60,7 +60,7 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
         if (!isValidOrganisation(payment, event)) {
             LOGGER.info("Ignoring GoCardless event {} because its organisation {} does not match organisation of " +
                             "stored payment {}",
-                    event.getGoCardlessEventId(), event.getOrganisationIdentifier(), payment.getExternalId());
+                    event.getGoCardlessEventId(), event.getLinksOrganisation(), payment.getExternalId());
             return Optional.empty();
         }
 
@@ -84,7 +84,7 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
 
     private boolean isValidOrganisation(Payment payment, GoCardlessEvent event) {
         return payment.getMandate().getGatewayAccount().getOrganisation()
-                .map(organisationIdentifier -> organisationIdentifier.equals(event.getOrganisationIdentifier()))
+                .map(organisationIdentifier -> organisationIdentifier.equals(event.getLinksOrganisation()))
                 .orElse(false);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessDirectDebitDirectDebitEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessDirectDebitDirectDebitEventDaoIT.java
@@ -9,6 +9,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
 import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
@@ -95,7 +96,7 @@ public class GoCardlessDirectDebitDirectDebitEventDaoIT {
                 .withLinksMandate(GoCardlessMandateId.valueOf( LINKS_MANDATE))
                 .withLinksNewCustomerBankAccount(LINKS_NEWCUSTOMERBANKACCOUNT)
                 .withLinksNewMandate(GoCardlessMandateId.valueOf(LINKS_NEWMANDATE))
-                .withLinksOrganisation(LINKS_ORGANISATION)
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf(LINKS_ORGANISATION))
                 .withLinksParentEvent(LINKS_PARENTEVENT)
                 .withLinksPayment(GoCardlessPaymentId.valueOf(LINKS_PAYMENT))
                 .withLinksPayout(LINKS_PAYOUT)

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GoCardlessEventFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GoCardlessEventFixture.java
@@ -35,7 +35,7 @@ public class GoCardlessEventFixture implements DbFixture<GoCardlessEventFixture,
     private GoCardlessMandateId linksMandate = GoCardlessMandateId.valueOf(randomAlphabetic(20));
     private String linksNewCustomerBankAccount = randomAlphabetic(20);
     private GoCardlessMandateId linksNewMandate = GoCardlessMandateId.valueOf(randomAlphabetic(20));
-    private String linksOrganisation = randomAlphabetic(20);
+    private GoCardlessOrganisationId linksOrganisation = GoCardlessOrganisationId.valueOf(randomAlphanumeric(20));
     private String linksParentEvent = randomAlphabetic(20);
     private GoCardlessPaymentId linksPayment = GoCardlessPaymentId.valueOf(randomAlphabetic(20));
     private String linksPayout = randomAlphabetic(20);
@@ -43,7 +43,6 @@ public class GoCardlessEventFixture implements DbFixture<GoCardlessEventFixture,
     private String linksRefund = randomAlphabetic(20);
     private String linksSubscription = randomAlphabetic(20);
     private ZonedDateTime createdAt = ZonedDateTime.now(ZoneOffset.UTC);
-    private GoCardlessOrganisationId organisationIdentifier = GoCardlessOrganisationId.valueOf(randomAlphanumeric(25));
 
     private GoCardlessEventFixture() {
     }
@@ -124,11 +123,6 @@ public class GoCardlessEventFixture implements DbFixture<GoCardlessEventFixture,
         return this;
     }
 
-    public GoCardlessEventFixture withOrganisationIdentifier(GoCardlessOrganisationId organisationIdentifier) {
-        this.organisationIdentifier = organisationIdentifier;
-        return this;
-    }
-
     public String getDetailsCause() {
         return detailsCause;
     }
@@ -201,11 +195,11 @@ public class GoCardlessEventFixture implements DbFixture<GoCardlessEventFixture,
         return this;
     }
 
-    public String getLinksOrganisation() {
+    public GoCardlessOrganisationId getLinksOrganisation() {
         return linksOrganisation;
     }
 
-    public GoCardlessEventFixture withLinksOrganisation(String linksOrganisation) {
+    public GoCardlessEventFixture withLinksOrganisation(GoCardlessOrganisationId linksOrganisation) {
         this.linksOrganisation = linksOrganisation;
         return this;
     }
@@ -308,7 +302,7 @@ public class GoCardlessEventFixture implements DbFixture<GoCardlessEventFixture,
                         linksMandate.toString(),
                         linksNewCustomerBankAccount,
                         linksNewMandate,
-                        linksOrganisation,
+                        linksOrganisation.toString(),
                         linksParentEvent,
                         linksPayment.toString(),
                         linksPayout,
@@ -346,7 +340,6 @@ public class GoCardlessEventFixture implements DbFixture<GoCardlessEventFixture,
                 .withLinksPreviousCustomerBankAccount(linksPreviousCustomerBankAccount)
                 .withLinksRefund(linksRefund).withLinksSubscription(linksSubscription)
                 .withCreatedAt(createdAt)
-                .withOrganisationIdentifier(organisationIdentifier)
                 .build();
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/api/GoCardlessWebhookParserTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/api/GoCardlessWebhookParserTest.java
@@ -60,7 +60,7 @@ public class GoCardlessWebhookParserTest {
         assertThat(firstEvent.getAction(), is(ACTION));
         assertThat(firstEvent.getResourceType(), is(RESOURCE_TYPE));
         assertThat(firstEvent.getCreatedAt(), is(CREATED_AT));
-        assertThat(firstEvent.getOrganisationIdentifier(), is(organisationIdentifier));
+        assertThat(firstEvent.getLinksOrganisation(), is(organisationIdentifier));
         assertThat(firstEvent.getJson(), is(objectMapper.readTree(validEvent).toString()));
     }
 
@@ -91,7 +91,7 @@ public class GoCardlessWebhookParserTest {
         assertThat(firstEvent.getAction(), is(ACTION));
         assertThat(firstEvent.getResourceType(), is(RESOURCE_TYPE));
         assertThat(firstEvent.getCreatedAt(), is(CREATED_AT));
-        assertThat(firstEvent.getOrganisationIdentifier(), is(organisationIdentifier));
+        assertThat(firstEvent.getLinksOrganisation(), is(organisationIdentifier));
         assertThat(firstEvent.getJson(), is(objectMapper.readTree(firstEventPayload).toString()));
         assertThat(firstEvent.getDetailsCause(), is("payment_confirmed"));
         assertThat(firstEvent.getDetailsDescription(), is("Payment was confirmed as collected"));
@@ -100,7 +100,7 @@ public class GoCardlessWebhookParserTest {
         assertThat(firstEvent.getDetailsScheme(), is("a details scheme"));
         assertThat(firstEvent.getLinksNewCustomerBankAccount(), is("a bank account"));
         assertThat(firstEvent.getLinksNewMandate().get().toString(), is("a new mandate"));
-        assertThat(firstEvent.getLinksOrganisation(), is(organisationIdentifier.toString()));
+        assertThat(firstEvent.getLinksOrganisation(), is(organisationIdentifier));
         assertThat(firstEvent.getLinksParentEvent(), is("a parent event"));
         assertThat(firstEvent.getLinksPreviousCustomerBankAccount(), is("a previous customer bank account"));
         assertThat(firstEvent.getLinksRefund(), is(""));
@@ -115,7 +115,7 @@ public class GoCardlessWebhookParserTest {
         assertThat(secondEvent.getAction(), is(secondEventAction));
         assertThat(secondEvent.getResourceType(), is(secondEventResourceType));
         assertThat(secondEvent.getCreatedAt(), is(eventCreatedAt));
-        assertThat(secondEvent.getOrganisationIdentifier(), is(organisationIdentifier));
+        assertThat(secondEvent.getLinksOrganisation(), is(organisationIdentifier));
         assertThat(secondEvent.getJson(), is(objectMapper.readTree(secondEventPayload).toString()));
         assertThat(secondEvent.getLinksPayment(), is(Optional.empty()));
         assertThat(secondEvent.getLinksMandate().get().toString(), is("mandate"));
@@ -128,7 +128,7 @@ public class GoCardlessWebhookParserTest {
         assertThat(thirdEvent.getAction(), is(thirdEventAction));
         assertThat(thirdEvent.getResourceType(), is(thirdEventResourceType));
         assertThat(thirdEvent.getCreatedAt(), is(eventCreatedAt));
-        assertThat(thirdEvent.getOrganisationIdentifier(), is(organisationIdentifier));
+        assertThat(thirdEvent.getLinksOrganisation(), is(organisationIdentifier));
         assertThat(thirdEvent.getJson(), is(objectMapper.readTree(thirdEventPayload).toString()));
         assertThat(thirdEvent.getLinksPayment(), is(Optional.empty()));
         assertThat(thirdEvent.getLinksMandate(), is(Optional.empty()));

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
@@ -72,7 +72,7 @@ public class GoCardlessMandateHandlerTest {
             .withMandateFixture(mandateFixture);
     private GoCardlessMandateHandler goCardlessMandateHandler;
     private GoCardlessEventFixture goCardlessEventFixture = GoCardlessEventFixture.aGoCardlessEventFixture()
-            .withOrganisationIdentifier(organisationIdentifier);
+            .withLinksOrganisation(organisationIdentifier);
 
     @Before
     public void setUp() {
@@ -251,7 +251,7 @@ public class GoCardlessMandateHandlerTest {
     @Test
     public void handle_onCreateMandateGoCardlessEvent_shouldNotRegisterEventAsMandatePending_whenOrganisationDoesNotExist() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture
-                .withOrganisationIdentifier(GoCardlessOrganisationId.valueOf("does_not_exist"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("does_not_exist"))
                 .withAction("created")
                 .toEntity());
 
@@ -265,7 +265,7 @@ public class GoCardlessMandateHandlerTest {
     @Test
     public void handle_onCreateMandateGoCardlessEvent_shouldThrowExceptionWhenEventHasNoLinkedMandate() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture
-                .withOrganisationIdentifier(GoCardlessOrganisationId.valueOf("does_not_exist"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("does_not_exist"))
                 .withAction("created")
                 .withLinksMandate(null)
                 .toEntity());

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
@@ -52,7 +52,7 @@ public class GoCardlessPaymentHandlerTest {
     private GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().withOrganisation(organisationIdentifier);
     private MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture);
     private Payment payment = PaymentFixture.aPaymentFixture().withMandateFixture(mandateFixture).toEntity();
-    private GoCardlessEventFixture goCardlessEventFixture = GoCardlessEventFixture.aGoCardlessEventFixture().withOrganisationIdentifier(organisationIdentifier);
+    private GoCardlessEventFixture goCardlessEventFixture = GoCardlessEventFixture.aGoCardlessEventFixture().withLinksOrganisation(organisationIdentifier);
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -191,9 +191,9 @@ public class GoCardlessPaymentHandlerTest {
     }
 
     @Test
-    public void handle_doNotProcess_noOrgansiationOnGatewayAccount() {
+    public void handle_doNotProcess_organisationOnEventDoesNotMatchGatewayAccount() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture
-                .withOrganisationIdentifier(GoCardlessOrganisationId.valueOf("i_do_not_exist_id"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("i_do_not_exist_id"))
                 .withAction("paid")
                 .toEntity());
 
@@ -207,7 +207,7 @@ public class GoCardlessPaymentHandlerTest {
     @Test
     public void handle_onCreatePaymentGoCardlessEvent_shouldThrowExceptionWhenEventHasNoLinkedPayment() {
         GoCardlessEvent goCardlessEvent = goCardlessEventFixture
-                .withOrganisationIdentifier(GoCardlessOrganisationId.valueOf("does_not_exist"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("does_not_exist"))
                 .withAction("created")
                 .withLinksPayment(null)
                 .toEntity();
@@ -220,7 +220,7 @@ public class GoCardlessPaymentHandlerTest {
     public void handle_onCreatePaymentGoCardlessEvent_shouldThrowPaymentNotFoundException() {
         GoCardlessPaymentId expectedPaymentProvider = GoCardlessPaymentId.valueOf("expected");
         GoCardlessEvent goCardlessEvent = goCardlessEventFixture
-                .withOrganisationIdentifier(GoCardlessOrganisationId.valueOf("does_not_exist"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("does_not_exist"))
                 .withAction("created")
                 .withLinksPayment(expectedPaymentProvider)
                 .toEntity();


### PR DESCRIPTION
`GoCardlessEvent` had two fields for the organisation identifier (`"links"."organisation"` in the JSON): `organisationIdentifier` and `linksOrganisation`. The former was a `GoCardlessOrganisationId` while the latter was a `String`. While we parsed both out of the incoming webhook event JSON, only `linksOrganisation` got persisted to and read from the database. In other places, we were inconsistent about which one we used.

Standardise on `linksOrganisation` (for consistency with similar fields in `GoCardlessEvent`) but make the type a `GoCardlessOrganisationId` rather than a `String`.

Remove code that tries to account for events that don’t have an organisation ID: all incoming events should do have an organisation ID (because they’re from an accounts linked to our partner app): there might still be some in the database but since we’re not live yet we can always clear them all out.