### PR TITLE
Pp 5302 Make PaymentViewSearchParams Immutable with Builder

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/model/SearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/SearchParams.java
@@ -1,0 +1,4 @@
+package uk.gov.pay.directdebit.common.model;
+
+public interface SearchParams {
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/model/SearchResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/SearchResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.directdebit.payments.api.PaymentResponse;
 import uk.gov.pay.directdebit.payments.model.LinksForSearchResult;
 
 import java.util.List;
@@ -18,17 +19,17 @@ public class SearchResponse<T> {
     @JsonIgnore
     private final String gatewayExternalId;
     @JsonProperty("total")
-    private final Long total;
+    private final Integer total;
     @JsonProperty("count")
-    private final int count;
+    private final Integer count;
     @JsonProperty("page")
-    private final Long page;
+    private final Integer page;
     @JsonProperty("results")
     private final List<T> results;
     @JsonProperty("_links")
     private final LinksForSearchResult linksForSearchResult;
 
-    public SearchResponse(String gatewayExternalId, Long total, Long page, List<T> results, LinksForSearchResult linksForSearchResult) {
+    public SearchResponse(String gatewayExternalId, Integer total, Integer page, List<T> results, LinksForSearchResult linksForSearchResult) {
         this.gatewayExternalId = gatewayExternalId;
         this.total = total;
         this.count = results.size();
@@ -41,11 +42,11 @@ public class SearchResponse<T> {
         return results;
     }
 
-    public Long getTotal() { return total; }
+    public Integer getTotal() { return total; }
 
-    public int getCount() { return count; }
+    public Integer getCount() { return count; }
 
-    public Long getPage() { return page; }
+    public Integer getPage() { return page; }
 
     public LinksForSearchResult getLinksForSearchResult() { return linksForSearchResult; }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidator.java
@@ -15,8 +15,8 @@ import static uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams.Pay
 
 public class PaymentViewValidator {
 
-    private static final Long MAX_PAGE_NUMBER = 500L;
-    private static final Long DEFAULT_PAGE_NUMBER = 1L;
+    private static final Integer MAX_PAGE_NUMBER = 500;
+    private static final Integer DEFAULT_PAGE_NUMBER = 1;
     private static final String FROM_DATE_FIELD = "fromDate";
     private static final String TO_DATE_FIELD = "toDate";
 
@@ -38,8 +38,8 @@ public class PaymentViewValidator {
     }
 
     private PaginationParams validatePagination(PaymentViewSearchParams searchParams) {
-        Long pageNumber = DEFAULT_PAGE_NUMBER - 1;
-        Long displaySize = MAX_PAGE_NUMBER;
+        Integer pageNumber = DEFAULT_PAGE_NUMBER - 1;
+        Integer displaySize = MAX_PAGE_NUMBER;
         PaginationParams paginationParams = searchParams.getPaginationParams();
         if (paginationParams.getDisplaySize() != null) {
             if (paginationParams.getDisplaySize() < 1) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidator.java
@@ -11,6 +11,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams.PaymentViewSearchParamsBuilder.aPaymentViewSearchParams;
 
 public class PaymentViewValidator {
 
@@ -22,7 +23,7 @@ public class PaymentViewValidator {
     public PaymentViewSearchParams validateParams(PaymentViewSearchParams searchParams) {
         PaginationParams paginationParams = validatePagination(searchParams);
         SearchDateParams searchDateParams = validateSearchDate(searchParams);
-        return new PaymentViewSearchParams(searchParams.getGatewayExternalId())
+        return aPaymentViewSearchParams(searchParams.getGatewayExternalId())
                 .withPage(searchParams.getPage() == null ? DEFAULT_PAGE_NUMBER : searchParams.getPage())        
                 .withDisplaySize(searchParams.getDisplaySize() == null ? MAX_PAGE_NUMBER : searchParams.getDisplaySize())
                 .withFromDateString(searchParams.getFromDateString())
@@ -32,7 +33,8 @@ public class PaymentViewValidator {
                 .withMandateId(searchParams.getMandateId())
                 .withPaginationParams(paginationParams)
                 .withSearchDateParams(searchDateParams)
-                .withState(searchParams.getState());
+                .withState(searchParams.getState())
+                .build();
     }
 
     private PaginationParams validatePagination(PaymentViewSearchParams searchParams) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
@@ -55,13 +55,13 @@ public class PaymentViewDao {
         });
     }
     
-    public Long getPaymentViewCount(PaymentViewSearchParams searchParams) {
+    public Integer getPaymentViewCount(PaymentViewSearchParams searchParams) {
         String searchExtraFields = searchParams.generateQuery();
         return jdbi.withHandle(handle -> {
             Query query = handle.createQuery(COUNT_QUERY_STRING.replace(":searchExtraFields", searchExtraFields));
             searchParams.getQueryMap().forEach(query::bind);
             return query
-                    .mapTo(Long.class)
+                    .mapTo(Integer.class)
                     .findOnly();
         });
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResult.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResult.java
@@ -24,9 +24,7 @@ public class LinksForSearchResult {
     private final UriInfo uriInfo;
 
     @JsonIgnore
-    private final Long totalCount;
-    @JsonIgnore
-    private final Long selfPageNum;
+    private final Integer totalCount;
     @JsonProperty(SELF_LINK)
     private PaginationLink selfLink;
     @JsonProperty(FIRST_LINK)
@@ -38,10 +36,9 @@ public class LinksForSearchResult {
     @JsonProperty(NEXT_LINK)
     private PaginationLink nextLink;
 
-    public LinksForSearchResult(PaymentViewSearchParams searchParams, UriInfo uriInfo, Long totalCount) {
+    public LinksForSearchResult(PaymentViewSearchParams searchParams, UriInfo uriInfo, Integer totalCount) {
         this.searchParams = searchParams;
         this.uriInfo = uriInfo;
-        this.selfPageNum = searchParams.getPage();
         this.totalCount = totalCount;
         buildLinks();
     }
@@ -57,15 +54,15 @@ public class LinksForSearchResult {
     public PaginationLink getNextLink() { return nextLink; }
 
     private void buildLinks() {
-        long currentPageNumber = searchParams.getPage();
-        long lastPageNumber = totalCount > 0 ? (totalCount + searchParams.getDisplaySize() - 1) / searchParams.getDisplaySize() : 1;
+        int currentPageNumber = searchParams.getPage();
+        int lastPageNumber = totalCount > 0 ? (totalCount + searchParams.getDisplaySize() - 1) / searchParams.getDisplaySize() : 1;
         
         selfLink = createLink(currentPageNumber);
-        firstLink = createLink(1L);
+        firstLink = createLink(1);
         lastLink = createLink(lastPageNumber);
         
         if (currentPageNumber > 1) {
-            long previousPageNumber = currentPageNumber > lastPageNumber ? lastPageNumber : currentPageNumber - 1;
+            int previousPageNumber = currentPageNumber > lastPageNumber ? lastPageNumber : currentPageNumber - 1;
             prevLink = createLink(previousPageNumber);
         }
         
@@ -74,7 +71,7 @@ public class LinksForSearchResult {
         }
     }
     
-    private PaginationLink createLink(long pageNumber) {
+    private PaginationLink createLink(Integer pageNumber) {
         var searchParamsForPage = fromPaymentViewParams(searchParams).withPage(pageNumber).build();
         return PaginationLink.ofValue(uriWithParams(searchParamsForPage.buildQueryParamString()).toString());
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/PaginationParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/PaginationParams.java
@@ -2,19 +2,19 @@ package uk.gov.pay.directdebit.payments.params;
 
 public class PaginationParams {
 
-    private Long pageNumber;
-    private Long displaySize;
+    private Integer pageNumber;
+    private Integer displaySize;
 
-    public PaginationParams(Long pageNumber, Long displaySize) {
+    public PaginationParams(Integer pageNumber, Integer displaySize) {
         this.pageNumber = pageNumber;
         this.displaySize = displaySize;
     }
 
-    public Long getPageNumber() {
+    public Integer getPageNumber() {
         return pageNumber;
     }
 
-    public Long getDisplaySize() {
+    public Integer getDisplaySize() {
         return displaySize;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
@@ -30,16 +30,16 @@ public class PaymentViewSearchParams {
     private static final String STATE_FIELD = "state";
     
     private final String gatewayExternalId;
-    private Long page;
-    private Long displaySize;
-    private String fromDateString;
-    private String toDateString;
-    private String reference;
-    private Long amount;
-    private String mandateId;
-    private String state;
-    private SearchDateParams searchDateParams;
-    private PaginationParams paginationParams;
+    private final Long page;
+    private final Long displaySize;
+    private final String fromDateString;
+    private final String toDateString;
+    private final String reference;
+    private final Long amount;
+    private final String mandateId;
+    private final String state;
+    private final SearchDateParams searchDateParams;
+    private final PaginationParams paginationParams;
     private Map<String, Object> queryMap;
 
     private static Map<String, String> externalPaymentToInternalStateQueryMap = new HashMap<>(4);
@@ -58,53 +58,18 @@ public class PaymentViewSearchParams {
                 .put(ExternalPaymentState.EXTERNAL_FAILED.getStatus(), FAILED.toSingleQuoteString() + ", " + CANCELLED.toSingleQuoteString() + ", " + EXPIRED.toSingleQuoteString());
     }
 
-    public PaymentViewSearchParams(String gatewayExternalId) {
-        this.gatewayExternalId = gatewayExternalId;
-    }
-
-    public PaymentViewSearchParams withDisplaySize(Long displaySize) {
-        this.displaySize = displaySize;
-        return this;
-    }
-
-    public PaymentViewSearchParams withFromDateString(String fromDateString) {
-        this.fromDateString = fromDateString;
-        return this;
-    }
-
-    public PaymentViewSearchParams withAmount(Long amount) {
-        this.amount = amount;
-        return this;
-    }
-
-    public PaymentViewSearchParams withToDateString(String toDateString) {
-        this.toDateString = toDateString;
-        return this;
-    }
-
-    public PaymentViewSearchParams withReference(String reference) {
-        this.reference = reference;
-        return this;
-    }
-
-    public PaymentViewSearchParams withMandateId(String mandateId) {
-        this.mandateId = mandateId;
-        return this;
-    }
-
-    public PaymentViewSearchParams withState(String state) {
-        this.state = state;
-        return this;
-    }
-
-    public PaymentViewSearchParams withPaginationParams(PaginationParams paginationParams) {
-        this.paginationParams = paginationParams;
-        return this;
-    }
-
-    public PaymentViewSearchParams withSearchDateParams(SearchDateParams searchDateParams) {
-        this.searchDateParams = searchDateParams;
-        return this;
+    private PaymentViewSearchParams(PaymentViewSearchParamsBuilder builder) {
+        this.gatewayExternalId = builder.gatewayAccountExternalId;
+        this.page = builder.page;
+        this.displaySize = builder.displaySize;
+        this.fromDateString = builder.fromDateString;
+        this.toDateString = builder.toDateString;
+        this.reference = builder.reference;
+        this.amount = builder.amount;
+        this.mandateId = builder.mandateId;
+        this.state = builder.state;
+        this.searchDateParams = builder.searchDateParams;
+        this.paginationParams = builder.paginationParams;
     }
 
     public String getGatewayExternalId() { return gatewayExternalId; }
@@ -133,11 +98,6 @@ public class PaymentViewSearchParams {
     }
 
     public SearchDateParams getSearchDateParams() { return searchDateParams; }
-    
-    public PaymentViewSearchParams withPage(Long page) {
-        this.page = page;
-        return this;
-    }
 
     public String generateQuery() {
         StringBuilder sb = new StringBuilder();
@@ -227,4 +187,95 @@ public class PaymentViewSearchParams {
         return "%" + rawUserInputText + "%";
     }
 
+
+    public static final class PaymentViewSearchParamsBuilder {
+        private final String gatewayAccountExternalId;
+        private Long page;
+        private Long displaySize;
+        private String fromDateString;
+        private String toDateString;
+        private String reference;
+        private Long amount;
+        private String mandateId;
+        private String state;
+        private SearchDateParams searchDateParams;
+        private PaginationParams paginationParams;
+
+        private PaymentViewSearchParamsBuilder(String gatewayAccountExternalId) {
+            this.gatewayAccountExternalId = gatewayAccountExternalId;
+        }
+        
+        public static PaymentViewSearchParamsBuilder fromPaymentViewParams(PaymentViewSearchParams paymentViewSearchParams) {
+            var builder = new PaymentViewSearchParamsBuilder(paymentViewSearchParams.getGatewayExternalId());
+            builder.page = paymentViewSearchParams.page;
+            builder.displaySize = paymentViewSearchParams.displaySize;
+            builder.fromDateString = paymentViewSearchParams.fromDateString;
+            builder.toDateString = paymentViewSearchParams.toDateString;
+            builder.reference = paymentViewSearchParams.reference;
+            builder.amount = paymentViewSearchParams.amount;
+            builder.mandateId = paymentViewSearchParams.mandateId;
+            builder.state = paymentViewSearchParams.state;
+            builder.searchDateParams = paymentViewSearchParams.searchDateParams;
+            builder.paginationParams = paymentViewSearchParams.paginationParams;
+            return builder;
+        }
+
+        public static PaymentViewSearchParamsBuilder aPaymentViewSearchParams(String gatewayAccountExternalId) {
+            return new PaymentViewSearchParamsBuilder(gatewayAccountExternalId);
+        }
+
+        public PaymentViewSearchParamsBuilder withPage(Long page) {
+            this.page = page;
+            return this;
+        }
+
+        public PaymentViewSearchParamsBuilder withDisplaySize(Long displaySize) {
+            this.displaySize = displaySize;
+            return this;
+        }
+
+        public PaymentViewSearchParamsBuilder withFromDateString(String fromDateString) {
+            this.fromDateString = fromDateString;
+            return this;
+        }
+
+        public PaymentViewSearchParamsBuilder withToDateString(String toDateString) {
+            this.toDateString = toDateString;
+            return this;
+        }
+
+        public PaymentViewSearchParamsBuilder withReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public PaymentViewSearchParamsBuilder withAmount(Long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public PaymentViewSearchParamsBuilder withMandateId(String mandateId) {
+            this.mandateId = mandateId;
+            return this;
+        }
+
+        public PaymentViewSearchParamsBuilder withState(String state) {
+            this.state = state;
+            return this;
+        }
+
+        public PaymentViewSearchParamsBuilder withSearchDateParams(SearchDateParams searchDateParams) {
+            this.searchDateParams = searchDateParams;
+            return this;
+        }
+
+        public PaymentViewSearchParamsBuilder withPaginationParams(PaginationParams paginationParams) {
+            this.paginationParams = paginationParams;
+            return this;
+        }
+
+        public PaymentViewSearchParams build() {
+            return new PaymentViewSearchParams(this);
+        }
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
@@ -30,8 +30,8 @@ public class PaymentViewSearchParams {
     private static final String STATE_FIELD = "state";
     
     private final String gatewayExternalId;
-    private final Long page;
-    private final Long displaySize;
+    private final Integer page;
+    private final Integer displaySize;
     private final String fromDateString;
     private final String toDateString;
     private final String reference;
@@ -74,9 +74,9 @@ public class PaymentViewSearchParams {
 
     public String getGatewayExternalId() { return gatewayExternalId; }
 
-    public Long getPage() { return page; }
+    public Integer getPage() { return page; }
 
-    public Long getDisplaySize() { return displaySize; }
+    public Integer getDisplaySize() { return displaySize; }
 
     public String getFromDateString() { return fromDateString; }
 
@@ -190,8 +190,8 @@ public class PaymentViewSearchParams {
 
     public static final class PaymentViewSearchParamsBuilder {
         private final String gatewayAccountExternalId;
-        private Long page;
-        private Long displaySize;
+        private Integer page;
+        private Integer displaySize;
         private String fromDateString;
         private String toDateString;
         private String reference;
@@ -224,12 +224,12 @@ public class PaymentViewSearchParams {
             return new PaymentViewSearchParamsBuilder(gatewayAccountExternalId);
         }
 
-        public PaymentViewSearchParamsBuilder withPage(Long page) {
+        public PaymentViewSearchParamsBuilder withPage(Integer page) {
             this.page = page;
             return this;
         }
 
-        public PaymentViewSearchParamsBuilder withDisplaySize(Long displaySize) {
+        public PaymentViewSearchParamsBuilder withDisplaySize(Integer displaySize) {
             this.displaySize = displaySize;
             return this;
         }

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResource.java
@@ -15,6 +15,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams.PaymentViewSearchParamsBuilder.aPaymentViewSearchParams;
 
 @Path("/")
 public class PaymentSearchResource {
@@ -42,7 +43,7 @@ public class PaymentSearchResource {
             @QueryParam("state") String state,
             @Context UriInfo uriInfo) {
 
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(accountExternalId)
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(accountExternalId)
                 .withPage(pageNumber)
                 .withDisplaySize(displaySize)
                 .withFromDateString(fromDate)
@@ -50,7 +51,8 @@ public class PaymentSearchResource {
                 .withReference(reference)
                 .withAmount(amount)
                 .withMandateId(mandateId)
-                .withState(state);
+                .withState(state)
+                .build();
         return Response.ok().entity(paymentSearchService.withUriInfo(uriInfo).getPaymentSearchResponse(searchParams)).build();
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResource.java
@@ -33,8 +33,8 @@ public class PaymentSearchResource {
     @Timed
     public Response searchPayments(
             @PathParam("accountId") String accountExternalId,
-            @QueryParam("page") Long pageNumber,
-            @QueryParam("display_size") Long displaySize,
+            @QueryParam("page") Integer pageNumber,
+            @QueryParam("display_size") Integer displaySize,
             @QueryParam("from_date") String fromDate,
             @QueryParam("to_date") String toDate,
             @QueryParam("reference") String reference,

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentSearchService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentSearchService.java
@@ -32,11 +32,11 @@ public class PaymentSearchService {
                 .orElseThrow(() -> new GatewayAccountNotFoundException(searchParams.getGatewayExternalId()));
 
         PaymentViewSearchParams validatedSearchParams = paymentViewValidator.validateParams(searchParams);
-        Long total = getTotal(validatedSearchParams);
+        Integer total = getTotal(validatedSearchParams);
         List<PaymentResponse> foundPayments = total > 0 ? getPaymentViewResultResponse(validatedSearchParams) : Collections.emptyList();
         LinksForSearchResult linksForSearchResult = new LinksForSearchResult(validatedSearchParams, uriInfo, total);
         
-        return new SearchResponse<>(validatedSearchParams.getGatewayExternalId(),
+        return new SearchResponse<PaymentResponse>(validatedSearchParams.getGatewayExternalId(),
                 total,
                 validatedSearchParams.getPage(),
                 foundPayments,
@@ -48,7 +48,7 @@ public class PaymentSearchService {
         return this;
     }
 
-    private Long getTotal(PaymentViewSearchParams searchParams) {
+    private Integer getTotal(PaymentViewSearchParams searchParams) {
         return paymentViewDao.getPaymentViewCount(searchParams);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentSearchService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentSearchService.java
@@ -32,14 +32,13 @@ public class PaymentSearchService {
                 .orElseThrow(() -> new GatewayAccountNotFoundException(searchParams.getGatewayExternalId()));
 
         PaymentViewSearchParams validatedSearchParams = paymentViewValidator.validateParams(searchParams);
-        long originalPageNumber = validatedSearchParams.getPage();
         Long total = getTotal(validatedSearchParams);
         List<PaymentResponse> foundPayments = total > 0 ? getPaymentViewResultResponse(validatedSearchParams) : Collections.emptyList();
         LinksForSearchResult linksForSearchResult = new LinksForSearchResult(validatedSearchParams, uriInfo, total);
         
         return new SearchResponse<>(validatedSearchParams.getGatewayExternalId(),
                 total,
-                originalPageNumber,
+                validatedSearchParams.getPage(),
                 foundPayments,
                 linksForSearchResult);
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidatorTest.java
@@ -28,8 +28,8 @@ public class PaymentViewValidatorTest {
     @Test
     public void shouldReturnNoErrors_withValidPagination() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(2L)
-                .withDisplaySize(3L)
+                .withPage(2)
+                .withDisplaySize(3)
                 .build();
         validator.validateParams(searchParams);
     }
@@ -37,8 +37,8 @@ public class PaymentViewValidatorTest {
     @Test
     public void shouldReturnAnError_whenPageIsZero() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(0L)
-                .withDisplaySize(300L)
+                .withPage(0)
+                .withDisplaySize(300)
                 .build();
         thrown.expect(NegativeSearchParamException.class);
         thrown.expectMessage("Query param 'page' should be a non zero positive integer");
@@ -48,19 +48,19 @@ public class PaymentViewValidatorTest {
     @Test
     public void shouldResetDisplaySizeTo500() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(2L)
-                .withDisplaySize(600L)
+                .withPage(2)
+                .withDisplaySize(600)
                 .build();
         searchParams = validator.validateParams(searchParams);
-        assertThat(searchParams.getPaginationParams().getDisplaySize(), is(500L));
+        assertThat(searchParams.getPaginationParams().getDisplaySize(), is(500));
     }
 
     @Test
     public void shouldSetPaginationWithDefaultValues() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account").build(); 
         searchParams = validator.validateParams(searchParams);
-        assertThat(searchParams.getPaginationParams().getDisplaySize(), is(500L));
-        assertThat(searchParams.getPaginationParams().getPageNumber(), is(0L));
+        assertThat(searchParams.getPaginationParams().getDisplaySize(), is(500));
+        assertThat(searchParams.getPaginationParams().getPageNumber(), is(0));
     }
     
     @Test
@@ -68,8 +68,8 @@ public class PaymentViewValidatorTest {
         String fromDate = "2018-05-03T15:00Z";
         String toDate = "2018-05-04T15:00Z";
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(2L)
-                .withDisplaySize(42L)
+                .withPage(2)
+                .withDisplaySize(42)
                 .withFromDateString(fromDate)
                 .withToDateString(toDate)
                 .build();
@@ -82,8 +82,8 @@ public class PaymentViewValidatorTest {
     public void shouldLeaveToDateNull_whenMissing() {
         String fromDate = "2018-05-03T15:00Z";
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(2L)
-                .withDisplaySize(3L)
+                .withPage(2)
+                .withDisplaySize(3)
                 .withFromDateString(fromDate)
                 .build();
         searchParams = validator.validateParams(searchParams);
@@ -95,8 +95,8 @@ public class PaymentViewValidatorTest {
     public void shouldLeaveFromDateNull_whenMissing() {
         String toDate = "2018-05-04T15:00Z";
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(2L)
-                .withDisplaySize(3L)
+                .withPage(2)
+                .withDisplaySize(3)
                 .withToDateString(toDate)
                 .build();
         searchParams = validator.validateParams(searchParams);
@@ -111,8 +111,8 @@ public class PaymentViewValidatorTest {
         thrown.expect(InvalidDateException.class);
         thrown.expectMessage("from_date (2018-05-05T15:00Z) must be earlier then to_date (2018-05-04T15:00Z)");
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(2L)
-                .withDisplaySize(3L)
+                .withPage(2)
+                .withDisplaySize(3)
                 .withFromDateString(fromDate)
                 .withToDateString(toDate)
                 .build();
@@ -126,8 +126,8 @@ public class PaymentViewValidatorTest {
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input toDate (2018-05-35T15:00Z) is wrong format");
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(3L)
-                .withDisplaySize(256L)
+                .withPage(3)
+                .withDisplaySize(256)
                 .withFromDateString(fromDate)
                 .withToDateString(toDate)
                 .build();
@@ -141,8 +141,8 @@ public class PaymentViewValidatorTest {
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input fromDate (2018-05-03T15:00Z') is wrong format");
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(2L)
-                .withDisplaySize(3L)
+                .withPage(2)
+                .withDisplaySize(3)
                 .withFromDateString(fromDate)
                 .withToDateString(toDate)
                 .build();
@@ -156,8 +156,8 @@ public class PaymentViewValidatorTest {
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input fromDate (%2018-05-03T15:00Z) is wrong format");
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
-                .withPage(2L)
-                .withDisplaySize(3L)
+                .withPage(2)
+                .withDisplaySize(3)
                 .withFromDateString(fromDate)
                 .withToDateString(toDate)
                 .build();

--- a/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/api/PaymentViewValidatorTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams.PaymentViewSearchParamsBuilder.aPaymentViewSearchParams;
 
 public class PaymentViewValidatorTest {
 
@@ -20,23 +21,25 @@ public class PaymentViewValidatorTest {
 
     @Test
     public void shouldReturnNoErrors_withMinimumParams() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account"); 
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account").build(); 
         validator.validateParams(searchParams);
     }
     
     @Test
     public void shouldReturnNoErrors_withValidPagination() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(2L)
-                .withDisplaySize(3L);
+                .withDisplaySize(3L)
+                .build();
         validator.validateParams(searchParams);
     }
 
     @Test
     public void shouldReturnAnError_whenPageIsZero() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(0L)
-                .withDisplaySize(300L);
+                .withDisplaySize(300L)
+                .build();
         thrown.expect(NegativeSearchParamException.class);
         thrown.expectMessage("Query param 'page' should be a non zero positive integer");
         validator.validateParams(searchParams);
@@ -44,16 +47,17 @@ public class PaymentViewValidatorTest {
 
     @Test
     public void shouldResetDisplaySizeTo500() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(2L)
-                .withDisplaySize(600L);
+                .withDisplaySize(600L)
+                .build();
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getPaginationParams().getDisplaySize(), is(500L));
     }
 
     @Test
     public void shouldSetPaginationWithDefaultValues() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account"); 
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account").build(); 
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getPaginationParams().getDisplaySize(), is(500L));
         assertThat(searchParams.getPaginationParams().getPageNumber(), is(0L));
@@ -63,11 +67,12 @@ public class PaymentViewValidatorTest {
     public void shouldCorrectlyValidate_toAndFromDate() {
         String fromDate = "2018-05-03T15:00Z";
         String toDate = "2018-05-04T15:00Z";
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(2L)
                 .withDisplaySize(42L)
                 .withFromDateString(fromDate)
-                .withToDateString(toDate);
+                .withToDateString(toDate)
+                .build();
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getSearchDateParams().getFromDate().toString(), is(fromDate));
         assertThat(searchParams.getSearchDateParams().getToDate().toString(), is(toDate));
@@ -76,10 +81,11 @@ public class PaymentViewValidatorTest {
     @Test 
     public void shouldLeaveToDateNull_whenMissing() {
         String fromDate = "2018-05-03T15:00Z";
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(2L)
                 .withDisplaySize(3L)
-                .withFromDateString(fromDate);
+                .withFromDateString(fromDate)
+                .build();
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getSearchDateParams().getFromDate().toString(), is(fromDate));
         assertThat(searchParams.getSearchDateParams().getToDate(), is(nullValue()));
@@ -88,10 +94,11 @@ public class PaymentViewValidatorTest {
     @Test
     public void shouldLeaveFromDateNull_whenMissing() {
         String toDate = "2018-05-04T15:00Z";
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(2L)
                 .withDisplaySize(3L)
-                .withToDateString(toDate);
+                .withToDateString(toDate)
+                .build();
         searchParams = validator.validateParams(searchParams);
         assertThat(searchParams.getSearchDateParams().getFromDate(), is(nullValue()));
         assertThat(searchParams.getSearchDateParams().getToDate().toString(), is(toDate));
@@ -103,11 +110,12 @@ public class PaymentViewValidatorTest {
         String toDate = "2018-05-04T15:00Z";
         thrown.expect(InvalidDateException.class);
         thrown.expectMessage("from_date (2018-05-05T15:00Z) must be earlier then to_date (2018-05-04T15:00Z)");
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(2L)
                 .withDisplaySize(3L)
                 .withFromDateString(fromDate)
-                .withToDateString(toDate);
+                .withToDateString(toDate)
+                .build();
         validator.validateParams(searchParams);
     }
 
@@ -117,11 +125,12 @@ public class PaymentViewValidatorTest {
         String toDate = "2018-05-35T15:00Z";
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input toDate (2018-05-35T15:00Z) is wrong format");
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(3L)
                 .withDisplaySize(256L)
                 .withFromDateString(fromDate)
-                .withToDateString(toDate);
+                .withToDateString(toDate)
+                .build();
         validator.validateParams(searchParams);
     }
 
@@ -131,11 +140,12 @@ public class PaymentViewValidatorTest {
         String toDate = "2018-05-04T15:00Z";
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input fromDate (2018-05-03T15:00Z') is wrong format");
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(2L)
                 .withDisplaySize(3L)
                 .withFromDateString(fromDate)
-                .withToDateString(toDate);
+                .withToDateString(toDate)
+                .build();
         validator.validateParams(searchParams);
     }
 
@@ -145,11 +155,12 @@ public class PaymentViewValidatorTest {
         String toDate = "2018-05-04T15:00Z";
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input fromDate (%2018-05-03T15:00Z) is wrong format");
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("a-gateway-account")
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("a-gateway-account")
                 .withPage(2L)
                 .withDisplaySize(3L)
                 .withFromDateString(fromDate)
-                .withToDateString(toDate);
+                .withToDateString(toDate)
+                .build();
         validator.validateParams(searchParams);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
@@ -69,8 +69,8 @@ public class PaymentViewDaoIT {
                     .insert(testContext.getJdbi());
         }
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withPage(0L)
-                .withDisplaySize(100L)
+                .withPage(0)
+                .withDisplaySize(100)
                 .withSearchDateParams(searchDateParams)
                 .build();
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
@@ -96,8 +96,8 @@ public class PaymentViewDaoIT {
                     .insert(testContext.getJdbi());
         }
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withPage(2L)
-                .withDisplaySize(1L)
+                .withPage(2)
+                .withDisplaySize(1)
                 .withSearchDateParams(searchDateParams)
                 .build();
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
@@ -131,8 +131,8 @@ public class PaymentViewDaoIT {
                     .insert(testContext.getJdbi());
         }
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withPage(1L)
-                .withDisplaySize(100L)
+                .withPage(1)
+                .withDisplaySize(100)
                 .withFromDateString(zonedDateTime7DaysAgo.toString())
                 .withSearchDateParams(new SearchDateParams(zonedDateTime7DaysAgo, zonedDateTimeNow))
                 .build();
@@ -213,8 +213,8 @@ public class PaymentViewDaoIT {
                     .insert(testContext.getJdbi());
         }
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withPage(2L)
-                .withDisplaySize(100L)
+                .withPage(2)
+                .withDisplaySize(100)
                 .withSearchDateParams(searchDateParams)
                 .build();
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
@@ -240,8 +240,8 @@ public class PaymentViewDaoIT {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withMandateId(mandateFixture.getExternalId().toString())
                 .build();
-        Long count = paymentViewDao.getPaymentViewCount(searchParams);
-        assertThat(count, is(3L));
+        Integer count = paymentViewDao.getPaymentViewCount(searchParams);
+        assertThat(count, is(3));
     }
 
     @Test
@@ -281,8 +281,8 @@ public class PaymentViewDaoIT {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withMandateId(mandateFixture1.getExternalId().toString())
                 .build();
-        Long count = paymentViewDao.getPaymentViewCount(searchParams);
-        assertThat(count, is(3L));
+        Integer count = paymentViewDao.getPaymentViewCount(searchParams);
+        assertThat(count, is(3));
         List<PaymentResponse> paymentViews = paymentViewDao.searchPaymentView(searchParams);
         assertThat(paymentViews.size(), is(3));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
@@ -28,6 +28,7 @@ import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFix
 import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
+import static uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams.PaymentViewSearchParamsBuilder.aPaymentViewSearchParams;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
@@ -67,10 +68,11 @@ public class PaymentViewDaoIT {
                     .withAmount(1000L + i)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withPage(0L)
                 .withDisplaySize(100L)
-                .withSearchDateParams(searchDateParams);
+                .withSearchDateParams(searchDateParams)
+                .build();
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(3));
     }
@@ -93,17 +95,18 @@ public class PaymentViewDaoIT {
                     .withAmount(1000L + i)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withPage(2L)
                 .withDisplaySize(1L)
-                .withSearchDateParams(searchDateParams);
+                .withSearchDateParams(searchDateParams)
+                .build();
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
     }
 
     @Test
     public void shouldReturnAnEmptyList_whenNoMatchingGatewayAccounts() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams("invalid-external-id");
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams("invalid-external-id").build();
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.isEmpty(), is(true));
     }
@@ -127,11 +130,12 @@ public class PaymentViewDaoIT {
                     .withAmount(1000L + i)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withPage(1L)
                 .withDisplaySize(100L)
                 .withFromDateString(zonedDateTime7DaysAgo.toString())
-                .withSearchDateParams(new SearchDateParams(zonedDateTime7DaysAgo, zonedDateTimeNow));
+                .withSearchDateParams(new SearchDateParams(zonedDateTime7DaysAgo, zonedDateTimeNow))
+                .build();
         List<PaymentResponse> paymentViewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(paymentViewList.size(), is(2));
         assertThat(paymentViewList.get(0).getCreatedDate().isAfter(zonedDateTime7DaysAgo), is(true));
@@ -157,8 +161,9 @@ public class PaymentViewDaoIT {
                     .withAmount(((long) 200 + i))
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withReference("bkh");
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withReference("bkh")
+                .build();
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(2));
         assertThat(viewList.get(0).getReference(), is(referenceList.get(2)));
@@ -181,9 +186,10 @@ public class PaymentViewDaoIT {
                     .withAmount(((long) 200 + i))
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withAmount(202L)
-                .withSearchDateParams(searchDateParams);
+                .withSearchDateParams(searchDateParams)
+                .build();
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
         assertThat(viewList.get(0).getReference(), is("ref2"));
@@ -206,10 +212,11 @@ public class PaymentViewDaoIT {
                     .withAmount(1000L + i)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
                 .withPage(2L)
                 .withDisplaySize(100L)
-                .withSearchDateParams(searchDateParams);
+                .withSearchDateParams(searchDateParams)
+                .build();
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
     }
@@ -230,8 +237,9 @@ public class PaymentViewDaoIT {
                     .withAmount(1000L + i)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withMandateId(mandateFixture.getExternalId().toString());
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withMandateId(mandateFixture.getExternalId().toString())
+                .build();
         Long count = paymentViewDao.getPaymentViewCount(searchParams);
         assertThat(count, is(3L));
     }
@@ -270,8 +278,9 @@ public class PaymentViewDaoIT {
                     .withMandateFixture(mandateFixture1)
                     .insert(testContext.getJdbi());
         }
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withMandateId(mandateFixture1.getExternalId().toString());
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withMandateId(mandateFixture1.getExternalId().toString())
+                .build();
         Long count = paymentViewDao.getPaymentViewCount(searchParams);
         assertThat(count, is(3L));
         List<PaymentResponse> paymentViews = paymentViewDao.searchPaymentView(searchParams);
@@ -302,8 +311,9 @@ public class PaymentViewDaoIT {
                 .withState(PaymentState.FAILED)
                 .insert(testContext.getJdbi());
 
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withState("started");
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withState("started")
+                .build();
 
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
@@ -333,8 +343,9 @@ public class PaymentViewDaoIT {
                 .withState(PaymentState.PENDING)
                 .insert(testContext.getJdbi());
 
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withState("pending");
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withState("pending")
+                .build();
 
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
@@ -364,8 +375,9 @@ public class PaymentViewDaoIT {
                 .withState(PaymentState.USER_CANCEL_NOT_ELIGIBLE)
                 .insert(testContext.getJdbi());
 
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withState("cancelled");
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withState("cancelled")
+                .build();
 
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
@@ -395,8 +407,9 @@ public class PaymentViewDaoIT {
                 .withState(PaymentState.SUCCESS)
                 .insert(testContext.getJdbi());
 
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withState("success");
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withState("success")
+                .build();
 
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(1));
@@ -442,8 +455,9 @@ public class PaymentViewDaoIT {
                     .insert(testContext.getJdbi());
         }
 
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountFixture.getExternalId())
-                .withState("failed");
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountFixture.getExternalId())
+                .withState("failed")
+                .build();
 
         List<PaymentResponse> viewList = paymentViewDao.searchPaymentView(searchParams);
         assertThat(viewList.size(), is(6));

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResultTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResultTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams.PaymentViewSearchParamsBuilder.aPaymentViewSearchParams;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LinksForSearchResultTest {
@@ -34,9 +35,10 @@ public class LinksForSearchResultTest {
 
     @Test
     public void shouldNotShowPrevLinkAndFirstLinkIsEqualToLastLink_whenOnlyOnePage() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
                 .withPage(1L)
-                .withDisplaySize(500L);
+                .withDisplaySize(500L)
+                .build();
         LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120L);
         assertThat(builder.getPrevLink(), is(nullValue()));
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
@@ -47,9 +49,10 @@ public class LinksForSearchResultTest {
 
     @Test
     public void shouldShowPrevLinkAndFirstLinkAndLastLinkAsPage1_whenCurrentPageIsBiggerThanLastPage() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
                 .withPage(777L)
-                .withDisplaySize(500L);
+                .withDisplaySize(500L)
+                .build();
         LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120L);
         assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=500"), is(true));
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
@@ -59,9 +62,10 @@ public class LinksForSearchResultTest {
 
     @Test
     public void shouldShowPrevLinkAndFirstLinkAsEqualsAndLastLinkAndNextLinkAsEquals() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
                 .withPage(2L)
-                .withDisplaySize(50L);
+                .withDisplaySize(50L)
+                .build();
         LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120L);
         assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=50"), is(true));
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=50"), is(true));
@@ -72,9 +76,10 @@ public class LinksForSearchResultTest {
 
     @Test
     public void shouldShowAllLinksCorrectly_whenMultiplePagesExists() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
                 .withPage(3L)
-                .withDisplaySize(10L);
+                .withDisplaySize(10L)
+                .build();
         LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120L);
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=10"), is(true));
         assertThat(builder.getLastLink().getHref().contains("?page=12&display_size=10"), is(true));

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResultTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResultTest.java
@@ -36,10 +36,10 @@ public class LinksForSearchResultTest {
     @Test
     public void shouldNotShowPrevLinkAndFirstLinkIsEqualToLastLink_whenOnlyOnePage() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
-                .withPage(1L)
-                .withDisplaySize(500L)
+                .withPage(1)
+                .withDisplaySize(500)
                 .build();
-        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120L);
+        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120);
         assertThat(builder.getPrevLink(), is(nullValue()));
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
         assertThat(builder.getLastLink().getHref().contains("?page=1&display_size=500"), is(true));
@@ -50,10 +50,10 @@ public class LinksForSearchResultTest {
     @Test
     public void shouldShowPrevLinkAndFirstLinkAndLastLinkAsPage1_whenCurrentPageIsBiggerThanLastPage() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
-                .withPage(777L)
-                .withDisplaySize(500L)
+                .withPage(777)
+                .withDisplaySize(500)
                 .build();
-        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120L);
+        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120);
         assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=500"), is(true));
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
         assertThat(builder.getLastLink().getHref().contains("?page=1&display_size=500"), is(true));
@@ -63,10 +63,10 @@ public class LinksForSearchResultTest {
     @Test
     public void shouldShowPrevLinkAndFirstLinkAsEqualsAndLastLinkAndNextLinkAsEquals() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
-                .withPage(2L)
-                .withDisplaySize(50L)
+                .withPage(2)
+                .withDisplaySize(50)
                 .build();
-        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120L);
+        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120);
         assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=50"), is(true));
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=50"), is(true));
         assertThat(builder.getLastLink().getHref().contains("?page=3&display_size=50"), is(true));
@@ -77,10 +77,10 @@ public class LinksForSearchResultTest {
     @Test
     public void shouldShowAllLinksCorrectly_whenMultiplePagesExists() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
-                .withPage(3L)
-                .withDisplaySize(10L)
+                .withPage(3)
+                .withDisplaySize(10)
                 .build();
-        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120L);
+        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120);
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=10"), is(true));
         assertThat(builder.getLastLink().getHref().contains("?page=12&display_size=10"), is(true));
         assertThat(builder.getPrevLink().getHref().contains("?page=2&display_size=10"), is(true));

--- a/src/test/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParamsTest.java
@@ -20,15 +20,15 @@ public class PaymentViewSearchParamsTest {
     @Test
     public void shouldCreateQueryMap() {
         searchParams = aPaymentViewSearchParams("account-id")
-                .withPage(2L)
-                .withDisplaySize(600L)
+                .withPage(2)
+                .withDisplaySize(600)
                 .withFromDateString(fromDate.toString())
                 .withToDateString(toDate.toString())
                 .build();        
         searchParams = new PaymentViewValidator().validateParams(searchParams);
         assertThat(searchParams.getQueryMap().get("gatewayAccountExternalId"), is("account-id"));
-        assertThat(searchParams.getQueryMap().get("offset"), is(500L));
-        assertThat(searchParams.getQueryMap().get("limit"), is(500L));
+        assertThat(searchParams.getQueryMap().get("offset"), is(500));
+        assertThat(searchParams.getQueryMap().get("limit"), is(500));
         assertThat(searchParams.getQueryMap().containsKey("fromDate"), is(true));
         assertThat(searchParams.getQueryMap().containsKey("toDate"), is(true));
     }

--- a/src/test/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParamsTest.java
@@ -9,6 +9,7 @@ import java.time.ZonedDateTime;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams.PaymentViewSearchParamsBuilder.aPaymentViewSearchParams;
 
 public class PaymentViewSearchParamsTest {
 
@@ -18,11 +19,12 @@ public class PaymentViewSearchParamsTest {
     
     @Test
     public void shouldCreateQueryMap() {
-        searchParams = new PaymentViewSearchParams("account-id")
-                                .withPage(2L)
-        .withDisplaySize(600L)
-        .withFromDateString(fromDate.toString())
-        .withToDateString(toDate.toString());        
+        searchParams = aPaymentViewSearchParams("account-id")
+                .withPage(2L)
+                .withDisplaySize(600L)
+                .withFromDateString(fromDate.toString())
+                .withToDateString(toDate.toString())
+                .build();        
         searchParams = new PaymentViewValidator().validateParams(searchParams);
         assertThat(searchParams.getQueryMap().get("gatewayAccountExternalId"), is("account-id"));
         assertThat(searchParams.getQueryMap().get("offset"), is(500L));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentSearchServiceTest.java
@@ -43,6 +43,7 @@ import static uk.gov.pay.directdebit.payers.fixtures.PayerFixture.aPayerFixture;
 import static uk.gov.pay.directdebit.payments.api.PaymentResponse.PaymentResponseBuilder.aPaymentResponse;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
+import static uk.gov.pay.directdebit.payments.params.PaymentViewSearchParams.PaymentViewSearchParamsBuilder.aPaymentViewSearchParams;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PaymentSearchServiceTest {
@@ -88,11 +89,12 @@ public class PaymentSearchServiceTest {
 
     @Test
     public void getPaymentViewList_withGatewayAccountIdAndOffsetAndLimit_shouldPopulateResponse() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
                 .withPage(1L)
                 .withDisplaySize(100L)
                 .withFromDateString(createdDate.toString())
-                .withToDateString(createdDate.toString());
+                .withToDateString(createdDate.toString())
+                .build();
         
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(gatewayAccount));
         when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);
@@ -106,11 +108,12 @@ public class PaymentSearchServiceTest {
 
     @Test
     public void shouldThrowGatewayAccountNotFoundException_whenGatewayNotExists() {
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
                 .withPage(10L)
                 .withDisplaySize(100L)
                 .withFromDateString(createdDate.toString())
-                .withToDateString(createdDate.toString());
+                .withToDateString(createdDate.toString())
+                .build();
         thrown.expect(GatewayAccountNotFoundException.class);
         thrown.expectMessage("Unknown gateway account: " + gatewayAccountExternalId);
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.empty());
@@ -149,9 +152,10 @@ public class PaymentSearchServiceTest {
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(testGatewayAccount));
         when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(50L);
         when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
                 .withPage(2L)
-                .withDisplaySize(20L);
+                .withDisplaySize(20L)
+                .build();
         SearchResponse paymentViewResponse = paymentSearchService.getPaymentSearchResponse(searchParams);
         assertThat(paymentViewResponse.getCount(), is(20));
         assertThat(paymentViewResponse.getPage(), is(2L));
@@ -171,8 +175,9 @@ public class PaymentSearchServiceTest {
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(testGatewayAccount));
         when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(18L);
         when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);
-        PaymentViewSearchParams searchParams = new PaymentViewSearchParams(gatewayAccountExternalId)
-                .withPage(2L);
+        PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
+                .withPage(2L)
+                .build();
         SearchResponse<PaymentResponse> paymentViewResponse = paymentSearchService.getPaymentSearchResponse(searchParams);
         assertThat(paymentViewResponse.getCount(), is(0));
         assertThat(paymentViewResponse.getPage(), is(2L));

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentSearchServiceTest.java
@@ -90,15 +90,15 @@ public class PaymentSearchServiceTest {
     @Test
     public void getPaymentViewList_withGatewayAccountIdAndOffsetAndLimit_shouldPopulateResponse() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
-                .withPage(1L)
-                .withDisplaySize(100L)
+                .withPage(1)
+                .withDisplaySize(100)
                 .withFromDateString(createdDate.toString())
                 .withToDateString(createdDate.toString())
                 .build();
         
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(gatewayAccount));
         when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);
-        when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(4L);
+        when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(4);
         SearchResponse<PaymentResponse> response = paymentSearchService.getPaymentSearchResponse(searchParams);
         assertThat(response.getResults().get(3).getAmount(), is(1003L));
         assertThat(response.getResults().get(0).getState(),
@@ -109,8 +109,8 @@ public class PaymentSearchServiceTest {
     @Test
     public void shouldThrowGatewayAccountNotFoundException_whenGatewayNotExists() {
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
-                .withPage(10L)
-                .withDisplaySize(100L)
+                .withPage(10)
+                .withDisplaySize(100)
                 .withFromDateString(createdDate.toString())
                 .withToDateString(createdDate.toString())
                 .build();
@@ -150,16 +150,16 @@ public class PaymentSearchServiceTest {
                     .build());
         }
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(testGatewayAccount));
-        when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(50L);
+        when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(50);
         when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
-                .withPage(2L)
-                .withDisplaySize(20L)
+                .withPage(2)
+                .withDisplaySize(20)
                 .build();
         SearchResponse paymentViewResponse = paymentSearchService.getPaymentSearchResponse(searchParams);
         assertThat(paymentViewResponse.getCount(), is(20));
-        assertThat(paymentViewResponse.getPage(), is(2L));
-        assertThat(paymentViewResponse.getTotal(), is(50L));
+        assertThat(paymentViewResponse.getPage(), is(2));
+        assertThat(paymentViewResponse.getTotal(), is(50));
         assertThat(paymentViewResponse.getLinksForSearchResult().getFirstLink().getHref().contains("?page=1"), is(true));
         assertThat(paymentViewResponse.getLinksForSearchResult().getLastLink().getHref().contains("?page=3"), is(true));
         assertThat(paymentViewResponse.getLinksForSearchResult().getPrevLink().getHref().contains("?page=1"), is(true));
@@ -173,15 +173,15 @@ public class PaymentSearchServiceTest {
         GatewayAccount testGatewayAccount = gatewayAccountFixture.toEntity();
         List<PaymentResponse> paymentViewList = new ArrayList<>();
         when(gatewayAccountDao.findByExternalId(gatewayAccountExternalId)).thenReturn(Optional.of(testGatewayAccount));
-        when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(18L);
+        when(paymentViewDao.getPaymentViewCount(any(PaymentViewSearchParams.class))).thenReturn(18);
         when(paymentViewDao.searchPaymentView(any(PaymentViewSearchParams.class))).thenReturn(paymentViewList);
         PaymentViewSearchParams searchParams = aPaymentViewSearchParams(gatewayAccountExternalId)
-                .withPage(2L)
+                .withPage(2)
                 .build();
         SearchResponse<PaymentResponse> paymentViewResponse = paymentSearchService.getPaymentSearchResponse(searchParams);
         assertThat(paymentViewResponse.getCount(), is(0));
-        assertThat(paymentViewResponse.getPage(), is(2L));
-        assertThat(paymentViewResponse.getTotal(), is(18L));
+        assertThat(paymentViewResponse.getPage(), is(2));
+        assertThat(paymentViewResponse.getTotal(), is(18));
         assertThat(paymentViewResponse.getResults().size(), is(0));
         assertThat(paymentViewResponse.getLinksForSearchResult().getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
         assertThat(paymentViewResponse.getLinksForSearchResult().getLastLink().getHref().contains("?page=1&display_size=500"), is(true));


### PR DESCRIPTION
In preparation for using a common interface for `PaymentViewSearchParams` and `MandateSearchParams` the following changes have been made:
- Make fields immutable and introduce a proper builder with static method to create a builder from an existing object.
- Clarify logic within `LinksForSearchResult` to no longer mutate the provided   
 `PaymentViewSearchParams` which has confusing side-effects for callers that provided it.
- For consistency with MandateSearchParams and in preparation for a common interface change page and displaySize from Long to Integer.
