### PR TITLE
PP-5301 Rename CollectPaymentResponse PaymentResponse

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
@@ -16,11 +16,11 @@ import java.time.ZonedDateTime;
 import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
-import static uk.gov.pay.directdebit.payments.api.CollectPaymentResponse.CollectPaymentResponseBuilder.aCollectPaymentResponse;
+import static uk.gov.pay.directdebit.payments.api.PaymentResponse.PaymentResponseBuilder.aPaymentResponse;
 
 @JsonInclude(Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
-public class CollectPaymentResponse {
+public class PaymentResponse {
     
     @JsonProperty("payment_id")
     private String paymentExternalId;
@@ -53,7 +53,7 @@ public class CollectPaymentResponse {
     @JsonProperty
     private ExternalPaymentStateWithDetails state;
 
-    public CollectPaymentResponse(CollectPaymentResponseBuilder builder) {
+    public PaymentResponse(PaymentResponseBuilder builder) {
         this.paymentExternalId = builder.paymentExternalId;
         this.state = builder.state;
         this.amount = builder.amount;
@@ -94,8 +94,8 @@ public class CollectPaymentResponse {
         return reference;
     }
 
-    public static CollectPaymentResponse from(Payment payment) {
-        CollectPaymentResponseBuilder collectPaymentResponseBuilder = aCollectPaymentResponse()
+    public static PaymentResponse from(Payment payment) {
+        PaymentResponseBuilder paymentResponseBuilder = aPaymentResponse()
                 .withPaymentExternalId(payment.getExternalId())
                 // TODO: should extract state details (go cardless cause details) from events table somehow
                 .withState(new ExternalPaymentStateWithDetails(payment.getState().toExternal(), "example_details"))
@@ -106,14 +106,14 @@ public class CollectPaymentResponse {
                 .withCreatedDate(payment.getCreatedDate())
                 .withPaymentProvider(payment.getMandate().getGatewayAccount().getPaymentProvider());
 
-        payment.getProviderId().ifPresent(collectPaymentResponseBuilder::withProviderId);
+        payment.getProviderId().ifPresent(paymentResponseBuilder::withProviderId);
 
-        return collectPaymentResponseBuilder.build();
+        return paymentResponseBuilder.build();
     }
 
     @Override
     public String toString() {
-        return "CollectPaymentResponse{" +
+        return "PaymentResponse{" +
                 " paymentExternalId='" + paymentExternalId + '\'' +
                 ", amount=" + amount +
                 ", mandateId='" + mandateId + '\'' +
@@ -129,7 +129,7 @@ public class CollectPaymentResponse {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        CollectPaymentResponse that = (CollectPaymentResponse) o;
+        PaymentResponse that = (PaymentResponse) o;
         return Objects.equals(paymentExternalId, that.paymentExternalId) &&
                 Objects.equals(amount, that.amount) &&
                 Objects.equals(mandateId, that.mandateId) &&
@@ -146,7 +146,7 @@ public class CollectPaymentResponse {
         return Objects.hash(paymentExternalId, amount, mandateId, providerId, paymentProvider, description, reference, createdDate, state);
     }
     
-    public static final class CollectPaymentResponseBuilder {
+    public static final class PaymentResponseBuilder {
 
         private String paymentExternalId;
         private Long amount;
@@ -158,60 +158,60 @@ public class CollectPaymentResponse {
         private ZonedDateTime createdDate;
         private ExternalPaymentStateWithDetails state;
 
-        private CollectPaymentResponseBuilder() {
+        private PaymentResponseBuilder() {
         }
 
-        public static CollectPaymentResponseBuilder aCollectPaymentResponse() {
-            return new CollectPaymentResponseBuilder();
+        public static PaymentResponseBuilder aPaymentResponse() {
+            return new PaymentResponseBuilder();
         }
         
-        public CollectPaymentResponseBuilder withPaymentExternalId(String paymentExternalId) {
+        public PaymentResponseBuilder withPaymentExternalId(String paymentExternalId) {
             this.paymentExternalId = paymentExternalId;
             return this;
         }
 
-        public CollectPaymentResponseBuilder withAmount(Long amount) {
+        public PaymentResponseBuilder withAmount(Long amount) {
             this.amount = amount;
             return this;
         }
 
-        public CollectPaymentResponseBuilder withMandateId(MandateExternalId mandateId) {
+        public PaymentResponseBuilder withMandateId(MandateExternalId mandateId) {
             this.mandateId = mandateId;
             return this;
         }
 
-        public CollectPaymentResponseBuilder withPaymentProvider(PaymentProvider paymentProvider) {
+        public PaymentResponseBuilder withPaymentProvider(PaymentProvider paymentProvider) {
             this.paymentProvider = paymentProvider;
             return this;
         }
 
-        public CollectPaymentResponseBuilder withDescription(String description) {
+        public PaymentResponseBuilder withDescription(String description) {
             this.description = description;
             return this;
         }
 
-        public CollectPaymentResponseBuilder withReference(String reference) {
+        public PaymentResponseBuilder withReference(String reference) {
             this.reference = reference;
             return this;
         }
 
-        public CollectPaymentResponseBuilder withCreatedDate(ZonedDateTime createdDate) {
+        public PaymentResponseBuilder withCreatedDate(ZonedDateTime createdDate) {
             this.createdDate = createdDate;
             return this;
         }
 
-        public CollectPaymentResponseBuilder withState(ExternalPaymentStateWithDetails state) {
+        public PaymentResponseBuilder withState(ExternalPaymentStateWithDetails state) {
             this.state = state;
             return this;
         }
         
-        public CollectPaymentResponseBuilder withProviderId(PaymentProviderPaymentId providerId) {
+        public PaymentResponseBuilder withProviderId(PaymentProviderPaymentId providerId) {
             this.providerId = providerId;
             return this;
         }
 
-        public CollectPaymentResponse build() {
-            return new CollectPaymentResponse(this);
+        public PaymentResponse build() {
+            return new PaymentResponse(this);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResponse.java
@@ -24,11 +24,11 @@ public class PaymentViewResponse {
     @JsonProperty("page")
     private Long page;
     @JsonProperty("results")
-    private List<CollectPaymentResponse> paymentViewResponses;
+    private List<PaymentResponse> paymentViewResponses;
     @JsonProperty("_links")
     private ViewPaginationBuilder paginationBuilder;
 
-    public PaymentViewResponse(String gatewayExternalId, Long total, Long page, List<CollectPaymentResponse> paymentViewResponses) {
+    public PaymentViewResponse(String gatewayExternalId, Long total, Long page, List<PaymentResponse> paymentViewResponses) {
         this.gatewayExternalId = gatewayExternalId;
         this.total = total;
         this.count = (long)paymentViewResponses.size();
@@ -36,7 +36,7 @@ public class PaymentViewResponse {
         this.paymentViewResponses = paymentViewResponses;
     }
 
-    public List<CollectPaymentResponse> getPaymentViewResponses() {
+    public List<PaymentResponse> getPaymentViewResponses() {
         return paymentViewResponses;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
@@ -5,8 +5,8 @@ import javax.inject.Inject;
 
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
-import uk.gov.pay.directdebit.payments.api.CollectPaymentResponse;
-import uk.gov.pay.directdebit.payments.dao.mapper.CollectPaymentResponseMapper;
+import uk.gov.pay.directdebit.payments.api.PaymentResponse;
+import uk.gov.pay.directdebit.payments.dao.mapper.PaymentResponseMapper;
 import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
 
 public class PaymentViewDao {
@@ -44,13 +44,13 @@ public class PaymentViewDao {
         this.jdbi = jdbi;
     }
 
-    public List<CollectPaymentResponse> searchPaymentView(PaymentViewSearchParams searchParams) {
+    public List<PaymentResponse> searchPaymentView(PaymentViewSearchParams searchParams) {
         String searchExtraFields = searchParams.generateQuery();
         return jdbi.withHandle(handle -> {
             Query query = handle.createQuery(QUERY_STRING.replace(":searchExtraFields", searchExtraFields));
             searchParams.getQueryMap().forEach(query::bind);
             return query
-                    .map(new CollectPaymentResponseMapper())
+                    .map(new PaymentResponseMapper())
                     .list();
         });
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentResponseMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentResponseMapper.java
@@ -4,7 +4,7 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
-import uk.gov.pay.directdebit.payments.api.CollectPaymentResponse;
+import uk.gov.pay.directdebit.payments.api.PaymentResponse;
 import uk.gov.pay.directdebit.payments.api.ExternalPaymentStateWithDetails;
 import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentId;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
@@ -16,15 +16,15 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static uk.gov.pay.directdebit.payments.api.CollectPaymentResponse.CollectPaymentResponseBuilder.aCollectPaymentResponse;
+import static uk.gov.pay.directdebit.payments.api.PaymentResponse.PaymentResponseBuilder.aPaymentResponse;
 
-public class CollectPaymentResponseMapper implements RowMapper<CollectPaymentResponse> {
+public class PaymentResponseMapper implements RowMapper<PaymentResponse> {
     
 
     @Override
-    public CollectPaymentResponse map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public PaymentResponse map(ResultSet rs, StatementContext ctx) throws SQLException {
         
-        CollectPaymentResponse.CollectPaymentResponseBuilder collectPaymentResponse = aCollectPaymentResponse()
+        PaymentResponse.PaymentResponseBuilder paymentResponse = aPaymentResponse()
                 .withState(
                         new ExternalPaymentStateWithDetails(
                                 PaymentState.valueOf(rs.getString("state")).toExternal(), ""))
@@ -40,13 +40,13 @@ public class CollectPaymentResponseMapper implements RowMapper<CollectPaymentRes
         if(rs.getString("payment_provider").equalsIgnoreCase("gocardless")) {
             Optional.ofNullable(rs.getString("provider_id"))
                     .map(GoCardlessPaymentId::valueOf)
-                    .ifPresent(collectPaymentResponse::withProviderId);
+                    .ifPresent(paymentResponse::withProviderId);
         } else {
             Optional.ofNullable(rs.getString("provider_id"))
                     .map(SandboxPaymentId::valueOf)
-                    .ifPresent(collectPaymentResponse::withProviderId);
+                    .ifPresent(paymentResponse::withProviderId);
         }
         
-        return collectPaymentResponse.build();
+        return paymentResponse.build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequest;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequestValidator;
-import uk.gov.pay.directdebit.payments.api.CollectPaymentResponse;
+import uk.gov.pay.directdebit.payments.api.PaymentResponse;
 import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.services.CollectService;
 import uk.gov.pay.directdebit.payments.services.PaymentService;
@@ -45,7 +45,7 @@ public class PaymentResource {
     @Produces(APPLICATION_JSON)
     @Timed
     public Response getCharge(@PathParam("paymentExternalId") String transactionExternalId) {
-        CollectPaymentResponse response = paymentService.getPaymentWithExternalId(transactionExternalId);
+        PaymentResponse response = paymentService.getPaymentWithExternalId(transactionExternalId);
         return Response.ok(response).build();
     }
 
@@ -57,7 +57,7 @@ public class PaymentResource {
         LOGGER.info("Received collect payment from mandate request");
         collectPaymentRequestValidator.validate(collectPaymentRequestMap);
         Payment paymentToCollect = collectService.collect(gatewayAccount, CollectPaymentRequest.of(collectPaymentRequestMap));
-        CollectPaymentResponse response = CollectPaymentResponse.from(paymentToCollect);
+        PaymentResponse response = PaymentResponse.from(paymentToCollect);
         return Response.status(SC_CREATED).entity(response).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentSearchService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentSearchService.java
@@ -2,7 +2,7 @@ package uk.gov.pay.directdebit.payments.services;
 
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountNotFoundException;
-import uk.gov.pay.directdebit.payments.api.CollectPaymentResponse;
+import uk.gov.pay.directdebit.payments.api.PaymentResponse;
 import uk.gov.pay.directdebit.payments.api.PaymentViewResponse;
 import uk.gov.pay.directdebit.payments.api.PaymentViewValidator;
 import uk.gov.pay.directdebit.payments.dao.PaymentViewDao;
@@ -31,7 +31,7 @@ public class PaymentSearchService {
         return gatewayAccountDao.findByExternalId(searchParams.getGatewayExternalId())
                 .map(gatewayAccount -> {
                     PaymentViewSearchParams validatedSearchParams = paymentViewValidator.validateParams(searchParams);
-                    List<CollectPaymentResponse> viewListResponse = Collections.emptyList();
+                    List<PaymentResponse> viewListResponse = Collections.emptyList();
                     Long total = getTotal(validatedSearchParams);
                     if (total > 0) {
                         viewListResponse = getPaymentViewResultResponse(validatedSearchParams);
@@ -58,7 +58,7 @@ public class PaymentSearchService {
         return paymentViewDao.getPaymentViewCount(searchParams);
     }
 
-    private List<CollectPaymentResponse> getPaymentViewResultResponse(PaymentViewSearchParams searchParams) {
+    private List<PaymentResponse> getPaymentViewResultResponse(PaymentViewSearchParams searchParams) {
         return paymentViewDao.searchPaymentView(searchParams);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.directdebit.payments.services;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
@@ -11,7 +9,7 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderServiceId;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
-import uk.gov.pay.directdebit.payments.api.CollectPaymentResponse;
+import uk.gov.pay.directdebit.payments.api.PaymentResponse;
 import uk.gov.pay.directdebit.payments.dao.PaymentDao;
 import uk.gov.pay.directdebit.payments.exception.ChargeNotFoundException;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
@@ -22,25 +20,16 @@ import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentId;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.PaymentStatesGraph;
-import uk.gov.pay.directdebit.payments.model.Token;
 import uk.gov.pay.directdebit.tokens.services.TokenService;
 
 import javax.inject.Inject;
-import javax.ws.rs.core.UriInfo;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static javax.ws.rs.HttpMethod.GET;
-import static javax.ws.rs.HttpMethod.POST;
-import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.createLink;
-import static uk.gov.pay.directdebit.common.util.URIBuilder.nextUrl;
-import static uk.gov.pay.directdebit.common.util.URIBuilder.selfUriFor;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_SUBMITTED_TO_BANK;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_SUBMITTED_TO_PROVIDER;
@@ -48,7 +37,6 @@ import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.CHARGE
 import static uk.gov.pay.directdebit.payments.model.Payment.PaymentBuilder.aPayment;
 import static uk.gov.pay.directdebit.payments.model.Payment.PaymentBuilder.fromPayment;
 import static uk.gov.pay.directdebit.payments.model.PaymentStatesGraph.getStates;
-import static uk.gov.pay.directdebit.payments.resources.PaymentResource.CHARGE_API_PATH;
 
 public class PaymentService {
 
@@ -113,9 +101,9 @@ public class PaymentService {
         return paymentSubmittedToProviderFor(submittedPayment);
     }
     
-    public CollectPaymentResponse getPaymentWithExternalId(String paymentExternalId) {
+    public PaymentResponse getPaymentWithExternalId(String paymentExternalId) {
         Payment payment = findPaymentForExternalId(paymentExternalId);
-        return CollectPaymentResponse.from(payment);
+        return PaymentResponse.from(payment);
     }
 
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
@@ -11,7 +11,7 @@ import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
-import uk.gov.pay.directdebit.payments.api.CollectPaymentResponse;
+import uk.gov.pay.directdebit.payments.api.PaymentResponse;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
@@ -71,7 +71,7 @@ public class PaymentViewDaoIT {
                 .withPage(0L)
                 .withDisplaySize(100L)
                 .withSearchDateParams(searchDateParams);
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(3));
     }
 
@@ -97,14 +97,14 @@ public class PaymentViewDaoIT {
                 .withPage(2L)
                 .withDisplaySize(1L)
                 .withSearchDateParams(searchDateParams);
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
     }
 
     @Test
     public void shouldReturnAnEmptyList_whenNoMatchingGatewayAccounts() {
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams("invalid-external-id");
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.isEmpty(), is(true));
     }
 
@@ -132,7 +132,7 @@ public class PaymentViewDaoIT {
                 .withDisplaySize(100L)
                 .withFromDateString(zonedDateTime7DaysAgo.toString())
                 .withSearchDateParams(new SearchDateParams(zonedDateTime7DaysAgo, zonedDateTimeNow));
-        List<CollectPaymentResponse> paymentViewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> paymentViewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(paymentViewList.size(), is(2));
         assertThat(paymentViewList.get(0).getCreatedDate().isAfter(zonedDateTime7DaysAgo), is(true));
         assertThat(paymentViewList.get(0).getCreatedDate().isBefore(zonedDateTimeNow), is(true));
@@ -159,7 +159,7 @@ public class PaymentViewDaoIT {
         }
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withReference("bkh");
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(2));
         assertThat(viewList.get(0).getReference(), is(referenceList.get(2)));
         assertThat(viewList.get(1).getReference(), is(referenceList.get(0)));
@@ -184,7 +184,7 @@ public class PaymentViewDaoIT {
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withAmount(202L)
                 .withSearchDateParams(searchDateParams);
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
         assertThat(viewList.get(0).getReference(), is("ref2"));
     }
@@ -210,7 +210,7 @@ public class PaymentViewDaoIT {
                 .withPage(2L)
                 .withDisplaySize(100L)
                 .withSearchDateParams(searchDateParams);
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
     }
 
@@ -274,7 +274,7 @@ public class PaymentViewDaoIT {
                 .withMandateId(mandateFixture1.getExternalId().toString());
         Long count = paymentViewDao.getPaymentViewCount(searchParams);
         assertThat(count, is(3L));
-        List<CollectPaymentResponse> paymentViews = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> paymentViews = paymentViewDao.searchPaymentView(searchParams);
         assertThat(paymentViews.size(), is(3));
     }
 
@@ -305,7 +305,7 @@ public class PaymentViewDaoIT {
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withState("started");
 
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
     }
 
@@ -336,7 +336,7 @@ public class PaymentViewDaoIT {
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withState("pending");
 
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
     }
 
@@ -367,7 +367,7 @@ public class PaymentViewDaoIT {
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withState("cancelled");
 
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
     }
 
@@ -398,7 +398,7 @@ public class PaymentViewDaoIT {
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withState("success");
 
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
     }
 
@@ -445,7 +445,7 @@ public class PaymentViewDaoIT {
         PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withState("failed");
 
-        List<CollectPaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
+        List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(6));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentSearchServiceTest.java
@@ -14,7 +14,7 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.payers.model.Payer;
-import uk.gov.pay.directdebit.payments.api.CollectPaymentResponse;
+import uk.gov.pay.directdebit.payments.api.PaymentResponse;
 import uk.gov.pay.directdebit.payments.api.ExternalPaymentState;
 import uk.gov.pay.directdebit.payments.api.ExternalPaymentStateWithDetails;
 import uk.gov.pay.directdebit.payments.api.PaymentViewResponse;
@@ -40,7 +40,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
 import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
-import static uk.gov.pay.directdebit.payments.api.CollectPaymentResponse.CollectPaymentResponseBuilder.aCollectPaymentResponse;
+import static uk.gov.pay.directdebit.payments.api.PaymentResponse.PaymentResponseBuilder.aPaymentResponse;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
 
@@ -50,7 +50,7 @@ public class PaymentSearchServiceTest {
     public ExpectedException thrown = ExpectedException.none();
     private String gatewayAccountExternalId = RandomIdGenerator.newId();
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
-    private List<CollectPaymentResponse> paymentViewList = new ArrayList<>();
+    private List<PaymentResponse> paymentViewList = new ArrayList<>();
     @Mock
     private PaymentViewDao paymentViewDao;
     @Mock
@@ -63,7 +63,7 @@ public class PaymentSearchServiceTest {
     @Before
     public void setUp() {
         for (int i = 0; i < 4; i++) {
-            CollectPaymentResponse paymentResponse = aCollectPaymentResponse()
+            PaymentResponse paymentResponse = aPaymentResponse()
                     .withCreatedDate(createdDate)
                     .withState(new ExternalPaymentStateWithDetails(ExternalPaymentState.EXTERNAL_PENDING, "example_details"))
                     .withReference("Pay reference " + i)
@@ -128,7 +128,7 @@ public class PaymentSearchServiceTest {
                 .withName("J. Doe")
                 .withEmail("j.doe@mail.fake")
                 .toEntity();
-        List<CollectPaymentResponse> paymentViewList = new ArrayList<>();
+        List<PaymentResponse> paymentViewList = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             Payment payment = aPaymentFixture()
                     .withId((long) i)
@@ -138,7 +138,7 @@ public class PaymentSearchServiceTest {
                     .withDescription("Description" + i)
                     .withCreatedDate(createdDate)
                     .toEntity();
-            paymentViewList.add(aCollectPaymentResponse()
+            paymentViewList.add(aPaymentResponse()
                     .withPaymentExternalId(payment.getExternalId())
                     .withAmount(payment.getAmount())
                     .withReference(payment.getReference())
@@ -167,7 +167,7 @@ public class PaymentSearchServiceTest {
     public void shouldReturnNoRecords_whenPaginationSetToPage2AndNoDisplaySize() {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().withExternalId(gatewayAccountExternalId);
         GatewayAccount testGatewayAccount = gatewayAccountFixture.toEntity();
-        List<CollectPaymentResponse> paymentViewList = new ArrayList<>();
+        List<PaymentResponse> paymentViewList = new ArrayList<>();
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(testGatewayAccount));
         when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(18L);
         when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
@@ -14,7 +14,7 @@ import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
-import uk.gov.pay.directdebit.payments.api.CollectPaymentResponse;
+import uk.gov.pay.directdebit.payments.api.PaymentResponse;
 import uk.gov.pay.directdebit.payments.dao.PaymentDao;
 import uk.gov.pay.directdebit.payments.exception.ChargeNotFoundException;
 import uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture;
@@ -116,17 +116,17 @@ public class PaymentServiceTest {
     }
 
     @Test
-    public void shouldCreateACollectPaymentResponseFromAValidTransaction() {
-        var collectPaymentResponse = CollectPaymentResponse.from(paymentFixture.toEntity());
-        assertThat(collectPaymentResponse.getAmount(), is(paymentFixture.getAmount()));
-        assertThat(collectPaymentResponse.getPaymentExternalId(), is(paymentFixture.getExternalId()));
-        assertThat(collectPaymentResponse.getDescription(), is(paymentFixture.getDescription()));
-        assertThat(collectPaymentResponse.getReference(), is(paymentFixture.getReference()));
-        assertThat(collectPaymentResponse.getPaymentProvider(), is(gatewayAccountFixture.getPaymentProvider()));
+    public void shouldCreateAPaymentResponseFromAValidTransaction() {
+        var paymentResponse = PaymentResponse.from(paymentFixture.toEntity());
+        assertThat(paymentResponse.getAmount(), is(paymentFixture.getAmount()));
+        assertThat(paymentResponse.getPaymentExternalId(), is(paymentFixture.getExternalId()));
+        assertThat(paymentResponse.getDescription(), is(paymentFixture.getDescription()));
+        assertThat(paymentResponse.getReference(), is(paymentFixture.getReference()));
+        assertThat(paymentResponse.getPaymentProvider(), is(gatewayAccountFixture.getPaymentProvider()));
     }
     @Test
     public void shouldCreateATransactionResponseWithLinksFromAValidTransaction() {
-        var paymentResponse = CollectPaymentResponse.from(paymentFixture.toEntity());
+        var paymentResponse = PaymentResponse.from(paymentFixture.toEntity());
 
         assertThat(paymentResponse.getAmount(), is(paymentFixture.getAmount()));
         assertThat(paymentResponse.getDescription(), is(paymentFixture.getDescription()));


### PR DESCRIPTION
- Since the CollectPaymentResponse object has been generalised, replacing all
  instances of the previous PaymentResponse object, it makes sense to drop the
  'collect' prefix.
- This commit does so while changing instances of the builder and auxiliary
  classes that work with CollectPaymentResponse to match the new name