### PR TITLE
PP-5377 Disallow Payment Creation on Invalid Mandate State

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <hamcrest.version>2.1</hamcrest.version>
         <rest-assured.version>4.0.0</rest-assured.version>
         <mockito.version>2.28.2</mockito.version>
-        <pay-java-commons.version>1.0.20190702102623</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190703115143</pay-java-commons.version>
         <surefire.version>2.22.2</surefire.version>
     </properties>
 

--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -27,6 +27,7 @@ import uk.gov.pay.directdebit.common.exception.GoCardlessAccountAlreadyConnected
 import uk.gov.pay.directdebit.common.exception.JerseyViolationExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.InternalServerErrorExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.JsonMappingExceptionMapper;
+import uk.gov.pay.directdebit.common.exception.MandateStateInvalidExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.NoAccessTokenExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.NotFoundExceptionMapper;
 import uk.gov.pay.directdebit.common.exception.PreconditionFailedExceptionMapper;
@@ -128,6 +129,7 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
         environment.jersey().register(new JsonMappingExceptionMapper());
         environment.jersey().register(new NoAccessTokenExceptionMapper());
         environment.jersey().register(new UnlinkedGCMerchantAccountExceptionMapper());
+        environment.jersey().register(new MandateStateInvalidExceptionMapper());
         environment.jersey().register(new GoCardlessAccountAlreadyConnectedExceptionMapper());
         initialiseMetrics(configuration, environment);
     }

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/MandateStateInvalidExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/MandateStateInvalidExceptionMapper.java
@@ -18,7 +18,7 @@ public class MandateStateInvalidExceptionMapper implements ExceptionMapper<Manda
     @Override
     public Response toResponse(MandateStateInvalidException exception) {
         LOGGER.error(exception.getMessage());
-        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.MANDATE_STATE_INVALID, exception.getMessage());
         return Response.status(500).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/MandateStateInvalidExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/MandateStateInvalidExceptionMapper.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.directdebit.common.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.model.ErrorIdentifier;
+import uk.gov.pay.directdebit.common.model.ErrorResponse;
+import uk.gov.pay.directdebit.mandate.exception.MandateStateInvalidException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class MandateStateInvalidExceptionMapper implements ExceptionMapper<MandateStateInvalidException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MandateStateInvalidExceptionMapper.class);
+
+    @Override
+    public Response toResponse(MandateStateInvalidException exception) {
+        LOGGER.error(exception.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        return Response.status(500).entity(errorResponse).type(APPLICATION_JSON).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/exception/MandateStateInvalidException.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/exception/MandateStateInvalidException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.directdebit.mandate.exception;
+
+import uk.gov.pay.directdebit.common.exception.InternalServerErrorException;
+
+public class MandateStateInvalidException extends InternalServerErrorException {
+    public MandateStateInvalidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
+import uk.gov.pay.directdebit.mandate.exception.MandateStateInvalidException;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequest;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequestValidator;
 import uk.gov.pay.directdebit.payments.api.PaymentResponse;
@@ -57,6 +58,10 @@ public class PaymentResource {
         LOGGER.info("Received collect payment from mandate request");
         collectPaymentRequestValidator.validate(collectPaymentRequestMap);
         Payment paymentToCollect = collectService.collect(gatewayAccount, CollectPaymentRequest.of(collectPaymentRequestMap));
+        if(!paymentService.isPaymentMandateStateValid(paymentToCollect)) {
+            throw new MandateStateInvalidException("Mandate state invalid for mandateId: " +
+                    paymentToCollect.getMandate().getExternalId());
+        }
         PaymentResponse response = PaymentResponse.from(paymentToCollect);
         return Response.status(SC_CREATED).entity(response).build();
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentResource.java
@@ -58,10 +58,6 @@ public class PaymentResource {
         LOGGER.info("Received collect payment from mandate request");
         collectPaymentRequestValidator.validate(collectPaymentRequestMap);
         Payment paymentToCollect = collectService.collect(gatewayAccount, CollectPaymentRequest.of(collectPaymentRequestMap));
-        if(!paymentService.isPaymentMandateStateValid(paymentToCollect)) {
-            throw new MandateStateInvalidException("Mandate state invalid for mandateId: " +
-                    paymentToCollect.getMandate().getExternalId());
-        }
         PaymentResponse response = PaymentResponse.from(paymentToCollect);
         return Response.status(SC_CREATED).entity(response).build();
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
@@ -7,6 +7,7 @@ import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderServiceId;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
 import uk.gov.pay.directdebit.payments.api.PaymentResponse;
@@ -204,5 +205,11 @@ public class PaymentService {
 
     public Optional<DirectDebitEvent> findPaymentSubmittedEventFor(Payment payment) {
         return directDebitEventService.findBy(payment.getId(), CHARGE, PAYMENT_SUBMITTED_TO_BANK);
+    }
+    
+    public boolean isPaymentMandateStateValid(Payment payment) {
+        return payment.getMandate().getState().equals(MandateState.SUBMITTED) || 
+                payment.getMandate().getState().equals(MandateState.PENDING)  ||
+                payment.getMandate().getState().equals(MandateState.ACTIVE);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -77,6 +77,7 @@ public class PublicApiContractTest {
         testMandate.withGatewayAccountFixture(testGatewayAccount)
                 .withExternalId(MandateExternalId.valueOf(params.get("mandate_id")))
                 .withPayerFixture(PayerFixture.aPayerFixture())
+                .withState(MandateState.PENDING)
                 .insert(app.getTestContext().getJdbi());
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -336,6 +336,7 @@ public class PaymentResourceIT {
                 .body(postBody)
                 .post(requestPath)
                 .then()
+                .body("error_identifier", is("MANDATE_STATE_INVALID"))
                 .statusCode(500);
 
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -20,6 +20,7 @@ import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentFixture;
@@ -29,31 +30,27 @@ import javax.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
+import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
+import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
 import static uk.gov.pay.directdebit.payments.resources.PaymentResource.CHARGE_API_PATH;
 import static uk.gov.pay.directdebit.util.GoCardlessStubs.stubCreatePayment;
 import static uk.gov.pay.directdebit.util.GoCardlessStubs.stubGetCreditor;
 import static uk.gov.pay.directdebit.util.NumberMatcher.isNumber;
-import static uk.gov.pay.directdebit.util.ResponseContainsLinkMatcher.containsLink;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
@@ -97,10 +94,11 @@ public class PaymentResourceIT {
 
     @Test
     public void shouldCollectAPayment_forSandbox() throws Exception {
-        PayerFixture payerFixture = PayerFixture.aPayerFixture();
-        MandateFixture mandateFixture = MandateFixture.aMandateFixture()
+        PayerFixture payerFixture = aPayerFixture();
+        MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(testGatewayAccount)
                 .withPayerFixture(payerFixture)
+                .withState(MandateState.PENDING)
                 .insert(testContext.getJdbi());
         String accountExternalId = testGatewayAccount.getExternalId();
         String expectedReference = "Test reference";
@@ -164,10 +162,11 @@ public class PaymentResourceIT {
 
     @Test
     public void shouldCollectAPayment_withNoDescription() throws Exception {
-        PayerFixture payerFixture = PayerFixture.aPayerFixture();
-        MandateFixture mandateFixture = MandateFixture.aMandateFixture()
+        PayerFixture payerFixture = aPayerFixture();
+        MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(testGatewayAccount)
                 .withPayerFixture(payerFixture)
+                .withState(MandateState.PENDING)
                 .insert(testContext.getJdbi());
         String accountExternalId = testGatewayAccount.getExternalId();
         String expectedReference = "Test reference";
@@ -194,12 +193,13 @@ public class PaymentResourceIT {
     public void shouldCollectAPayment_forGoCardless() throws Exception {
         GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()
                 .withPaymentProvider(PaymentProvider.GOCARDLESS).insert(testContext.getJdbi());
-        PayerFixture payerFixture = PayerFixture.aPayerFixture();
+        PayerFixture payerFixture = aPayerFixture();
         GoCardlessMandateId goCardlessMandate = GoCardlessMandateId.valueOf("aGoCardlessMandateId");
-        Mandate mandate = MandateFixture.aMandateFixture()
+        Mandate mandate = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withPaymentProviderId(goCardlessMandate)
                 .withPayerFixture(payerFixture)
+                .withState(MandateState.PENDING)
                 .insert(testContext.getJdbi())
                 .toEntity();
         
@@ -288,7 +288,7 @@ public class PaymentResourceIT {
 
         String accountExternalId = testGatewayAccount.getExternalId();
 
-        MandateFixture mandateFixture = MandateFixture.aMandateFixture()
+        MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(testGatewayAccount)
                 .insert(testContext.getJdbi());
 
@@ -309,6 +309,35 @@ public class PaymentResourceIT {
                 .body(JSON_STATE_STATUS_KEY, is(paymentFixture.getState().toExternal().getStatus()))
                 .body(JSON_STATE_FINISHED_KEY, is(false))
                 .body(JSON_STATE_DETAILS_KEY, is("example_details"));
+    }
+    
+    @Test
+    public void shouldTriggerAnInvalidMandateStateException() throws Exception {
+        String accountExternalId = testGatewayAccount.getExternalId();
+        PayerFixture payerFixture = aPayerFixture();
+        MandateFixture mandateFixture = aMandateFixture()
+                .withGatewayAccountFixture(testGatewayAccount)
+                .withPayerFixture(payerFixture)
+                .withState(MandateState.CANCELLED)
+                .insert(testContext.getJdbi());
+
+        String postBody = new ObjectMapper().writeValueAsString(ImmutableMap.builder()
+                .put(JSON_AMOUNT_KEY, AMOUNT)
+                .put(JSON_REFERENCE_KEY, "Test description")
+                .put(JSON_DESCRIPTION_KEY, "Test description")
+                .put(JSON_GATEWAY_ACC_KEY, accountExternalId)
+                .put(JSON_MANDATE_ID_KEY, mandateFixture.getExternalId().toString())
+                .build());
+
+        String requestPath = "/v1/api/accounts/{accountId}/charges/collect"
+                .replace("{accountId}", accountExternalId);
+
+        ValidatableResponse response = givenSetup()
+                .body(postBody)
+                .post(requestPath)
+                .then()
+                .statusCode(500);
+
     }
     
     private PaymentFixture createTransactionFixtureWith(MandateFixture mandateFixture, PaymentState paymentState) {

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/CollectServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/CollectServiceTest.java
@@ -9,6 +9,7 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.exception.MandateNotFoundException;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
 import uk.gov.pay.directdebit.payments.api.CollectPaymentRequest;
@@ -39,7 +40,7 @@ public class CollectServiceTest {
 
     private GatewayAccount gatewayAccount = GatewayAccountFixture.aGatewayAccountFixture().withExternalId(GATEWAY_ACCOUNT_EXTERNAL_ID).toEntity();
 
-    private Mandate mandate = MandateFixture.aMandateFixture().withExternalId(MANDATE_EXTERNAL_ID).toEntity();
+    private Mandate mandate = MandateFixture.aMandateFixture().withExternalId(MANDATE_EXTERNAL_ID).withState(MandateState.PENDING).toEntity();
     
     private CollectPaymentRequest collectPaymentRequest = new CollectPaymentRequest(MANDATE_EXTERNAL_ID, AMOUNT, DESCRIPTION, REFERENCE);
     


### PR DESCRIPTION
- If a mandate has an invalid state and cannot take payments, currently the payment is accepted then an error occurs further down the line of the user journey.
- This fix changes that and does not allow payments to be created if a mandate has an invalid state, instead an error is returned from DD connector which will be handled in publicapi.