### PR TITLE
PP-5300: Update sandbox payment with provider id and charge date

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
@@ -4,16 +4,18 @@ import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.common.model.subtype.SunName;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
-import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
 import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.SortCode;
+import uk.gov.pay.directdebit.payments.dao.PaymentDao;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentFixture;
 import uk.gov.pay.directdebit.payments.model.Payment;
@@ -26,21 +28,25 @@ import java.util.Optional;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SandboxServiceTest {
-
-
+    
     private SandboxService service;
 
     private GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture();
     private MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture);
 
+    @Mock
+    protected PaymentDao paymentDao;
+
     @Before
     public void setUp() {
-        service = new SandboxService();
+        service = new SandboxService(paymentDao);
     }
 
     @Test
@@ -62,10 +68,12 @@ public class SandboxServiceTest {
         Mandate mandate = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).toEntity();
         Payment payment = PaymentFixture.aPaymentFixture().withMandateFixture(mandateFixture).toEntity();
 
-        PaymentProviderPaymentIdAndChargeDate collectResponse = service.collect(mandate, payment);
+        PaymentProviderPaymentIdAndChargeDate providerPaymentIdAndChargeDate = service.collect(mandate, payment);
 
-        assertThat(collectResponse.getChargeDate(), is(LocalDateMatchers
+        assertThat(providerPaymentIdAndChargeDate.getChargeDate(), is(LocalDateMatchers
                 .within(1, ChronoUnit.DAYS, LocalDate.now().plusDays(4))));
+        
+        verify(paymentDao).updateProviderIdAndChargeDate(any(Payment.class));
     }
 
     @Test


### PR DESCRIPTION
Testing of story PP-5300 showed that the provider_id wasn't present when getting a sandbox direct debit payment. This PR fixes it.