### PR TITLE
PP-5318 MandateLookupKey for updating mandate state from GC events

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
@@ -10,11 +10,10 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.events.dao.mapper.GoCardlessEventMapper;
 import uk.gov.pay.directdebit.events.model.GoCardlessOrganisationIdArgumentFactory;
-import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
-import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventIdArgumentFactory;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdArgumentFactory;
 
 import java.util.Optional;
@@ -99,13 +98,12 @@ public interface GoCardlessEventDao {
             "json, " +
             "event_id " +
             "FROM gocardless_events " +
-            "WHERE links_mandate = :linksMandate " +
-            "AND links_organisation = :linksOrganisation " +
+            "WHERE links_mandate = :goCardlessMandateId " +
+            "AND links_organisation = :goCardlessOrganisationId " +
             "AND action IN (<applicableActions>) " +
             "ORDER BY created_at DESC " +
             "LIMIT 1")
-    Optional<GoCardlessEvent> findLatestApplicableEventForMandate(@Bind("linksMandate") GoCardlessMandateId goCardlessMandateId,
-                                                                        @Bind("linksOrganisation") GoCardlessOrganisationId goCardlessOrganisationId,
-                                                                        @BindList("applicableActions") Set<String> applicableActions);
+    Optional<GoCardlessEvent> findLatestApplicableEventForMandate(@BindBean GoCardlessMandateIdAndOrganisationId goCardlessMandateIdAndOrganisationId,
+                                                                  @BindList("applicableActions") Set<String> applicableActions);
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -116,10 +116,16 @@ public interface MandateDao {
 
     @SqlUpdate("UPDATE mandates m SET state = :state FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
             "AND g.id = m.gateway_account_id AND g.organisation = :providerServiceId AND g.payment_provider = :provider")
-    int updateStateByPaymentProviderMandateId(@Bind("provider") PaymentProvider paymentProvider,
-                                              @Bind("providerServiceId") PaymentProviderServiceId paymentProviderServiceId,
-                                              @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
-                                              @Bind("state") MandateState mandateState);
+    int updateStateByPaymentProviderMandateIdAndOrganisationId(@Bind("provider") PaymentProvider paymentProvider,
+                                                               @Bind("providerServiceId") PaymentProviderServiceId paymentProviderServiceId,
+                                                               @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
+                                                               @Bind("state") MandateState mandateState);
+
+    @SqlUpdate("UPDATE mandates m SET state = :state FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
+            "AND g.id = m.gateway_account_id AND g.organisation IS NULL AND g.payment_provider = :provider")
+    int updateStateByPaymentProviderMandateIdAndOrganisationId(@Bind("provider") PaymentProvider paymentProvider,
+                                                               @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
+                                                               @Bind("state") MandateState mandateState);
 
     @SqlUpdate("UPDATE mandates m SET mandate_reference = :mandateBankStatementReference, payment_provider_id = :paymentProviderMandateId WHERE m.id = :id")
     int updateReferenceAndPaymentProviderId(@BindBean Mandate mandate);

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateLookupKey.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateLookupKey.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.directdebit.mandate.model;
+
+public interface MandateLookupKey {
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/PaymentProviderMandateId.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/PaymentProviderMandateId.java
@@ -2,7 +2,7 @@ package uk.gov.pay.directdebit.mandate.model;
 
 import uk.gov.pay.commons.model.WrappedStringValue;
 
-public abstract class PaymentProviderMandateId extends WrappedStringValue {
+public abstract class PaymentProviderMandateId extends WrappedStringValue implements MandateLookupKey {
 
     PaymentProviderMandateId(String paymentProviderId) {
         super(paymentProviderId);

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/SandboxMandateId.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/SandboxMandateId.java
@@ -3,7 +3,7 @@ package uk.gov.pay.directdebit.mandate.model;
 /**
  * The ID of the mandate used by Sandbox provider
  */
-public class SandboxMandateId extends PaymentProviderMandateId {
+public class SandboxMandateId extends PaymentProviderMandateId implements MandateLookupKey {
 
     private SandboxMandateId(String sandboxMandateId) {
         super(sandboxMandateId);

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateService.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.directdebit.mandate.services;
+
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.mandate.dao.MandateDao;
+import uk.gov.pay.directdebit.mandate.model.MandateLookupKey;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
+import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateId;
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
+
+import javax.inject.Inject;
+
+public class MandateUpdateService {
+
+    private final MandateDao mandateDao;
+
+    @Inject
+    MandateUpdateService(MandateDao mandateDao) {
+        this.mandateDao = mandateDao;
+    }
+
+    public int updateStateByPaymentProviderMandateId(PaymentProvider paymentProvider, MandateLookupKey mandateLookupKey, MandateState mandateState) {
+        if (mandateLookupKey.getClass() == GoCardlessMandateIdAndOrganisationId.class) {
+            var goCardlessMandateIdAndOrganisationId = (GoCardlessMandateIdAndOrganisationId) mandateLookupKey;
+            return mandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(paymentProvider, goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId(),
+                    goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(), mandateState);
+        } else if (mandateLookupKey.getClass() == SandboxMandateId.class) {
+            var paymentProviderMandateId = (PaymentProviderMandateId) mandateLookupKey;
+            return mandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(paymentProvider, paymentProviderMandateId, mandateState);
+        }
+        throw new IllegalArgumentException("Unrecognised MandateLookupKey of type " + mandateLookupKey.getClass());
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculator.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculator.java
@@ -1,10 +1,9 @@
 package uk.gov.pay.directdebit.mandate.services.gocardless;
 
 import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
-import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
-import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 
 import javax.inject.Inject;
 import java.util.Map;
@@ -36,8 +35,8 @@ class GoCardlessMandateStateCalculator {
         this.goCardlessEventDao = goCardlessEventDao;
     }
 
-    Optional<MandateState> calculate(GoCardlessMandateId goCardlessMandateId, GoCardlessOrganisationId goCardlessOrganisationId) {
-        return goCardlessEventDao.findLatestApplicableEventForMandate(goCardlessMandateId, goCardlessOrganisationId, GOCARDLESS_ACTIONS_THAT_CHANGE_STATE)
+    Optional<MandateState> calculate(GoCardlessMandateIdAndOrganisationId goCardlessMandateIdAndOrganisationId) {
+        return goCardlessEventDao.findLatestApplicableEventForMandate(goCardlessMandateIdAndOrganisationId, GOCARDLESS_ACTIONS_THAT_CHANGE_STATE)
                 .map(GoCardlessEvent::getAction)
                 .map(GOCARDLESS_ACTION_TO_MANDATE_STATE::get);
     }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdater.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdater.java
@@ -2,9 +2,8 @@ package uk.gov.pay.directdebit.mandate.services.gocardless;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
-import uk.gov.pay.directdebit.mandate.dao.MandateDao;
-import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+import uk.gov.pay.directdebit.mandate.services.MandateUpdateService;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 
 import javax.inject.Inject;
 
@@ -15,28 +14,32 @@ public class GoCardlessMandateStateUpdater {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(GoCardlessMandateStateUpdater.class);
 
-    private final MandateDao mandateDao;
+    private final MandateUpdateService mandateUpdateService;
     private final GoCardlessMandateStateCalculator goCardlessMandateStateCalculator;
 
     @Inject
-    GoCardlessMandateStateUpdater(MandateDao mandateDao, GoCardlessMandateStateCalculator goCardlessMandateStateCalculator) {
-        this.mandateDao = mandateDao;
+    GoCardlessMandateStateUpdater(MandateUpdateService mandateUpdateService, GoCardlessMandateStateCalculator goCardlessMandateStateCalculator) {
+        this.mandateUpdateService = mandateUpdateService;
         this.goCardlessMandateStateCalculator = goCardlessMandateStateCalculator;
     }
 
-    public void updateState(GoCardlessMandateId goCardlessMandateId, GoCardlessOrganisationId goCardlessOrganisationId) {
-        goCardlessMandateStateCalculator.calculate(goCardlessMandateId, goCardlessOrganisationId)
+    public void updateState(GoCardlessMandateIdAndOrganisationId goCardlessMandateIdAndOrganisationId) {
+        goCardlessMandateStateCalculator.calculate(goCardlessMandateIdAndOrganisationId)
                 .ifPresentOrElse(state -> {
-                    int updated = mandateDao.updateStateByPaymentProviderMandateId(GOCARDLESS, goCardlessOrganisationId, goCardlessMandateId, state);
+                    int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, goCardlessMandateIdAndOrganisationId, state);
                     if (updated == 1) {
-                        LOGGER.info(format("Updated status of GoCardless mandate %s for organisation %s to %s", goCardlessMandateId, goCardlessOrganisationId,
+                        LOGGER.info(format("Updated status of GoCardless mandate %s for organisation %s to %s", 
+                                goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(),
+                                goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId(),
                                 state));
                     } else {
                         LOGGER.error(format("Could not update status of GoCardless mandate %s for organisation %s to %s because the mandate was not found",
-                                goCardlessMandateId, goCardlessOrganisationId, state));
+                                goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(),
+                                goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId(), state));
                     }
                 }, () -> LOGGER.info(format("Asked to update the status for GoCardless mandate %s for organisation %s " +
-                                "but there appear to be no events stored that require it to be updated", goCardlessMandateId, goCardlessOrganisationId)));
+                                "but there appear to be no events stored that require it to be updated",
+                        goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(), goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId())));
     }
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessMandateIdAndOrganisationId.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/GoCardlessMandateIdAndOrganisationId.java
@@ -2,10 +2,11 @@ package uk.gov.pay.directdebit.payments.model;
 
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+import uk.gov.pay.directdebit.mandate.model.MandateLookupKey;
 
 import java.util.Objects;
 
-public class GoCardlessMandateIdAndOrganisationId {
+public class GoCardlessMandateIdAndOrganisationId implements MandateLookupKey {
 
     private final GoCardlessMandateId goCardlessMandateId;
     private final GoCardlessOrganisationId goCardlessOrganisationId;

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
@@ -57,13 +57,7 @@ public class WebhookGoCardlessService {
     }
 
     private void updateStateForMandateEvents(List<GoCardlessEvent> eventsThatAffectMandates) {
-        determineAffectedMandates(eventsThatAffectMandates)
-                .forEach(goCardlessMandateIdAndOrganisationId ->
-                        goCardlessMandateStateUpdater.updateState(
-                                goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(),
-                                goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId()
-                        )
-                );
+        determineAffectedMandates(eventsThatAffectMandates).forEach(goCardlessMandateStateUpdater::updateState);
     }
 
     private Set<GoCardlessMandateIdAndOrganisationId> determineAffectedMandates(List<GoCardlessEvent> eventsThatAffectMandates) {

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoITest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoITest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventId;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
@@ -110,16 +111,18 @@ public class GoCardlessEventDaoITest {
         goCardlessEventDao.insert(laterEventWrongMandateId.toEntity());
         goCardlessEventDao.insert(laterEventWrongOrganisationId.toEntity());
 
-        GoCardlessEvent event = goCardlessEventDao.findLatestApplicableEventForMandate(GoCardlessMandateId.valueOf("Mandate ID we want"),
-                GoCardlessOrganisationId.valueOf("Organisation ID we want"), Set.of("Action we want")).get();
+        GoCardlessEvent event = goCardlessEventDao.findLatestApplicableEventForMandate(
+                new GoCardlessMandateIdAndOrganisationId(
+                        GoCardlessMandateId.valueOf("Mandate ID we want"), GoCardlessOrganisationId.valueOf("Organisation ID we want")),
+                Set.of("Action we want")).get();
 
         assertThat(event.getGoCardlessEventId(), is(GoCardlessEventId.valueOf("This is the latest applicable event")));
     }
 
     @Test
     public void shouldNotFindAnythingIfNoApplicableEventForMandate() {
-        Optional<GoCardlessEvent> event = goCardlessEventDao.findLatestApplicableEventForMandate(GoCardlessMandateId.valueOf("Mandate ID we want"),
-                GoCardlessOrganisationId.valueOf("Organisation ID we want"), Set.of("Action we want"));
+        Optional<GoCardlessEvent> event = goCardlessEventDao.findLatestApplicableEventForMandate(new GoCardlessMandateIdAndOrganisationId(
+                GoCardlessMandateId.valueOf("Mandate ID we want"), GoCardlessOrganisationId.valueOf("Organisation ID we want")), Set.of("Action we want"));
         
         assertThat(event, is(Optional.empty()));
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateServiceTest.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.directdebit.mandate.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+import uk.gov.pay.directdebit.mandate.dao.MandateDao;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+import uk.gov.pay.directdebit.mandate.model.MandateLookupKey;
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.ignoreStubs;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.PENDING;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MandateUpdateServiceTest {
+    
+    private static final SandboxMandateId SANDBOX_MANDATE_ID = SandboxMandateId.valueOf("Sandy");
+    private static final GoCardlessMandateId GOCARDLESS_MANDATE_ID = GoCardlessMandateId.valueOf("MD123");
+    private static final GoCardlessOrganisationId GOCARDLESS_ORGANISATION_ID = GoCardlessOrganisationId.valueOf("OR123");
+    private static final GoCardlessMandateIdAndOrganisationId GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID =
+            new GoCardlessMandateIdAndOrganisationId(GOCARDLESS_MANDATE_ID, GOCARDLESS_ORGANISATION_ID);
+
+    @Mock
+    private MandateDao mockMandateDao;
+    
+    private MandateUpdateService mandateUpdateService;
+    
+    @Before
+    public void setUp() {
+        mandateUpdateService = new MandateUpdateService(mockMandateDao);
+    }
+
+    @Test
+    public void updateStateByPaymentProviderMandateIdWithGoCardlessMandateIdAndOrganisationIdReturnsUpdateCount() {
+        given(mockMandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(SANDBOX, SANDBOX_MANDATE_ID, PENDING)).willReturn(1);
+
+        int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(SANDBOX, SANDBOX_MANDATE_ID, PENDING);
+
+        assertThat(updated, is(1));
+
+        verifyZeroInteractions(ignoreStubs(mockMandateDao));
+    }
+
+    @Test
+    public void updateStateByPaymentProviderMandateIdWithSandboxMandateIdReturnsUpdateCount() {
+        given(mockMandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(GOCARDLESS, GOCARDLESS_ORGANISATION_ID, GOCARDLESS_MANDATE_ID, PENDING)).willReturn(1);
+
+        int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID, PENDING);
+
+        assertThat(updated, is(1));
+
+        verifyZeroInteractions(ignoreStubs(mockMandateDao));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void updateStateByPaymentProviderMandateIdWithUnrecognisedTypeThrowsException() {
+        
+        mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, new UnrecognisedMandateLookupKeyImplementation(), PENDING);
+    }
+    
+    private static class UnrecognisedMandateLookupKeyImplementation implements MandateLookupKey {
+        
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
@@ -6,10 +6,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
-import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
-import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 
 import java.util.Optional;
 
@@ -22,10 +21,7 @@ import static uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessManda
 public class GoCardlessMandateStateCalculatorTest {
 
     @Mock
-    private GoCardlessMandateId mockGoCardlessMandateId;
-
-    @Mock
-    private GoCardlessOrganisationId mockGoCardlessOrganisationId;
+    private GoCardlessMandateIdAndOrganisationId mockGoCardlessMandateIdAndOrganisationId;
     
     @Mock
     private GoCardlessEvent mockGoCardlessEvent;
@@ -37,8 +33,8 @@ public class GoCardlessMandateStateCalculatorTest {
 
     @Before
     public void setUp() {
-        given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(mockGoCardlessMandateId, mockGoCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE)).willReturn(Optional.of(mockGoCardlessEvent));
+        given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(mockGoCardlessMandateIdAndOrganisationId, GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                .willReturn(Optional.of(mockGoCardlessEvent));
 
         goCardlessMandateStateCalculator = new GoCardlessMandateStateCalculator(mockGoCardlessEventDao);
     }
@@ -47,7 +43,7 @@ public class GoCardlessMandateStateCalculatorTest {
     public void createdActionMapsToCreatedState() {
         given(mockGoCardlessEvent.getAction()).willReturn("created");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
         
         assertThat(mandateState.get(), is(MandateState.CREATED));
     }
@@ -56,7 +52,7 @@ public class GoCardlessMandateStateCalculatorTest {
     public void submittedActionMapsToSubmittedState() {
         given(mockGoCardlessEvent.getAction()).willReturn("submitted");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
         assertThat(mandateState.get(), is(MandateState.SUBMITTED));
     }
@@ -65,7 +61,7 @@ public class GoCardlessMandateStateCalculatorTest {
     public void activeActionMapsToActiveState() {
         given(mockGoCardlessEvent.getAction()).willReturn("active");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
         assertThat(mandateState.get(), is(MandateState.ACTIVE));
     }
@@ -74,7 +70,7 @@ public class GoCardlessMandateStateCalculatorTest {
     public void cancelledActionMapsToCancelledState() {
         given(mockGoCardlessEvent.getAction()).willReturn("cancelled");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
         assertThat(mandateState.get(), is(MandateState.CANCELLED));
     }
@@ -83,7 +79,7 @@ public class GoCardlessMandateStateCalculatorTest {
     public void failedActionMapsToFailedState() {
         given(mockGoCardlessEvent.getAction()).willReturn("failed");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
         assertThat(mandateState.get(), is(MandateState.FAILED));
     }
@@ -92,17 +88,17 @@ public class GoCardlessMandateStateCalculatorTest {
     public void unrecognisedActionMapsToNothing() {
         given(mockGoCardlessEvent.getAction()).willReturn("eaten_by_wolves");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
         assertThat(mandateState, is(Optional.empty()));
     }
 
     @Test
     public void noApplicableEventsMapsToNothing() {
-        given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(mockGoCardlessMandateId, mockGoCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE)).willReturn(Optional.empty());
+        given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(mockGoCardlessMandateIdAndOrganisationId, GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                .willReturn(Optional.empty());
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateId, mockGoCardlessOrganisationId);
+        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
         assertThat(mandateState, is(Optional.empty()));
     }


### PR DESCRIPTION
GoCardless mandate IDs aren’t unique, so to retrieve a mandate from the database, we have use the mandate ID in combination with the GoCardless organisation ID. Sandbox mandate IDs don’t have this limitation and sandbox accounts don’t have organisation IDs.

Make things simpler for ourselves by introducing a `MandateUpdateService`, which acts as a façade over the `MandateDao` and takes a `MandateLookupKey` object. Both `GoCardlessMandateIdAndOrganisationId` (a value type that wraps a GoCardless mandate ID and organisation ID) and `SandboxMandateId` implement the `MandateLookupKey` marker interface. The
`MandateUpdateService` uses some fantastically non-polymorphic code to determine the precise runtime type of the `MandateLookupKey` it’s been passed and calls the appropriate method on the `MandateDao` depending on whether the lookup needs to take account of the organisation ID or not.

Make use of the new `MandateUpdateService` when updating the status of a mandate in response to a GoCardless webhook. This means we can pass it a `GoCardlessMandateIdAndOrganisationId` (rather than a `GoCardlessMandateId` and a `GoCardlessOrganisationId`).

Spread more widely, this pattern will allow us to remove `PaymentProviderServiceId`, which is the interface implemented by `GoCardlessOrganisationId` in order to maintain the fiction that all payment providers have this concept of organisation IDs.