### PR TITLE
PP-5318 Update GoCardless mandate state based on all events

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
@@ -4,14 +4,21 @@ import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.events.dao.mapper.GoCardlessEventMapper;
 import uk.gov.pay.directdebit.events.model.GoCardlessOrganisationIdArgumentFactory;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdArgumentFactory;
+
+import java.util.Optional;
+import java.util.Set;
 
 @RegisterArgumentFactory(GoCardlessEventIdArgumentFactory.class)
 @RegisterArgumentFactory(GoCardlessMandateIdArgumentFactory.class)
@@ -65,6 +72,40 @@ public interface GoCardlessEventDao {
     @GetGeneratedKeys
     Long insert(@BindBean GoCardlessEvent goCardlessEvent);
 
-    @SqlUpdate("UPDATE gocardless_events t SET internal_event_id = :eventId WHERE t.id = :id")
+    @SqlUpdate("UPDATE gocardless_events SET internal_event_id = :eventId WHERE id = :id")
     int updateEventId(@Bind("id") Long id, @Bind("eventId") Long eventId);
+    
+    @SqlQuery("SELECT id, " +
+            "internal_event_id, " +
+            "event_id, " +
+            "action, " +
+            "created_at, " +
+            "details_cause, " +
+            "details_description, " +
+            "details_origin, " +
+            "details_reason_code, " +
+            "details_scheme, " +
+            "resource_type," +
+            "links_mandate, " +
+            "links_new_customer_bank_account, " +
+            "links_new_mandate, " +
+            "links_organisation, " +
+            "links_parent_event, " +
+            "links_payment, " +
+            "links_payout, " +
+            "links_previous_customer_bank_account, " +
+            "links_refund, " +
+            "links_subscription, " +
+            "json, " +
+            "event_id " +
+            "FROM gocardless_events " +
+            "WHERE links_mandate = :linksMandate " +
+            "AND links_organisation = :linksOrganisation " +
+            "AND action IN (<applicableActions>) " +
+            "ORDER BY created_at DESC " +
+            "LIMIT 1")
+    Optional<GoCardlessEvent> findLatestApplicableEventForMandate(@Bind("linksMandate") GoCardlessMandateId goCardlessMandateId,
+                                                                        @Bind("linksOrganisation") GoCardlessOrganisationId goCardlessOrganisationId,
+                                                                        @BindList("applicableActions") Set<String> applicableActions);
+
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -114,6 +114,13 @@ public interface MandateDao {
     @SqlUpdate("UPDATE mandates m SET state = :state WHERE m.id = :id")
     int updateState(@Bind("id") Long id, @Bind("state") MandateState mandateState);
 
+    @SqlUpdate("UPDATE mandates m SET state = :state FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
+            "AND g.id = m.gateway_account_id AND g.organisation = :providerServiceId AND g.payment_provider = :provider")
+    int updateStateByPaymentProviderMandateId(@Bind("provider") PaymentProvider paymentProvider,
+                                              @Bind("providerServiceId") PaymentProviderServiceId paymentProviderServiceId,
+                                              @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
+                                              @Bind("state") MandateState mandateState);
+
     @SqlUpdate("UPDATE mandates m SET mandate_reference = :mandateBankStatementReference, payment_provider_id = :paymentProviderMandateId WHERE m.id = :id")
     int updateReferenceAndPaymentProviderId(@BindBean Mandate mandate);
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
@@ -16,10 +16,6 @@ import javax.inject.Inject;
 
 import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.fromMandate;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_ACTIVE;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_CANCELLED;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_FAILED;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.MANDATE_PENDING;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.TOKEN_EXCHANGED;
 
 
@@ -62,8 +58,7 @@ public class MandateStateUpdateService {
     }
 
     public DirectDebitEvent mandateActiveFor(Mandate mandate) {
-        Mandate updatedMandate = updateStateFor(mandate, MANDATE_ACTIVE);
-        return directDebitEventService.registerMandateActiveEventFor(updatedMandate);
+        return directDebitEventService.registerMandateActiveEventFor(mandate);
     }
 
     public void mandateExpiredFor(Mandate mandate) {
@@ -72,20 +67,17 @@ public class MandateStateUpdateService {
     }
 
     public DirectDebitEvent mandateFailedFor(Mandate mandate) {
-        Mandate newMandate = updateStateFor(mandate, MANDATE_FAILED);
-        userNotificationService.sendMandateFailedEmailFor(newMandate);
-        return directDebitEventService.registerMandateFailedEventFor(newMandate);
+        userNotificationService.sendMandateFailedEmailFor(mandate);
+        return directDebitEventService.registerMandateFailedEventFor(mandate);
     }
 
     public DirectDebitEvent mandateCancelledFor(Mandate mandate) {
-        Mandate newMandate = updateStateFor(mandate, MANDATE_CANCELLED);
-        userNotificationService.sendMandateCancelledEmailFor(newMandate);
-        return directDebitEventService.registerMandateCancelledEventFor(newMandate);
+        userNotificationService.sendMandateCancelledEmailFor(mandate);
+        return directDebitEventService.registerMandateCancelledEventFor(mandate);
     }
 
     public DirectDebitEvent mandatePendingFor(Mandate mandate) {
-        Mandate newMandate = updateStateFor(mandate, MANDATE_PENDING);
-        return directDebitEventService.registerMandatePendingEventFor(newMandate);
+        return directDebitEventService.registerMandatePendingEventFor(mandate);
     }
 
     public Mandate receiveDirectDebitDetailsFor(Mandate mandate) {

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculator.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculator.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.directdebit.mandate.services.gocardless;
+
+import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
+import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static uk.gov.pay.directdebit.mandate.model.MandateState.ACTIVE;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.CANCELLED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.FAILED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED;
+
+class GoCardlessMandateStateCalculator {
+
+    private final GoCardlessEventDao goCardlessEventDao;
+
+    private static final Map<String, MandateState> GOCARDLESS_ACTION_TO_MANDATE_STATE = Map.of(
+            "created", CREATED,
+            "submitted", SUBMITTED,
+            "active", ACTIVE,
+            "cancelled", CANCELLED,
+            "failed", FAILED
+    );
+
+    static final Set<String> GOCARDLESS_ACTIONS_THAT_CHANGE_STATE = GOCARDLESS_ACTION_TO_MANDATE_STATE.keySet();
+
+    @Inject
+    GoCardlessMandateStateCalculator(GoCardlessEventDao goCardlessEventDao) {
+        this.goCardlessEventDao = goCardlessEventDao;
+    }
+
+    Optional<MandateState> calculate(GoCardlessMandateId goCardlessMandateId, GoCardlessOrganisationId goCardlessOrganisationId) {
+        return goCardlessEventDao.findLatestApplicableEventForMandate(goCardlessMandateId, goCardlessOrganisationId, GOCARDLESS_ACTIONS_THAT_CHANGE_STATE)
+                .map(GoCardlessEvent::getAction)
+                .map(GOCARDLESS_ACTION_TO_MANDATE_STATE::get);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdater.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdater.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.directdebit.mandate.services.gocardless;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+import uk.gov.pay.directdebit.mandate.dao.MandateDao;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+
+import javax.inject.Inject;
+
+import static java.lang.String.format;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
+
+public class GoCardlessMandateStateUpdater {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoCardlessMandateStateUpdater.class);
+
+    private final MandateDao mandateDao;
+    private final GoCardlessMandateStateCalculator goCardlessMandateStateCalculator;
+
+    @Inject
+    GoCardlessMandateStateUpdater(MandateDao mandateDao, GoCardlessMandateStateCalculator goCardlessMandateStateCalculator) {
+        this.mandateDao = mandateDao;
+        this.goCardlessMandateStateCalculator = goCardlessMandateStateCalculator;
+    }
+
+    public void updateState(GoCardlessMandateId goCardlessMandateId, GoCardlessOrganisationId goCardlessOrganisationId) {
+        goCardlessMandateStateCalculator.calculate(goCardlessMandateId, goCardlessOrganisationId)
+                .ifPresentOrElse(state -> {
+                    int updated = mandateDao.updateStateByPaymentProviderMandateId(GOCARDLESS, goCardlessOrganisationId, goCardlessMandateId, state);
+                    if (updated == 1) {
+                        LOGGER.info(format("Updated status of GoCardless mandate %s for organisation %s to %s", goCardlessMandateId, goCardlessOrganisationId,
+                                state));
+                    } else {
+                        LOGGER.error(format("Could not update status of GoCardless mandate %s for organisation %s to %s because the mandate was not found",
+                                goCardlessMandateId, goCardlessOrganisationId, state));
+                    }
+                }, () -> LOGGER.info(format("Asked to update the status for GoCardless mandate %s for organisation %s " +
+                                "but there appear to be no events stored that require it to be updated", goCardlessMandateId, goCardlessOrganisationId)));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessMandateIdAndOrganisationId.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessMandateIdAndOrganisationId.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.directdebit.payments.model;
+
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+
+import java.util.Objects;
+
+public class GoCardlessMandateIdAndOrganisationId {
+
+    private final GoCardlessMandateId goCardlessMandateId;
+    private final GoCardlessOrganisationId goCardlessOrganisationId;
+
+    public GoCardlessMandateIdAndOrganisationId(GoCardlessMandateId goCardlessMandateId, GoCardlessOrganisationId goCardlessOrganisationId) {
+        this.goCardlessMandateId = Objects.requireNonNull(goCardlessMandateId);
+        this.goCardlessOrganisationId = Objects.requireNonNull(goCardlessOrganisationId);
+    }
+    
+    public GoCardlessMandateId getGoCardlessMandateId() {
+        return goCardlessMandateId;
+    }
+
+    public GoCardlessOrganisationId getGoCardlessOrganisationId() {
+        return goCardlessOrganisationId;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == GoCardlessMandateIdAndOrganisationId.class) {
+            var that = (GoCardlessMandateIdAndOrganisationId) other;
+            return this.goCardlessMandateId.equals(that.goCardlessMandateId) && this.goCardlessOrganisationId.equals(that.goCardlessOrganisationId);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 37 * goCardlessMandateId.hashCode() ^ goCardlessOrganisationId.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "GoCardlessMandateId: " + goCardlessMandateId + ", GoCardlessOrganisationId: " + goCardlessOrganisationId;
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoITest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoITest.java
@@ -4,18 +4,27 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture;
+import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.payments.model.GoCardlessEventId;
 
 import java.sql.Timestamp;
+import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
+import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture.aGoCardlessEventFixture;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
@@ -33,7 +42,7 @@ public class GoCardlessEventDaoITest {
 
     @Test
     public void shouldInsertAnEvent() {
-        GoCardlessEventFixture goCardlessEventFixture = GoCardlessEventFixture.aGoCardlessEventFixture();
+        GoCardlessEventFixture goCardlessEventFixture = aGoCardlessEventFixture();
 
         Long id = goCardlessEventDao.insert(goCardlessEventFixture.toEntity());
 
@@ -61,6 +70,58 @@ public class GoCardlessEventDaoITest {
         assertThat(goCardlessEvent.get("links_refund"), is(goCardlessEventFixture.getLinksRefund()));
         assertThat(goCardlessEvent.get("links_subscription"), is(goCardlessEventFixture.getLinksSubscription()));
         assertThat(goCardlessEvent.get("created_at"), is(Timestamp.from(goCardlessEventFixture.getCreatedAt().toInstant())));
+    }
+
+    @Test
+    public void shouldFindLatestApplicableEventForMandate() {
+        GoCardlessEventFixture latestEvent = aGoCardlessEventFixture().withLinksMandate(GoCardlessMandateId.valueOf("Mandate ID we want"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("Organisation ID we want"))
+                .withAction("Action we want")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 5, 12, 0, 0, 0, UTC))
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("This is the latest applicable event"));
+
+        GoCardlessEventFixture earlierEvent = aGoCardlessEventFixture().withLinksMandate(GoCardlessMandateId.valueOf("Mandate ID we want"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("Organisation ID we want"))
+                .withAction("Action we want")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 5, 11, 59, 59, 999_999_999, UTC))
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("This is an earlier event"));
+
+        GoCardlessEventFixture laterEventWrongAction = aGoCardlessEventFixture().withLinksMandate(GoCardlessMandateId.valueOf("Mandate ID we want"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("Organisation ID we want"))
+                .withAction("Different action")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 5, 13, 0, 0, 0, UTC))
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("This is a later event but with the wrong action"));
+
+        GoCardlessEventFixture laterEventWrongMandateId = aGoCardlessEventFixture().withLinksMandate(GoCardlessMandateId.valueOf("Different mandate ID"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("Organisation ID we want"))
+                .withAction("Action we want")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 5, 13, 0, 0, 0, UTC))
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("This is an later event but with the wrong mandate ID"));
+
+        GoCardlessEventFixture laterEventWrongOrganisationId = aGoCardlessEventFixture().withLinksMandate(GoCardlessMandateId.valueOf("Mandate ID we want"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("Different organisation ID"))
+                .withAction("Action we want")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 5, 13, 0, 0, 0, UTC))
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("This is an later event with the wrong organisation ID"));
+
+        goCardlessEventDao.insert(latestEvent.toEntity());
+        goCardlessEventDao.insert(earlierEvent.toEntity());
+        goCardlessEventDao.insert(laterEventWrongAction.toEntity());
+        goCardlessEventDao.insert(laterEventWrongMandateId.toEntity());
+        goCardlessEventDao.insert(laterEventWrongOrganisationId.toEntity());
+
+        GoCardlessEvent event = goCardlessEventDao.findLatestApplicableEventForMandate(GoCardlessMandateId.valueOf("Mandate ID we want"),
+                GoCardlessOrganisationId.valueOf("Organisation ID we want"), Set.of("Action we want")).get();
+
+        assertThat(event.getGoCardlessEventId(), is(GoCardlessEventId.valueOf("This is the latest applicable event")));
+    }
+
+    @Test
+    public void shouldNotFindAnythingIfNoApplicableEventForMandate() {
+        Optional<GoCardlessEvent> event = goCardlessEventDao.findLatestApplicableEventForMandate(GoCardlessMandateId.valueOf("Mandate ID we want"),
+                GoCardlessOrganisationId.valueOf("Organisation ID we want"), Set.of("Action we want"));
+        
+        assertThat(event, is(Optional.empty()));
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateServiceTest.java
@@ -22,12 +22,9 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.fromMandate;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.ACTIVE;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.AWAITING_DIRECT_DEBIT_DETAILS;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.CANCELLED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.EXPIRED;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.FAILED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.PENDING;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED;
 
@@ -58,14 +55,11 @@ public class MandateStateUpdateServiceTest {
                 .aMandateFixture()
                 .withState(PENDING)
                 .toEntity();
-        Mandate expectedMandateWithFailedStatus = fromMandate(mandate)
-                .withState(FAILED)
-                .build();
 
         service.mandateFailedFor(mandate);
 
-        verify(mockedDirectDebitEventService).registerMandateFailedEventFor(expectedMandateWithFailedStatus);
-        verify(mockedUserNotificationService).sendMandateFailedEmailFor(expectedMandateWithFailedStatus);
+        verify(mockedDirectDebitEventService).registerMandateFailedEventFor(mandate);
+        verify(mockedUserNotificationService).sendMandateFailedEmailFor(mandate);
     }
 
     @Test
@@ -75,14 +69,10 @@ public class MandateStateUpdateServiceTest {
                 .withState(PENDING)
                 .toEntity();
 
-        Mandate expectedMandateWithCancelledStatus = fromMandate(mandate)
-                .withState(CANCELLED)
-                .build();
-
         service.mandateCancelledFor(mandate);
 
-        verify(mockedDirectDebitEventService).registerMandateCancelledEventFor(expectedMandateWithCancelledStatus);
-        verify(mockedUserNotificationService).sendMandateCancelledEmailFor(expectedMandateWithCancelledStatus);
+        verify(mockedDirectDebitEventService).registerMandateCancelledEventFor(mandate);
+        verify(mockedUserNotificationService).sendMandateCancelledEmailFor(mandate);
     }
 
     @Test
@@ -91,13 +81,10 @@ public class MandateStateUpdateServiceTest {
                 .aMandateFixture()
                 .withState(PENDING)
                 .toEntity();
-        Mandate expectedMandateWithActiveStatus = fromMandate(mandate)
-                .withState(ACTIVE)
-                .build();
 
         service.mandateActiveFor(mandate);
 
-        verify(mockedDirectDebitEventService).registerMandateActiveEventFor(expectedMandateWithActiveStatus);
+        verify(mockedDirectDebitEventService).registerMandateActiveEventFor(mandate);
     }
 
     @Test
@@ -171,13 +158,10 @@ public class MandateStateUpdateServiceTest {
                 .aMandateFixture()
                 .withState(SUBMITTED)
                 .toEntity();
-        Mandate expectedMandateWithPendingState = fromMandate(mandate)
-                .withState(PENDING)
-                .build();
 
         service.mandatePendingFor(mandate);
 
-        verify(mockedDirectDebitEventService).registerMandatePendingEventFor(expectedMandateWithPendingState);
+        verify(mockedDirectDebitEventService).registerMandatePendingEventFor(mandate);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
@@ -1,0 +1,110 @@
+package uk.gov.pay.directdebit.mandate.services.gocardless;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
+import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+
+import java.util.Optional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessMandateStateCalculator.GOCARDLESS_ACTIONS_THAT_CHANGE_STATE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoCardlessMandateStateCalculatorTest {
+
+    @Mock
+    private GoCardlessMandateId mockGoCardlessMandateId;
+
+    @Mock
+    private GoCardlessOrganisationId mockGoCardlessOrganisationId;
+    
+    @Mock
+    private GoCardlessEvent mockGoCardlessEvent;
+
+    @Mock
+    private GoCardlessEventDao mockGoCardlessEventDao;
+
+    private GoCardlessMandateStateCalculator goCardlessMandateStateCalculator;
+
+    @Before
+    public void setUp() {
+        given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(mockGoCardlessMandateId, mockGoCardlessOrganisationId,
+                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE)).willReturn(Optional.of(mockGoCardlessEvent));
+
+        goCardlessMandateStateCalculator = new GoCardlessMandateStateCalculator(mockGoCardlessEventDao);
+    }
+
+    @Test
+    public void createdActionMapsToCreatedState() {
+        given(mockGoCardlessEvent.getAction()).willReturn("created");
+
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+        
+        assertThat(mandateState.get(), is(MandateState.CREATED));
+    }
+
+    @Test
+    public void submittedActionMapsToSubmittedState() {
+        given(mockGoCardlessEvent.getAction()).willReturn("submitted");
+
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+
+        assertThat(mandateState.get(), is(MandateState.SUBMITTED));
+    }
+
+    @Test
+    public void activeActionMapsToActiveState() {
+        given(mockGoCardlessEvent.getAction()).willReturn("active");
+
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+
+        assertThat(mandateState.get(), is(MandateState.ACTIVE));
+    }
+
+    @Test
+    public void cancelledActionMapsToCancelledState() {
+        given(mockGoCardlessEvent.getAction()).willReturn("cancelled");
+
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+
+        assertThat(mandateState.get(), is(MandateState.CANCELLED));
+    }
+
+    @Test
+    public void failedActionMapsToFailedState() {
+        given(mockGoCardlessEvent.getAction()).willReturn("failed");
+
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+
+        assertThat(mandateState.get(), is(MandateState.FAILED));
+    }
+
+    @Test
+    public void unrecognisedActionMapsToNothing() {
+        given(mockGoCardlessEvent.getAction()).willReturn("eaten_by_wolves");
+
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+
+        assertThat(mandateState, is(Optional.empty()));
+    }
+
+    @Test
+    public void noApplicableEventsMapsToNothing() {
+        given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(mockGoCardlessMandateId, mockGoCardlessOrganisationId,
+                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE)).willReturn(Optional.empty());
+
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+
+        assertThat(mandateState, is(Optional.empty()));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdaterTest.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.directdebit.mandate.services.gocardless;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+import uk.gov.pay.directdebit.mandate.dao.MandateDao;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.PENDING;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoCardlessMandateStateUpdaterTest {
+
+    private static final GoCardlessMandateId GOCARDLESS_MANDATE_ID = GoCardlessMandateId.valueOf("MD123");
+    private static final GoCardlessOrganisationId GOCARDLESS_ORGANISATION_ID = GoCardlessOrganisationId.valueOf("OR123");
+
+    @Mock
+    private MandateDao mockMandateDao;
+
+    @Mock
+    private GoCardlessMandateStateCalculator mockGoCardlessMandateStateCalculator;
+
+    private GoCardlessMandateStateUpdater mockGoCardlessMandateStateUpdater;
+
+    @Before
+    public void setUp() {
+        mockGoCardlessMandateStateUpdater = new GoCardlessMandateStateUpdater(mockMandateDao, mockGoCardlessMandateStateCalculator);
+    }
+
+    @Test
+    public void updatesMandateWithStateReturnedByCalculator() {
+        given(mockGoCardlessMandateStateCalculator.calculate(GOCARDLESS_MANDATE_ID, GOCARDLESS_ORGANISATION_ID))
+                .willReturn(Optional.of(PENDING));
+
+        mockGoCardlessMandateStateUpdater.updateState(GOCARDLESS_MANDATE_ID, GOCARDLESS_ORGANISATION_ID);
+
+        verify(mockMandateDao).updateStateByPaymentProviderMandateId(GOCARDLESS, GOCARDLESS_ORGANISATION_ID, GOCARDLESS_MANDATE_ID, PENDING);
+    }
+
+    @Test
+    public void updatesNothingIfCalculatorDoesNotReturnState() {
+        given(mockGoCardlessMandateStateCalculator.calculate(GOCARDLESS_MANDATE_ID, GOCARDLESS_ORGANISATION_ID))
+                .willReturn(Optional.empty());
+
+        mockGoCardlessMandateStateUpdater.updateState(GOCARDLESS_MANDATE_ID, GOCARDLESS_ORGANISATION_ID);
+
+        verify(mockMandateDao, never()).updateStateByPaymentProviderMandateId(any(), any(), any(), any());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/DatabaseTestHelper.java
@@ -168,28 +168,6 @@ public class DatabaseTestHelper {
         );
     }
 
-    public Map<String, Object> getGoCardlessMandateById(Long id) {
-        return jdbi.withHandle(handle ->
-                handle
-                        .createQuery("SELECT * from gocardless_mandates g WHERE g.id = :id")
-                        .bind("id", id)
-                        .mapToMap()
-                        .findFirst()
-                        .get()
-        );
-    }
-
-    public Map<String, Object> getGoCardlessPaymentById(Long id) {
-        return jdbi.withHandle(handle ->
-                handle
-                        .createQuery("SELECT * from gocardless_payments g WHERE g.id = :id")
-                        .bind("id", id)
-                        .mapToMap()
-                        .findFirst()
-                        .get()
-        );
-    }
-
     public Map<String, Object> getGoCardlessEventById(Long id) {
         return jdbi.withHandle(handle ->
                 handle

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessMandateStateUpdater;
 import uk.gov.pay.directdebit.payments.exception.GoCardlessMandateNotFoundException;
 import uk.gov.pay.directdebit.payments.exception.GoCardlessPaymentNotFoundException;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
@@ -33,12 +34,15 @@ public class WebhookGoCardlessServiceTest {
     private GoCardlessPaymentHandler mockedGoCardlessPaymentHandler;
     @Mock
     private GoCardlessMandateHandler mockedGoCardlessMandateHandler;
+    @Mock
+    private GoCardlessMandateStateUpdater mockedGoCardlessMandateStateUpdater;
 
     private WebhookGoCardlessService webhookGoCardlessService;
 
     @Before
     public void setUp() {
-        webhookGoCardlessService = new WebhookGoCardlessService(mockedGoCardlessEventService, mockedGoCardlessPaymentHandler, mockedGoCardlessMandateHandler);
+        webhookGoCardlessService = new WebhookGoCardlessService(mockedGoCardlessEventService, mockedGoCardlessPaymentHandler, mockedGoCardlessMandateHandler,
+                mockedGoCardlessMandateStateUpdater);
     }
 
     @Test


### PR DESCRIPTION
After receiving a webhook from GoCardless, update the state of each affected mandate by examining all of the events stored for that mandate, rather than the one that’s just been received. This means that we can handle webhook events from GoCardless for mandates being received out of order.