### PR TITLE
PP-5318 Use MandateLookupKey for retrieving mandates

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -9,8 +9,8 @@ import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.PaymentProviderServiceIdArgumentFactory;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
-import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProviderServiceId;
 import uk.gov.pay.directdebit.mandate.dao.mapper.MandateMapper;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReferenceArgumentFactory;
@@ -103,10 +103,14 @@ public interface MandateDao {
     Optional<Mandate> findByExternalIdAndGatewayAccountExternalId(@Bind("mandateExternalId") MandateExternalId mandateExternalId,
                                                                   @Bind("gatewayAccountExternalId") String gatewayAccountExternalId);
 
-    @SqlQuery(query + "WHERE m.payment_provider_id = :paymentProviderMandateId AND g.organisation = :paymentProviderServiceId AND g.payment_provider = :provider")
+    @SqlQuery(query + "WHERE m.payment_provider_id = :paymentProviderMandateId AND g.organisation = :goCardlessOrganisationId AND g.payment_provider = :provider")
+    Optional<Mandate> findByPaymentProviderMandateIdAndOrganisation(@Bind("provider") PaymentProvider paymentProvider,
+                                                                    @Bind("paymentProviderMandateId") PaymentProviderMandateId paymentProviderMandateId,
+                                                                    @Bind("goCardlessOrganisationId") GoCardlessOrganisationId goCardlessOrganisationId);
+
+    @SqlQuery(query + "WHERE m.payment_provider_id = :paymentProviderMandateId AND g.organisation IS NULL AND g.payment_provider = :provider")
     Optional<Mandate> findByPaymentProviderMandateId(@Bind("provider") PaymentProvider paymentProvider,
-                                                     @Bind("paymentProviderMandateId") PaymentProviderMandateId paymentProviderMandateId,
-                                                     @Bind("paymentProviderServiceId") PaymentProviderServiceId paymentProviderServiceId);
+                                                     @Bind("paymentProviderMandateId") PaymentProviderMandateId paymentProviderMandateId);
 
     @SqlQuery(query + "WHERE m.state IN (<states>) AND m.created_date < :maxDateTime")
     List<Mandate> findAllMandatesBySetOfStatesAndMaxCreationTime(@BindList("states") Set<MandateState> states, @Bind("maxDateTime") ZonedDateTime maxDateTime);
@@ -115,9 +119,9 @@ public interface MandateDao {
     int updateState(@Bind("id") Long id, @Bind("state") MandateState mandateState);
 
     @SqlUpdate("UPDATE mandates m SET state = :state FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
-            "AND g.id = m.gateway_account_id AND g.organisation = :providerServiceId AND g.payment_provider = :provider")
+            "AND g.id = m.gateway_account_id AND g.organisation = :goCardlessOrganisationId AND g.payment_provider = :provider")
     int updateStateByPaymentProviderMandateIdAndOrganisationId(@Bind("provider") PaymentProvider paymentProvider,
-                                                               @Bind("providerServiceId") PaymentProviderServiceId paymentProviderServiceId,
+                                                               @Bind("goCardlessOrganisationId") GoCardlessOrganisationId goCardlessOrganisationId,
                                                                @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
                                                                @Bind("state") MandateState mandateState);
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/exception/MandateNotFoundException.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/exception/MandateNotFoundException.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.mandate.exception;
 
 import uk.gov.pay.directdebit.common.exception.NotFoundException;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 
 import static java.lang.String.format;
 
@@ -18,5 +19,10 @@ public class MandateNotFoundException extends NotFoundException {
 
     public MandateNotFoundException(MandateExternalId mandateExternalId, String gatewayAccountExternalId) {
         super(format("Couldn't find mandate for gateway account %s with id: %s", gatewayAccountExternalId, mandateExternalId));
+    }
+
+    public MandateNotFoundException(GoCardlessMandateIdAndOrganisationId goCardlessMandateIdAndOrganisationId) {
+        super(format("Couldn't find GoCardless mandate %s for organisation %s", goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(),
+                goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId()));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessMandateHandler.java
@@ -11,6 +11,7 @@ import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 import uk.gov.pay.directdebit.payments.services.DirectDebitEventService;
 import uk.gov.pay.directdebit.payments.services.GoCardlessEventService;
 import uk.gov.pay.directdebit.payments.services.PaymentService;
@@ -89,8 +90,10 @@ public class GoCardlessMandateHandler extends GoCardlessHandler {
                 .map((handledAction -> {
                     Mandate mandate = mandateQueryService.findByPaymentProviderMandateId(
                             GOCARDLESS,
-                            event.getLinksMandate().orElseThrow(() -> new GoCardlessEventHasNoMandateIdException(event.getGoCardlessEventId())),
-                            event.getLinksOrganisation()
+                            new GoCardlessMandateIdAndOrganisationId(
+                                    event.getLinksMandate().orElseThrow(() -> new GoCardlessEventHasNoMandateIdException(event.getGoCardlessEventId())),
+                                    event.getLinksOrganisation()
+                            )
                     );
 
                     if (isValidOrganisation(mandate, event)) {

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.directdebit.payments.fixtures.PaymentFixture;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 import uk.gov.pay.directdebit.payments.services.DirectDebitEventService;
 import uk.gov.pay.directdebit.payments.services.GoCardlessEventService;
 import uk.gov.pay.directdebit.payments.services.PaymentService;
@@ -87,7 +88,8 @@ public class GoCardlessMandateHandlerTest {
     public void handle_onCreateMandateGoCardlessEvent_shouldRegisterEventAsMandatePending_whenDoesNotPreviouslyExist() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("created").toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS,
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
                 .thenReturn(mandateFixture.toEntity());
         when(mandateStateUpdateService.mandatePendingFor(mandateFixture.toEntity())).thenReturn(
                 directDebitEvent);
@@ -104,7 +106,8 @@ public class GoCardlessMandateHandlerTest {
     public void handle_onCreateMandateGoCardlessEvent_shouldNotRegisterAnEventAsMandatePending_whenAPreviousMandatePendingEventExists() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("created").toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(), goCardlessEvent.getLinksOrganisation()))
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS,
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
                 .thenReturn(mandateFixture.toEntity());
         when(directDebitEventService.findBy(mandateFixture.getId(), MANDATE, SupportedEvent.MANDATE_PENDING)).thenReturn(Optional
                 .of(
@@ -123,7 +126,8 @@ public class GoCardlessMandateHandlerTest {
     public void handle_onActiveMandateGoCardlessEvent_shouldSetAPayEventAsMandateActive_whenDoesNotPreviouslyExist() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("active").toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(), goCardlessEvent.getLinksOrganisation()))
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS,
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
                 .thenReturn(mandateFixture.toEntity());
         when(mandateStateUpdateService.mandateActiveFor(mandateFixture.toEntity())).thenReturn(
                 directDebitEvent);
@@ -140,7 +144,8 @@ public class GoCardlessMandateHandlerTest {
     public void handle_onActiveMandateGoCardlessEvent_shouldNotRegisterAnEventAsMandatePending_whenAPreviousMandatePendingEventExists() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("active").toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(), goCardlessEvent.getLinksOrganisation()))
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS,
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
                 .thenReturn(mandateFixture.toEntity());
 
         when(mandateStateUpdateService.mandateActiveFor(mandateFixture.toEntity())).thenReturn(
@@ -160,7 +165,8 @@ public class GoCardlessMandateHandlerTest {
     public void handle_onSubmittedMandateGoCardlessEvent_shouldSetAPayEventAsMandatePending_whenDoesNotPreviouslyExist() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("submitted").toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(), goCardlessEvent.getLinksOrganisation()))
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS,
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
                 .thenReturn(mandateFixture.toEntity());
         when(mandateStateUpdateService.mandatePendingFor(mandateFixture.toEntity())).thenReturn(
                 directDebitEvent);
@@ -178,7 +184,8 @@ public class GoCardlessMandateHandlerTest {
     public void handle_onSubmittedMandateGoCardlessEvent_shouldNotRegisterAnEventAsMandatePending_whenAPreviousMandatePendingEventExists() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("submitted").toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(), goCardlessEvent.getLinksOrganisation()))
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS,
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
                 .thenReturn(mandateFixture.toEntity());
         when(directDebitEventService.findBy(mandateFixture.getId(), MANDATE, SupportedEvent.MANDATE_PENDING)).thenReturn(Optional.of(
                 directDebitEvent));
@@ -196,7 +203,8 @@ public class GoCardlessMandateHandlerTest {
     public void handle_onAFailedMandateGoCardlessEvent_shouldRegisterAPayEventAsMandateFailed() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("failed").toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(), goCardlessEvent.getLinksOrganisation()))
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS,
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
                 .thenReturn(mandateFixture.toEntity());
         when(mandateStateUpdateService.mandateFailedFor(mandateFixture.toEntity())).thenReturn(
                 directDebitEvent);
@@ -218,7 +226,8 @@ public class GoCardlessMandateHandlerTest {
     public void handle_onACancelledMandateGoCardlessEvent_shouldRegisterAPayEventAsMandateCancelled_AndFailPaymentIfNotSubmittedToGC() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("cancelled").toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(), goCardlessEvent.getLinksOrganisation()))
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS,
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
                 .thenReturn(mandateFixture.toEntity());
         when(paymentService.findPaymentSubmittedEventFor(paymentFixture.toEntity())).thenReturn(Optional.empty());
         when(mandateStateUpdateService.mandateCancelledFor(mandateFixture.toEntity())).thenReturn(
@@ -241,7 +250,8 @@ public class GoCardlessMandateHandlerTest {
     public void handle_onACancelledMandateGoCardlessEvent_shouldRegisterAPayEventAsMandateCancelled_withoutFailingPaymentIfSubmittedToGC() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("cancelled").toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(), goCardlessEvent.getLinksOrganisation()))
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS,
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
                 .thenReturn(mandateFixture.toEntity());
         when(paymentService.findPaymentSubmittedEventFor(paymentFixture.toEntity())).thenReturn(Optional.of(
                 directDebitEvent));
@@ -265,8 +275,9 @@ public class GoCardlessMandateHandlerTest {
                 .withAction("created")
                 .toEntity());
 
-        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, goCardlessEvent.getLinksMandate().get(),
-                goCardlessEventFixture.getLinksOrganisation())).thenReturn(mandateFixture.toEntity());
+        when(mandateQueryService.findByPaymentProviderMandateId(GOCARDLESS, 
+                        new GoCardlessMandateIdAndOrganisationId(goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation())))
+                .thenReturn(mandateFixture.toEntity());
 
         goCardlessMandateHandler.handle(goCardlessEvent);
         verify(goCardlessEvent, never()).setInternalEventId(anyLong());


### PR DESCRIPTION
Conceptually very similar to https://github.com/alphagov/pay-direct-debit-connector/pull/587.

`PaymentProviderServiceId` remains for now as it used for database queries relating to payments.