### PR TITLE
PP-5318 Fix GoCardlessEvent persistence and depersistence

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
@@ -21,8 +21,8 @@ import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdArgumentFactory;
 public interface GoCardlessEventDao {
 
     @SqlUpdate("INSERT INTO gocardless_events(" +
-            " internal_event_id," +
-            " event_id, action," +
+            " event_id," +
+            " action," +
             " resource_type," +
             " json," +
             " details_cause," +
@@ -42,7 +42,6 @@ public interface GoCardlessEventDao {
             " links_subscription," +
             " created_at)" +
             " VALUES (" +
-            " :eventId," +
             " :goCardlessEventId," +
             " :action," +
             " :resourceType," +

--- a/src/main/java/uk/gov/pay/directdebit/events/dao/mapper/GoCardlessEventMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/mapper/GoCardlessEventMapper.java
@@ -21,7 +21,7 @@ public class GoCardlessEventMapper implements RowMapper<GoCardlessEvent> {
     public GoCardlessEvent map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
         var builder = GoCardlessEvent.GoCardlessEventBuilder.aGoCardlessEvent()
                 .withId(resultSet.getLong("id"))
-                .withEventId(resultSet.getLong("internal_event_id"))
+                .withInternalEventId(resultSet.getLong("internal_event_id"))
                 .withGoCardlessEventId(GoCardlessEventId.valueOf(resultSet.getString("event_id")))
                 .withAction(resultSet.getString("action"))
                 .withResourceType(GoCardlessResourceType.fromString(resultSet.getString("resource_type")))

--- a/src/main/java/uk/gov/pay/directdebit/events/dao/mapper/GoCardlessEventMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/mapper/GoCardlessEventMapper.java
@@ -21,8 +21,8 @@ public class GoCardlessEventMapper implements RowMapper<GoCardlessEvent> {
     public GoCardlessEvent map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
         var builder = GoCardlessEvent.GoCardlessEventBuilder.aGoCardlessEvent()
                 .withId(resultSet.getLong("id"))
-                .withEventId(resultSet.getLong("event_id"))
-                .withGoCardlessEventId(GoCardlessEventId.valueOf(resultSet.getString("gocardless_event_id")))
+                .withEventId(resultSet.getLong("internal_event_id"))
+                .withGoCardlessEventId(GoCardlessEventId.valueOf(resultSet.getString("event_id")))
                 .withAction(resultSet.getString("action"))
                 .withResourceType(GoCardlessResourceType.fromString(resultSet.getString("resource_type")))
                 .withJson(resultSet.getString("json"))

--- a/src/main/java/uk/gov/pay/directdebit/events/exception/GoCardlessEventHasNoMandateIdException.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/exception/GoCardlessEventHasNoMandateIdException.java
@@ -1,12 +1,13 @@
 package uk.gov.pay.directdebit.events.exception;
 
 import uk.gov.pay.directdebit.common.exception.NotFoundException;
+import uk.gov.pay.directdebit.payments.model.GoCardlessEventId;
 
 import static java.lang.String.format;
 
-public class EventHasNoMandateIdException extends NotFoundException {
+public class GoCardlessEventHasNoMandateIdException extends NotFoundException {
 
-    public EventHasNoMandateIdException(long id) {
+    public GoCardlessEventHasNoMandateIdException(GoCardlessEventId id) {
         super(format("Event with id: %s has no linked mandate", id));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/exception/GoCardlessEventHasNoPaymentIdException.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/exception/GoCardlessEventHasNoPaymentIdException.java
@@ -1,12 +1,13 @@
 package uk.gov.pay.directdebit.events.exception;
 
 import uk.gov.pay.directdebit.common.exception.NotFoundException;
+import uk.gov.pay.directdebit.payments.model.GoCardlessEventId;
 
 import static java.lang.String.format;
 
-public class EventHasNoPaymentIdException extends NotFoundException {
+public class GoCardlessEventHasNoPaymentIdException extends NotFoundException {
 
-    public EventHasNoPaymentIdException(long id) {
+    public GoCardlessEventHasNoPaymentIdException(GoCardlessEventId id) {
         super(format("Event with id: %s has no linked payment", id));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessEvent.java
@@ -11,7 +11,7 @@ public class GoCardlessEvent {
 
     private final Long id;
     private final String resourceId;
-    private Long eventId;
+    private Long internalEventId;
     private final GoCardlessEventId goCardlessEventId;
     //todo action should be typed (see https://developer.gocardless.com/api-reference/#events-payment-actions and the equivalent for other resource_types
     private final String action;
@@ -37,7 +37,7 @@ public class GoCardlessEvent {
     private GoCardlessEvent(GoCardlessEventBuilder goCardlessEventBuilder) {
         this.id = goCardlessEventBuilder.id;
         this.resourceId = goCardlessEventBuilder.resourceId;
-        this.eventId = goCardlessEventBuilder.eventId;
+        this.internalEventId = goCardlessEventBuilder.internalEventId;
         this.goCardlessEventId = goCardlessEventBuilder.goCardlessEventId;
         this.action = goCardlessEventBuilder.action;
         this.resourceType = goCardlessEventBuilder.resourceType;
@@ -61,16 +61,16 @@ public class GoCardlessEvent {
     }
     
     //TODO: This method will be removed once we stop creating generic events
-    public void setEventId(Long eventId) {
-        this.eventId = eventId;
+    public void setInternalEventId(Long internalEventId) {
+        this.internalEventId = internalEventId;
     }
     
     public Long getId() {
         return id;
     }
 
-    public Long getEventId() {
-        return eventId;
+    public Long getInternalEventId() {
+        return internalEventId;
     }
 
     public GoCardlessEventId getGoCardlessEventId() {
@@ -163,7 +163,7 @@ public class GoCardlessEvent {
         if (o == null || getClass() != o.getClass()) return false;
         GoCardlessEvent that = (GoCardlessEvent) o;
         return id.equals(that.id) &&
-                eventId.equals(that.eventId) &&
+                internalEventId.equals(that.internalEventId) &&
                 goCardlessEventId.equals(that.goCardlessEventId) &&
                 action.equals(that.action) &&
                 resourceType == that.resourceType &&
@@ -189,7 +189,7 @@ public class GoCardlessEvent {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, eventId, goCardlessEventId, action, resourceType, resourceId, json, detailsCause,
+        return Objects.hash(id, internalEventId, goCardlessEventId, action, resourceType, resourceId, json, detailsCause,
                 detailsDescription, detailsOrigin, detailsReasonCode, detailsScheme, linksMandate,
                 linksNewCustomerBankAccount, linksNewMandate, linksOrganisation, linksParentEvent,
                 linksPayment, linksPayout, linksPreviousCustomerBankAccount, linksRefund, linksSubscription,
@@ -198,7 +198,7 @@ public class GoCardlessEvent {
 
     public static final class GoCardlessEventBuilder {
         private Long id;
-        private Long eventId;
+        private Long internalEventId;
         private GoCardlessEventId goCardlessEventId;
         //todo action should be typed (see https://developer.gocardless.com/api-reference/#events-payment-actions and the equivalent for other resource_types
         private String action;
@@ -235,8 +235,8 @@ public class GoCardlessEvent {
             return this;
         }
 
-        public GoCardlessEventBuilder withEventId(Long eventId) {
-            this.eventId = eventId;
+        public GoCardlessEventBuilder withInternalEventId(Long internalEventId) {
+            this.internalEventId = internalEventId;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/GoCardlessEventService.java
@@ -23,8 +23,8 @@ public class GoCardlessEventService {
     }
 
     public void updateInternalEventId(GoCardlessEvent event) {
-        goCardlessEventDao.updateEventId(event.getId(), event.getEventId());
-        LOGGER.info("Updated gocardless event with gocardless event id {}, internal event id {} ", event.getGoCardlessEventId(), event.getEventId());
+        goCardlessEventDao.updateEventId(event.getId(), event.getInternalEventId());
+        LOGGER.info("Updated gocardless event with gocardless event id {}, internal event id {} ", event.getGoCardlessEventId(), event.getInternalEventId());
     }
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
@@ -42,7 +42,7 @@ public class WebhookGoCardlessService {
     }
 
     private void logUnknownResourceTypeForEvent(GoCardlessEvent event) {
-        LOGGER.info("unhandled resource type for event with id {} ", event.getEventId());
+        LOGGER.info("unhandled resource type for event with id {} ", event.getInternalEventId());
     }
 
     private GoCardlessActionHandler getHandlerFor(GoCardlessResourceType goCardlessResourceType) {

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessHandler.java
@@ -1,12 +1,13 @@
 package uk.gov.pay.directdebit.webhook.gocardless.services.handlers;
 
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.services.GoCardlessEventService;
 import uk.gov.pay.directdebit.payments.services.PaymentService;
+
+import java.util.Optional;
 
 public abstract class GoCardlessHandler implements GoCardlessActionHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(GoCardlessHandler.class);
@@ -24,9 +25,9 @@ public abstract class GoCardlessHandler implements GoCardlessActionHandler {
 
     public void handle(GoCardlessEvent event) {
         process(event).ifPresent((directDebitEvent) -> {
-            event.setEventId(directDebitEvent.getId());
+            event.setInternalEventId(directDebitEvent.getId());
             goCardlessService.updateInternalEventId(event);
-            LOGGER.info("handled gocardless event with id: {}, resource type: {}", event.getEventId(), event.getResourceType().toString());
+            LOGGER.info("handled gocardless event with id: {}, resource type: {}", event.getInternalEventId(), event.getResourceType().toString());
         });
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
@@ -3,7 +3,7 @@ package uk.gov.pay.directdebit.webhook.gocardless.services.handlers;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.directdebit.events.exception.EventHasNoMandateIdException;
+import uk.gov.pay.directdebit.events.exception.GoCardlessEventHasNoMandateIdException;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
 import uk.gov.pay.directdebit.mandate.services.MandateStateUpdateService;
@@ -89,7 +89,7 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
                 .map((handledAction -> {
                     Mandate mandate = mandateQueryService.findByPaymentProviderMandateId(
                             GOCARDLESS,
-                            event.getLinksMandate().orElseThrow(() -> new EventHasNoMandateIdException(event.getInternalEventId())),
+                            event.getLinksMandate().orElseThrow(() -> new GoCardlessEventHasNoMandateIdException(event.getGoCardlessEventId())),
                             event.getLinksOrganisation()
                     );
 

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
@@ -89,7 +89,7 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
                 .map((handledAction -> {
                     Mandate mandate = mandateQueryService.findByPaymentProviderMandateId(
                             GOCARDLESS,
-                            event.getLinksMandate().orElseThrow(() -> new EventHasNoMandateIdException(event.getEventId())),
+                            event.getLinksMandate().orElseThrow(() -> new EventHasNoMandateIdException(event.getInternalEventId())),
                             event.getLinksOrganisation()
                     );
 

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -3,7 +3,7 @@ package uk.gov.pay.directdebit.webhook.gocardless.services.handlers;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.directdebit.events.exception.EventHasNoPaymentIdException;
+import uk.gov.pay.directdebit.events.exception.GoCardlessEventHasNoPaymentIdException;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateException;
 import uk.gov.pay.directdebit.payments.exception.PaymentNotFoundException;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
@@ -51,7 +51,7 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
     @Override
     protected Optional<DirectDebitEvent> process(GoCardlessEvent event) {
         var goCardlessPaymentId = event.getLinksPayment()
-                .orElseThrow(() -> new EventHasNoPaymentIdException(event.getInternalEventId()));
+                .orElseThrow(() -> new GoCardlessEventHasNoPaymentIdException(event.getGoCardlessEventId()));
 
         var goCardlessOrganisationId = event.getLinksOrganisation();
 

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -51,7 +51,7 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
     @Override
     protected Optional<DirectDebitEvent> process(GoCardlessEvent event) {
         var goCardlessPaymentId = event.getLinksPayment()
-                .orElseThrow(() -> new EventHasNoPaymentIdException(event.getEventId()));
+                .orElseThrow(() -> new EventHasNoPaymentIdException(event.getInternalEventId()));
 
         var goCardlessOrganisationId = event.getLinksOrganisation();
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessDirectDebitDirectDebitEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/GoCardlessDirectDebitDirectDebitEventDaoIT.java
@@ -29,6 +29,7 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.payments.fixtures.DirectDebitEventFixture.aDirectDebitEventFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
@@ -84,7 +85,6 @@ public class GoCardlessDirectDebitDirectDebitEventDaoIT {
                 .withId(EVENT_ID)
                 .insert(testContext.getJdbi());
         goCardlessEvent = GoCardlessEventFixture.aGoCardlessEventFixture()
-                .withEventId(EVENT_ID)
                 .withGoCardlessEventId(GOCARDLESS_EVENT_ID)
                 .withAction(GOCARDLESS_ACTION)
                 .withResourceType(GOCARDLESS_RESOURCE_TYPE)
@@ -113,7 +113,7 @@ public class GoCardlessDirectDebitDirectDebitEventDaoIT {
         Long id = goCardlessEventDao.insert(goCardlessEvent);
         Map<String, Object> foundGoCardlessEvent = testContext.getDatabaseTestHelper().getGoCardlessEventById(id);
         assertThat(foundGoCardlessEvent.get("id"), is(id));
-        assertThat(foundGoCardlessEvent.get("internal_event_id"), is(EVENT_ID));
+        assertThat(foundGoCardlessEvent.get("internal_event_id"), is(nullValue()));
         assertThat(foundGoCardlessEvent.get("event_id"), is(GOCARDLESS_EVENT_ID.toString()));
         assertThat(foundGoCardlessEvent.get("action"), is(GOCARDLESS_ACTION));
         assertThat(foundGoCardlessEvent.get("resource_type"), is(GOCARDLESS_RESOURCE_TYPE.toString()));

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GoCardlessEventFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/GoCardlessEventFixture.java
@@ -319,7 +319,7 @@ public class GoCardlessEventFixture implements DbFixture<GoCardlessEventFixture,
     public GoCardlessEvent toEntity() {
         return aGoCardlessEvent()
                 .withId(id)
-                .withEventId(eventId)
+                .withInternalEventId(eventId)
                 .withGoCardlessEventId(goCardlessEventId)
                 .withAction(action)
                 .withResourceId(resourceId)

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/api/GoCardlessWebhookParserTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/api/GoCardlessWebhookParserTest.java
@@ -55,7 +55,7 @@ public class GoCardlessWebhookParserTest {
         List<GoCardlessEvent> parsedEvents = parser.parse(payload);
 
         GoCardlessEvent firstEvent = parsedEvents.get(0);
-        assertThat(firstEvent.getEventId(), is(nullValue()));
+        assertThat(firstEvent.getInternalEventId(), is(nullValue()));
         assertThat(firstEvent.getId(), is(nullValue()));
         assertThat(firstEvent.getAction(), is(ACTION));
         assertThat(firstEvent.getResourceType(), is(RESOURCE_TYPE));
@@ -86,7 +86,7 @@ public class GoCardlessWebhookParserTest {
         List<GoCardlessEvent> parsedEvents = parser.parse(payload);
 
         GoCardlessEvent firstEvent = parsedEvents.get(0);
-        assertThat(firstEvent.getEventId(), is(nullValue()));
+        assertThat(firstEvent.getInternalEventId(), is(nullValue()));
         assertThat(firstEvent.getId(), is(nullValue()));
         assertThat(firstEvent.getAction(), is(ACTION));
         assertThat(firstEvent.getResourceType(), is(RESOURCE_TYPE));
@@ -110,7 +110,7 @@ public class GoCardlessWebhookParserTest {
         assertThat(firstEvent.getLinksPayout(), is(nullValue()));
         
         GoCardlessEvent secondEvent = parsedEvents.get(1);
-        assertThat(secondEvent.getEventId(), is(nullValue()));
+        assertThat(secondEvent.getInternalEventId(), is(nullValue()));
         assertThat(secondEvent.getId(), is(nullValue()));
         assertThat(secondEvent.getAction(), is(secondEventAction));
         assertThat(secondEvent.getResourceType(), is(secondEventResourceType));
@@ -123,7 +123,7 @@ public class GoCardlessWebhookParserTest {
 
 
         GoCardlessEvent thirdEvent = parsedEvents.get(2);
-        assertThat(thirdEvent.getEventId(), is(nullValue()));
+        assertThat(thirdEvent.getInternalEventId(), is(nullValue()));
         assertThat(thirdEvent.getId(), is(nullValue()));
         assertThat(thirdEvent.getAction(), is(thirdEventAction));
         assertThat(thirdEvent.getResourceType(), is(thirdEventResourceType));

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
@@ -10,7 +10,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.directdebit.events.exception.EventHasNoMandateIdException;
+import uk.gov.pay.directdebit.events.exception.GoCardlessEventHasNoMandateIdException;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
@@ -281,7 +281,7 @@ public class GoCardlessMandateHandlerTest {
                 .withLinksMandate(null)
                 .toEntity());
         
-        thrown.expect(EventHasNoMandateIdException.class);
+        thrown.expect(GoCardlessEventHasNoMandateIdException.class);
         goCardlessMandateHandler.handle(goCardlessEvent);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
@@ -93,10 +93,10 @@ public class GoCardlessMandateHandlerTest {
                 directDebitEvent);
 
         goCardlessMandateHandler.handle(goCardlessEvent);
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(goCardlessService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -112,10 +112,10 @@ public class GoCardlessMandateHandlerTest {
         goCardlessMandateHandler.handle(goCardlessEvent);
 
         verify(mandateStateUpdateService, never()).mandatePendingFor(mandateFixture.toEntity());
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(goCardlessService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -129,10 +129,10 @@ public class GoCardlessMandateHandlerTest {
                 directDebitEvent);
         goCardlessMandateHandler.handle(goCardlessEvent);
 
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(goCardlessService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -148,11 +148,11 @@ public class GoCardlessMandateHandlerTest {
 
         goCardlessMandateHandler.handle(goCardlessEvent);
 
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mandateStateUpdateService, never()).mandatePendingFor(mandateFixture.toEntity());
         verify(goCardlessService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -167,10 +167,10 @@ public class GoCardlessMandateHandlerTest {
 
         goCardlessMandateHandler.handle(goCardlessEvent);
 
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(goCardlessService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -184,11 +184,11 @@ public class GoCardlessMandateHandlerTest {
                 directDebitEvent));
         goCardlessMandateHandler.handle(goCardlessEvent);
 
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mandateStateUpdateService, never()).mandatePendingFor(mandateFixture.toEntity());
         verify(goCardlessService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -207,10 +207,10 @@ public class GoCardlessMandateHandlerTest {
 
         verify(paymentService).paymentFailedWithoutEmailFor(paymentFixture.toEntity());
         verify(mandateStateUpdateService).mandateFailedFor(mandateFixture.toEntity());
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(goCardlessService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -230,10 +230,10 @@ public class GoCardlessMandateHandlerTest {
 
         verify(paymentService).paymentFailedWithoutEmailFor(paymentFixture.toEntity());
         verify(mandateStateUpdateService).mandateCancelledFor(mandateFixture.toEntity());
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(goCardlessService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -254,7 +254,7 @@ public class GoCardlessMandateHandlerTest {
         verify(mandateStateUpdateService).mandateCancelledFor(mandateFixture.toEntity());
         verify(goCardlessService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -269,7 +269,7 @@ public class GoCardlessMandateHandlerTest {
                 goCardlessEventFixture.getLinksOrganisation())).thenReturn(mandateFixture.toEntity());
 
         goCardlessMandateHandler.handle(goCardlessEvent);
-        verify(goCardlessEvent, never()).setEventId(anyLong());
+        verify(goCardlessEvent, never()).setInternalEventId(anyLong());
         verify(goCardlessService, never()).storeEvent(goCardlessEvent);
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
@@ -10,7 +10,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.directdebit.events.exception.EventHasNoPaymentIdException;
+import uk.gov.pay.directdebit.events.exception.GoCardlessEventHasNoPaymentIdException;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.payments.exception.PaymentNotFoundException;
@@ -212,7 +212,7 @@ public class GoCardlessPaymentHandlerTest {
                 .withLinksPayment(null)
                 .toEntity();
 
-        thrown.expect(EventHasNoPaymentIdException.class);
+        thrown.expect(GoCardlessEventHasNoPaymentIdException.class);
         goCardlessPaymentHandler.handle(goCardlessEvent);
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
@@ -73,10 +73,10 @@ public class GoCardlessPaymentHandlerTest {
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
         verify(mockedPaymentService).paymentPaidOutFor(payment);
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessEventService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        Assert.assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        Assert.assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         Assert.assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -92,10 +92,10 @@ public class GoCardlessPaymentHandlerTest {
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
         verify(mockedPaymentService).paymentAcknowledgedFor(payment);
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessEventService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        Assert.assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        Assert.assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         Assert.assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -111,10 +111,10 @@ public class GoCardlessPaymentHandlerTest {
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
         verify(mockedPaymentService).payoutPaidFor(payment);
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessEventService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        Assert.assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        Assert.assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         Assert.assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -129,10 +129,10 @@ public class GoCardlessPaymentHandlerTest {
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
         verify(mockedPaymentService).paymentSubmittedFor(payment);
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessEventService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        Assert.assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        Assert.assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         Assert.assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -147,10 +147,10 @@ public class GoCardlessPaymentHandlerTest {
 
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessEventService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        Assert.assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        Assert.assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         Assert.assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -166,10 +166,10 @@ public class GoCardlessPaymentHandlerTest {
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
         verify(mockedPaymentService).paymentFailedWithEmailFor(payment);
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessEventService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        Assert.assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        Assert.assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         Assert.assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
@@ -183,10 +183,10 @@ public class GoCardlessPaymentHandlerTest {
 
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessEventService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        Assert.assertThat(storedGoCardlessEvent.getEventId(), is(directDebitEvent.getId()));
+        Assert.assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
         Assert.assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessHandlerTest.java
@@ -1,9 +1,6 @@
 package uk.gov.pay.directdebit.webhook.gocardless.services.handlers;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -17,6 +14,10 @@ import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.services.GoCardlessEventService;
 import uk.gov.pay.directdebit.payments.services.PaymentService;
 import uk.gov.pay.directdebit.webhook.gocardless.services.GoCardlessAction;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
 import static org.mockito.Mockito.verify;
 
@@ -51,7 +52,7 @@ public class GoCardlessHandlerTest {
             }
         };
         goCardlessHandler.handle(goCardlessEvent);
-        verify(goCardlessEvent).setEventId(directDebitEvent.getId());
+        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessService).updateInternalEventId(goCardlessEvent);
     }
 }


### PR DESCRIPTION
- Stop inserting a new `GoCardlessEvent` to the `gocardless_events` table with `GoCardlessEvent.eventId` as the value for the `internal_event_id` column because it will always be null
- Map the` internal_event_id column` (not `event_id`) to `GoCardlessEvent.eventId`
- Map the `event_id` column (not the non-existent `gocardless_event_id`) to `GoCardlessEvent.goCardlessEventId`
- In `GoCardlessEvent`, rename `eventId` to `internalEventId` to match the column name in the `gocardless_events` database table because the table also has an `eventId` column (which maps to `goCardlessEventId`) and it’s confusing

This is almost certainly easier to review commit by commit.