### PR TITLE
PP-5431 Add latest GoCardless event to payment state calculator

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
@@ -14,6 +14,7 @@ import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEventIdArgumentFactory;
 import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdAndOrganisationId;
 import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdArgumentFactory;
 
 import java.util.Optional;
@@ -104,6 +105,38 @@ public interface GoCardlessEventDao {
             "ORDER BY created_at DESC " +
             "LIMIT 1")
     Optional<GoCardlessEvent> findLatestApplicableEventForMandate(@BindBean GoCardlessMandateIdAndOrganisationId goCardlessMandateIdAndOrganisationId,
+                                                                  @BindList("applicableActions") Set<String> applicableActions);
+
+    @SqlQuery("SELECT id, " +
+            "internal_event_id, " +
+            "event_id, " +
+            "action, " +
+            "created_at, " +
+            "details_cause, " +
+            "details_description, " +
+            "details_origin, " +
+            "details_reason_code, " +
+            "details_scheme, " +
+            "resource_type," +
+            "links_mandate, " +
+            "links_new_customer_bank_account, " +
+            "links_new_mandate, " +
+            "links_organisation, " +
+            "links_parent_event, " +
+            "links_payment, " +
+            "links_payout, " +
+            "links_previous_customer_bank_account, " +
+            "links_refund, " +
+            "links_subscription, " +
+            "json, " +
+            "event_id " +
+            "FROM gocardless_events " +
+            "WHERE links_payment = :goCardlessPaymentId " +
+            "AND links_organisation = :goCardlessOrganisationId " +
+            "AND action IN (<applicableActions>) " +
+            "ORDER BY created_at DESC " +
+            "LIMIT 1")
+    Optional<GoCardlessEvent> findLatestApplicableEventForPayment(@BindBean GoCardlessPaymentIdAndOrganisationId goCardlessPaymentIdAndOrganisationId,
                                                                   @BindList("applicableActions") Set<String> applicableActions);
 
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculator.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.directdebit.payments.services.gocardless;
+
+import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdAndOrganisationId;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static uk.gov.pay.directdebit.payments.model.PaymentState.FAILED;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.SUCCESS;
+
+public class GoCardlessPaymentStateCalculator {
+
+    private final GoCardlessEventDao goCardlessEventDao;
+
+    private static final Map<String, PaymentState> GOCARDLESS_ACTION_TO_PAYMENT_STATE = Map.of(
+            "failed", FAILED,
+            "paid_out", SUCCESS
+    );
+
+    static final Set<String> GOCARDLESS_ACTIONS_THAT_CHANGE_STATE = GOCARDLESS_ACTION_TO_PAYMENT_STATE.keySet();
+
+    @Inject
+    GoCardlessPaymentStateCalculator(GoCardlessEventDao goCardlessEventDao) {
+        this.goCardlessEventDao = goCardlessEventDao;
+    }
+
+    Optional<PaymentState> calculate(GoCardlessPaymentIdAndOrganisationId goCardlessPaymentIdAndOrganisationId) {
+        return goCardlessEventDao.findLatestApplicableEventForPayment(goCardlessPaymentIdAndOrganisationId, GOCARDLESS_ACTIONS_THAT_CHANGE_STATE)
+                .map(GoCardlessEvent::getAction)
+                .map(GOCARDLESS_ACTION_TO_PAYMENT_STATE::get);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculatorTest.java
@@ -1,0 +1,79 @@
+package uk.gov.pay.directdebit.payments.services.gocardless;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdAndOrganisationId;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+
+import java.util.Optional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.directdebit.payments.services.gocardless.GoCardlessPaymentStateCalculator.GOCARDLESS_ACTIONS_THAT_CHANGE_STATE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoCardlessPaymentStateCalculatorTest {
+
+    @Mock
+    private GoCardlessPaymentIdAndOrganisationId mockGoCardlessPaymentIdAndOrganisationId;
+
+    @Mock
+    private GoCardlessEvent mockGoCardlessEvent;
+
+    @Mock
+    private GoCardlessEventDao mockGoCardlessEventDao;
+
+    private GoCardlessPaymentStateCalculator goCardlessPaymentStateCalculator;
+
+    @Before
+    public void setUp() {
+        given(mockGoCardlessEventDao.findLatestApplicableEventForPayment(mockGoCardlessPaymentIdAndOrganisationId, GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                .willReturn(Optional.of(mockGoCardlessEvent));
+
+        goCardlessPaymentStateCalculator = new GoCardlessPaymentStateCalculator(mockGoCardlessEventDao);
+    }
+
+    @Test
+    public void failedActionMapsToFailedState() {
+        given(mockGoCardlessEvent.getAction()).willReturn("failed");
+
+        Optional<PaymentState> paymentState = goCardlessPaymentStateCalculator.calculate(mockGoCardlessPaymentIdAndOrganisationId);
+
+        assertThat(paymentState.get(), is(PaymentState.FAILED));
+    }
+
+    @Test
+    public void paidOutActionMapsToSuccessState() {
+        given(mockGoCardlessEvent.getAction()).willReturn("paid_out");
+
+        Optional<PaymentState> paymentState = goCardlessPaymentStateCalculator.calculate(mockGoCardlessPaymentIdAndOrganisationId);
+
+        assertThat(paymentState.get(), is(PaymentState.SUCCESS));
+    }
+
+    @Test
+    public void unrecognisedActionMapsToNothing() {
+        given(mockGoCardlessEvent.getAction()).willReturn("eaten_by_wolves");
+
+        Optional<PaymentState> paymentState = goCardlessPaymentStateCalculator.calculate(mockGoCardlessPaymentIdAndOrganisationId);
+
+        assertThat(paymentState, is(Optional.empty()));
+    }
+
+    @Test
+    public void noApplicableEventsMapsToNothing() {
+        given(mockGoCardlessEventDao.findLatestApplicableEventForPayment(mockGoCardlessPaymentIdAndOrganisationId, GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                .willReturn(Optional.empty());
+
+        Optional<PaymentState> paymentState = goCardlessPaymentStateCalculator.calculate(mockGoCardlessPaymentIdAndOrganisationId);
+
+        assertThat(paymentState, is(Optional.empty()));
+    }
+
+}


### PR DESCRIPTION
Add a calculator that, given a GoCardless payment ID and a GoCardless organisation ID, finds the latest state-changing event that GoCardless sent us for that payment and maps the event’s action to the new payment state.

No actual updating of the state; that will come later.