### PR TITLE
PP-5334 Return an error when Go Cardless account already linked

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <hamcrest.version>2.1</hamcrest.version>
         <rest-assured.version>4.0.0</rest-assured.version>
         <mockito.version>2.28.2</mockito.version>
-        <pay-java-commons.version>1.0.20190701105351</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190702102623</pay-java-commons.version>
         <surefire.version>2.22.2</surefire.version>
     </properties>
 

--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -23,6 +23,7 @@ import uk.gov.pay.directdebit.app.healthcheck.Database;
 import uk.gov.pay.directdebit.app.healthcheck.Ping;
 import uk.gov.pay.directdebit.common.exception.BadRequestExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.ConflictExceptionMapper;
+import uk.gov.pay.directdebit.common.exception.GoCardlessAccountAlreadyConnectedExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.JerseyViolationExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.InternalServerErrorExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.JsonMappingExceptionMapper;
@@ -127,6 +128,7 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
         environment.jersey().register(new JsonMappingExceptionMapper());
         environment.jersey().register(new NoAccessTokenExceptionMapper());
         environment.jersey().register(new UnlinkedGCMerchantAccountExceptionMapper());
+        environment.jersey().register(new GoCardlessAccountAlreadyConnectedExceptionMapper());
         initialiseMetrics(configuration, environment);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/GoCardlessAccountAlreadyConnectedException.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/GoCardlessAccountAlreadyConnectedException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.directdebit.common.exception;
+
+public class GoCardlessAccountAlreadyConnectedException extends RuntimeException {
+    public GoCardlessAccountAlreadyConnectedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/GoCardlessAccountAlreadyConnectedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/GoCardlessAccountAlreadyConnectedExceptionMapper.java
@@ -6,11 +6,11 @@ import uk.gov.pay.directdebit.common.model.ErrorResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
-public class UnlinkedGCMerchantAccountExceptionMapper implements ExceptionMapper<UnlinkedGCMerchantAccountException> {
+public class GoCardlessAccountAlreadyConnectedExceptionMapper implements ExceptionMapper<GoCardlessAccountAlreadyConnectedException> {
     @Override
-    public Response toResponse(UnlinkedGCMerchantAccountException e) {
+    public Response toResponse(GoCardlessAccountAlreadyConnectedException exception) {
         ErrorResponse errorResponse =
-                new ErrorResponse(ErrorIdentifier.GO_CARDLESS_ACCOUNT_NOT_LINKED, e.getMessage());
+                new ErrorResponse(ErrorIdentifier.GO_CARDLESS_ACCOUNT_ALREADY_LINKED_TO_ANOTHER_ACCOUNT, exception.getMessage());
         return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDao.java
@@ -10,6 +10,7 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.mapper.GatewayAccountMapper;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderAccessToken;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderServiceId;
 
@@ -43,4 +44,7 @@ public interface GatewayAccountDao {
     int updateAccessTokenAndOrganisation(@Bind("externalId") String externalId,
                                          @Bind("accessToken") PaymentProviderAccessToken accessToken,
                                          @Bind("organisation") PaymentProviderServiceId organisation);
+    
+    @SqlQuery("SELECT EXISTS (SELECT * FROM gateway_accounts where organisation = :organisation)")
+    boolean existsWithOrganisation(@Bind("organisation") GoCardlessOrganisationId organisation);
 }

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
@@ -254,4 +254,21 @@ public class GatewayAccountDaoIT {
         assertThat(foundGatewayAccount.get("access_token"), is("an-access-token"));
         assertThat(foundGatewayAccount.get("organisation"), is("an-organisation"));
     }
+
+    @Test
+    public void shouldReturnTrueWhenGatewayAccountWithOrganisationExists() {
+        var organisationId = GoCardlessOrganisationId.valueOf("ABC123");
+        gatewayAccountDao.insert(testGatewayAccount
+                .withOrganisation(organisationId)
+                .toEntity());
+        assertThat(gatewayAccountDao.existsWithOrganisation(organisationId), is(true));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenGatewayAccountWithOrganisationDoesNotExist() {
+        gatewayAccountDao.insert(testGatewayAccount
+                .withOrganisation(GoCardlessOrganisationId.valueOf("ABC123"))
+                .toEntity());
+        assertThat(gatewayAccountDao.existsWithOrganisation(GoCardlessOrganisationId.valueOf("XYZ789")), is(false));
+    }
 }


### PR DESCRIPTION
Return a 400 response when we try to exchange a Go Cardless access code
for an access token and the organisation ID in the response is already
stored for a different account.