### PR TITLE
PP-5302 Add logic for mandate search to MandateResource

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
@@ -11,6 +11,7 @@ import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
 import uk.gov.pay.directdebit.events.dao.SandboxEventDao;
 import uk.gov.pay.directdebit.gatewayaccounts.dao.GatewayAccountDao;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
+import uk.gov.pay.directdebit.mandate.dao.MandateSearchDao;
 import uk.gov.pay.directdebit.notifications.clients.AdminUsersClient;
 import uk.gov.pay.directdebit.notifications.clients.ClientFactory;
 import uk.gov.pay.directdebit.partnerapp.client.GoCardlessAppConnectClient;
@@ -140,5 +141,11 @@ public class DirectDebitModule extends AbstractModule {
     @Singleton
     public GoCardlessAppConnectAccountTokenDao providePartnerAppTokenDao() {
         return jdbi.onDemand(GoCardlessAppConnectAccountTokenDao.class);
+    }
+    
+    @Provides
+    @Singleton
+    public MandateSearchDao provideMandateSearchDao() {
+        return new MandateSearchDao(jdbi);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/model/SearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/SearchParams.java
@@ -4,6 +4,5 @@ public interface SearchParams {
 
     Integer getPage();
     Integer getDisplaySize();
-    String getGatewayExternalId();
     String buildQueryParamString();
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDao.java
@@ -11,18 +11,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class MandateSearchDao {
+public class MandateSearchDao {
     
     private final Jdbi jdbi;
 
     @Inject
-    MandateSearchDao(Jdbi jdbi) {
+    public MandateSearchDao(Jdbi jdbi) {
         this.jdbi = jdbi;
     }
 
-    List<Mandate> search(MandateSearchParams mandateSearchParams) {
+    public List<Mandate> search(MandateSearchParams mandateSearchParams, String gatewayAccountExternalId) {
         return jdbi.withHandle(handle -> {
-            var sqlQueryAndParameters = createSqlQuery(mandateSearchParams, SearchMode.SELECT);
+            var sqlQueryAndParameters = createSqlQuery(mandateSearchParams, gatewayAccountExternalId, SearchMode.SELECT);
 
             Query query = handle.createQuery(sqlQueryAndParameters.query);
             sqlQueryAndParameters.parameters.forEach(query::bind);
@@ -30,9 +30,9 @@ class MandateSearchDao {
         });
     }
 
-    int countTotalMatchingMandates(MandateSearchParams mandateSearchParams) {
+    public int countTotalMatchingMandates(MandateSearchParams mandateSearchParams, String gatewayAccountExternalId) {
         return jdbi.withHandle(handle -> {
-            var sqlQueryAndParameters = createSqlQuery(mandateSearchParams, SearchMode.COUNT);
+            var sqlQueryAndParameters = createSqlQuery(mandateSearchParams, gatewayAccountExternalId, SearchMode.COUNT);
             
             Query query = handle.createQuery(sqlQueryAndParameters.query);
             sqlQueryAndParameters.parameters.forEach(query::bind);
@@ -40,7 +40,7 @@ class MandateSearchDao {
         });
     }
 
-    private SqlStatementAndParameters createSqlQuery(MandateSearchParams params, SearchMode searchMode) {
+    private SqlStatementAndParameters createSqlQuery(MandateSearchParams params, String gatewayAccountExternalId, SearchMode searchMode) {
         var sql = new StringBuilder(2048);
         if (searchMode.equals(SearchMode.COUNT)) {
             sql.append("SELECT COUNT(*) ");
@@ -82,7 +82,7 @@ class MandateSearchDao {
         Map<String, Object> sqlParams = new HashMap<>();
         
         sql.append(" WHERE g.external_id = :gatewayAccountExternalId");
-        sqlParams.put("gatewayAccountExternalId", params.getGatewayAccountExternalId());
+        sqlParams.put("gatewayAccountExternalId", gatewayAccountExternalId);
         
         params.getServiceReference().filter(s -> !s.isBlank()).ifPresent(serviceReference -> {
             sql.append(" AND m.service_reference ILIKE :serviceReference");

--- a/src/main/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParams.java
@@ -7,6 +7,7 @@ import uk.gov.pay.directdebit.mandate.model.MandateState;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -47,15 +48,29 @@ public class MandateSearchParams implements SearchParams {
     private String toDate;
 
     @QueryParam(PAGE)
+    @DefaultValue("1")
     @Min(value = 1, message = "Invalid attribute value: page. Must be greater than or equal to {value}")
     private Integer page = 1;
 
     @QueryParam(DISPLAY_SIZE)
+    @DefaultValue("500")
     @Min(value = 1, message = "Invalid attribute value: display_size. Must be greater than or equal to {value}")
     @Max(value = 500, message = "Invalid attribute value: display_size. Must be less than or equal to {value}")
     private Integer displaySize = 500;
-
-    private String gatewayAccountExternalId;
+    
+    public MandateSearchParams() { };
+    
+    private MandateSearchParams(MandateSearchParamsBuilder builder) {
+        this.serviceReference = builder.serviceReference; 
+        this.mandateState = builder.mandateState;
+        this.mandateBankStatementReference = builder.mandateBankStatementReference;
+        this.name = builder.name;
+        this.email = builder.email;
+        this.fromDate = builder.fromDate;
+        this.toDate = builder.toDate;
+        this.page = builder.page;
+        this.displaySize = builder.displaySize;
+    }
 
     public Optional<String> getServiceReference() {
         return Optional.ofNullable(serviceReference);
@@ -92,12 +107,7 @@ public class MandateSearchParams implements SearchParams {
     public Integer getDisplaySize() {
         return displaySize;
     }
-
-    @Override
-    public String getGatewayExternalId() {
-        return this.gatewayAccountExternalId;
-    }
-
+    
     @Override
     public String buildQueryParamString() {
         var query = new StringBuilder();
@@ -143,11 +153,7 @@ public class MandateSearchParams implements SearchParams {
     private String createQueryParamFor(String name, String value) {
         return name + "=" + value;
     }
-
-    public String getGatewayAccountExternalId() {
-        return gatewayAccountExternalId;
-    }
-
+    
     public static final class MandateSearchParamsBuilder {
         private String serviceReference;
         private MandateState mandateState;
@@ -158,14 +164,9 @@ public class MandateSearchParams implements SearchParams {
         private String toDate;
         private Integer page = 1;
         private Integer displaySize = 500;
-        private String gatewayAccountExternalId;
-
-        private MandateSearchParamsBuilder(String gatewayAccountExternalId) {
-            this.gatewayAccountExternalId = gatewayAccountExternalId;
-        }
-
-        public static MandateSearchParamsBuilder aMandateSearchParams(String gatewayAccountExternalId) {
-            return new MandateSearchParamsBuilder(gatewayAccountExternalId);
+        
+        public static MandateSearchParamsBuilder aMandateSearchParams() {
+            return new MandateSearchParamsBuilder();
         }
 
         public MandateSearchParamsBuilder withServiceReference(String serviceReference) {
@@ -213,24 +214,8 @@ public class MandateSearchParams implements SearchParams {
             return this;
         }
 
-        public MandateSearchParamsBuilder withGatewayAccountExternalId(String gatewayAccountExternalId) {
-            this.gatewayAccountExternalId = gatewayAccountExternalId;
-            return this;
-        }
-
         public MandateSearchParams build() {
-            MandateSearchParams mandateSearchParams = new MandateSearchParams();
-            mandateSearchParams.mandateBankStatementReference = this.mandateBankStatementReference;
-            mandateSearchParams.page = this.page;
-            mandateSearchParams.serviceReference = this.serviceReference;
-            mandateSearchParams.displaySize = this.displaySize;
-            mandateSearchParams.toDate = this.toDate;
-            mandateSearchParams.name = this.name;
-            mandateSearchParams.gatewayAccountExternalId = this.gatewayAccountExternalId;
-            mandateSearchParams.email = this.email;
-            mandateSearchParams.fromDate = this.fromDate;
-            mandateSearchParams.mandateState = this.mandateState;
-            return mandateSearchParams;
+            return new MandateSearchParams(this);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/resources/MandateResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/resources/MandateResource.java
@@ -3,8 +3,8 @@ package uk.gov.pay.directdebit.mandate.resources;
 import com.codahale.metrics.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.common.model.SearchResponse;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
-import uk.gov.pay.directdebit.gatewayaccounts.services.GatewayAccountService;
 import uk.gov.pay.directdebit.mandate.api.ConfirmMandateRequest;
 import uk.gov.pay.directdebit.mandate.api.CreateMandateRequest;
 import uk.gov.pay.directdebit.mandate.api.DirectDebitInfoFrontendResponse;
@@ -13,7 +13,9 @@ import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.mandate.params.MandateSearchParams;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
+import uk.gov.pay.directdebit.mandate.services.MandateQueryService.MandateSearchResults;
 import uk.gov.pay.directdebit.mandate.services.MandateService;
+import uk.gov.pay.directdebit.payments.model.LinksForSearchResult;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -29,6 +31,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.created;
@@ -52,9 +55,26 @@ public class MandateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Timed
-    public List<MandateResponse> searchMandates(@PathParam("accountId") GatewayAccount gatewayAccount,
-                                                @Valid @BeanParam MandateSearchParams mandateSearchParams) {
-        return List.of();
+    public SearchResponse<MandateResponse> searchMandates(@PathParam("accountId") GatewayAccount gatewayAccount,
+                                                          @Valid @BeanParam MandateSearchParams mandateSearchParams,
+                                                          @Context UriInfo uriInfo) {
+
+        MandateSearchResults results = mandateQueryService.search(mandateSearchParams, gatewayAccount.getExternalId());
+        List<MandateResponse> mandateResponses = results.getMandatesForRequestedPage()
+                .stream()
+                .map(mandate -> mandateService.populateGetMandateResponse(mandate, uriInfo))
+                .collect(Collectors.toList());
+
+        LinksForSearchResult linksForSearchResult =
+                new LinksForSearchResult(mandateSearchParams, uriInfo, results.getTotalMatchingMandates(), gatewayAccount.getExternalId());
+
+        return new SearchResponse<>(
+                gatewayAccount.getExternalId(),
+                results.getTotalMatchingMandates(),
+                mandateSearchParams.getPage(),
+                mandateResponses,
+                linksForSearchResult
+        );
     }
     
     @POST

--- a/src/main/java/uk/gov/pay/directdebit/mandate/resources/MandateResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/resources/MandateResource.java
@@ -13,7 +13,8 @@ import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.mandate.params.MandateSearchParams;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
-import uk.gov.pay.directdebit.mandate.services.MandateQueryService.MandateSearchResults;
+import uk.gov.pay.directdebit.mandate.services.MandateSearchService;
+import uk.gov.pay.directdebit.mandate.services.MandateSearchService.MandateSearchResults;
 import uk.gov.pay.directdebit.mandate.services.MandateService;
 import uk.gov.pay.directdebit.payments.model.LinksForSearchResult;
 
@@ -43,11 +44,13 @@ public class MandateResource {
     
     private final MandateService mandateService;
     private final MandateQueryService mandateQueryService;
+    private final MandateSearchService mandateSearchService;
 
     @Inject
-    public MandateResource(MandateService mandateService, MandateQueryService mandateQueryService) {
+    public MandateResource(MandateService mandateService, MandateQueryService mandateQueryService, MandateSearchService mandateSearchService) {
         this.mandateService = mandateService;
         this.mandateQueryService = mandateQueryService;
+        this.mandateSearchService = mandateSearchService;
     }
     
     @GET
@@ -59,7 +62,7 @@ public class MandateResource {
                                                           @Valid @BeanParam MandateSearchParams mandateSearchParams,
                                                           @Context UriInfo uriInfo) {
 
-        MandateSearchResults results = mandateQueryService.search(mandateSearchParams, gatewayAccount.getExternalId());
+        MandateSearchResults results = mandateSearchService.search(mandateSearchParams, gatewayAccount.getExternalId());
         List<MandateResponse> mandateResponses = results.getMandatesForRequestedPage()
                 .stream()
                 .map(mandate -> mandateService.populateGetMandateResponse(mandate, uriInfo))

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateQueryService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateQueryService.java
@@ -10,23 +10,19 @@ import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateId;
 import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
-import uk.gov.pay.directdebit.mandate.params.MandateSearchParams;
 import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 public class MandateQueryService {
     private MandateDao mandateDao;
-    private MandateSearchDao mandateSearchDao;
 
     @Inject
-    public MandateQueryService(MandateDao mandateDao, MandateSearchDao mandateSearchDao) {
+    public MandateQueryService(MandateDao mandateDao) {
         this.mandateDao = mandateDao;
-        this.mandateSearchDao = mandateSearchDao;
     }
 
     public Mandate findByExternalId(MandateExternalId externalId) {
@@ -65,31 +61,5 @@ public class MandateQueryService {
 
     public List<Mandate> findAllMandatesBySetOfStatesAndMaxCreationTime(Set<MandateState> states, ZonedDateTime cutOffTime) {
         return mandateDao.findAllMandatesBySetOfStatesAndMaxCreationTime(states, cutOffTime);
-    }
-    
-    public MandateSearchResults search(MandateSearchParams params, String gatewayAccountExternalId) {
-        int totalMatchingMandates = mandateSearchDao.countTotalMatchingMandates(params, gatewayAccountExternalId);
-        List<Mandate> mandatesForRequestedPage = 
-                totalMatchingMandates > 0 ? mandateSearchDao.search(params, gatewayAccountExternalId) : Collections.emptyList();
-
-        return new MandateSearchResults(totalMatchingMandates, mandatesForRequestedPage);
-    }
-    
-    public static class MandateSearchResults {
-        private final int totalMatchingMandates;
-        private final List<Mandate> mandatesForRequestedPage;
-
-        MandateSearchResults(int totalMatchingMandates, List<Mandate> mandatesForRequestedPage) {
-            this.totalMatchingMandates = totalMatchingMandates;
-            this.mandatesForRequestedPage = mandatesForRequestedPage;
-        }
-
-        public int getTotalMatchingMandates() {
-            return totalMatchingMandates;
-        }
-
-        public List<Mandate> getMandatesForRequestedPage() {
-            return mandatesForRequestedPage;
-        }
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateSearchService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateSearchService.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.directdebit.mandate.services;
+
+import uk.gov.pay.directdebit.mandate.dao.MandateDao;
+import uk.gov.pay.directdebit.mandate.dao.MandateSearchDao;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.params.MandateSearchParams;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+
+public class MandateSearchService {
+
+    private MandateSearchDao mandateSearchDao;
+
+    @Inject
+    public MandateSearchService(MandateSearchDao mandateSearchDao) {
+        this.mandateSearchDao = mandateSearchDao;
+    }
+
+    public MandateSearchResults search(MandateSearchParams params, String gatewayAccountExternalId) {
+        int totalMatchingMandates = mandateSearchDao.countTotalMatchingMandates(params, gatewayAccountExternalId);
+        List<Mandate> mandatesForRequestedPage =
+                totalMatchingMandates > 0 ? mandateSearchDao.search(params, gatewayAccountExternalId) : Collections.emptyList();
+
+        return new MandateSearchResults(totalMatchingMandates, mandatesForRequestedPage);
+    }
+
+    public static class MandateSearchResults {
+        private final int totalMatchingMandates;
+        private final List<Mandate> mandatesForRequestedPage;
+
+        MandateSearchResults(int totalMatchingMandates, List<Mandate> mandatesForRequestedPage) {
+            this.totalMatchingMandates = totalMatchingMandates;
+            this.mandatesForRequestedPage = mandatesForRequestedPage;
+        }
+
+        public int getTotalMatchingMandates() {
+            return totalMatchingMandates;
+        }
+
+        public List<Mandate> getMandatesForRequestedPage() {
+            return mandatesForRequestedPage;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -143,6 +143,11 @@ public class MandateService {
         List<Map<String, Object>> dataLinks = createLinks(mandate, accountExternalId, uriInfo);
         return new MandateResponse(mandate, dataLinks);
     }
+    
+    public MandateResponse populateGetMandateResponse(Mandate mandate, UriInfo uriInfo) {
+        var dataLinks = createLinks(mandate, mandate.getGatewayAccount().getExternalId(), uriInfo);
+        return new MandateResponse(mandate, dataLinks);
+    }
 
     public Mandate findByExternalId(MandateExternalId externalId) {
         return mandateDao

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResult.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResult.java
@@ -20,6 +20,7 @@ public class LinksForSearchResult {
     private final Integer pageNumberForSelfLink;
     private final Integer lastPageNumber;
     private final Integer previousPageNumber;
+    private final String gatewayAccountExternalId;
 
     @JsonProperty("self")
     private PaginationLink selfLink;
@@ -32,7 +33,7 @@ public class LinksForSearchResult {
     @JsonProperty("next_page")
     private PaginationLink nextLink;
 
-    public LinksForSearchResult(SearchParams searchParams, UriInfo uriInfo, Integer totalCount) {
+    public LinksForSearchResult(SearchParams searchParams, UriInfo uriInfo, Integer totalCount, String gatewayAccountExternalId) {
         this.uriInfo = uriInfo;
         this.totalCount = totalCount;
         this.searchParams = searchParams;
@@ -40,6 +41,7 @@ public class LinksForSearchResult {
         this.pageNumberForSelfLink = searchParams.getPage();
         this.lastPageNumber = calculateLastPageNumber();
         this.previousPageNumber = calculatePreviousPageNumber();
+        this.gatewayAccountExternalId = gatewayAccountExternalId;
         buildLinks();
     }
 
@@ -95,6 +97,6 @@ public class LinksForSearchResult {
         return uriInfo.getBaseUriBuilder()
                 .path(uriInfo.getPath())
                 .replaceQuery(params)
-                .build(searchParams.getGatewayExternalId());
+                .build(gatewayAccountExternalId);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentSearchService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentSearchService.java
@@ -34,7 +34,7 @@ public class PaymentSearchService {
         PaymentViewSearchParams validatedSearchParams = paymentViewValidator.validateParams(searchParams);
         Integer total = getTotal(validatedSearchParams);
         List<PaymentResponse> foundPayments = total > 0 ? getPaymentViewResultResponse(validatedSearchParams) : Collections.emptyList();
-        LinksForSearchResult linksForSearchResult = new LinksForSearchResult(validatedSearchParams, uriInfo, total);
+        LinksForSearchResult linksForSearchResult = new LinksForSearchResult(validatedSearchParams, uriInfo, total, searchParams.getGatewayExternalId());
         
         return new SearchResponse<PaymentResponse>(validatedSearchParams.getGatewayExternalId(),
                 total,

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDaoIT.java
@@ -66,88 +66,88 @@ public class MandateSearchDaoIT {
     @Test
     @Parameters({"REF1234", "ref1234", "f12"})
     public void searchByReference(String searchString) {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID).withServiceReference(searchString).build();
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        var searchParams = aMandateSearchParams().withServiceReference(searchString).build();
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(1);
-        assertThat(mandateSearchDao.search(searchParams)).containsExactly(mandate1.toEntity());
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactly(mandate1.toEntity());
     }
     
     @Test
     public void searchByState() {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID).withMandateState(FAILED).build();
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        var searchParams = aMandateSearchParams().withMandateState(FAILED).build();
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(1);
-        assertThat(mandateSearchDao.search(searchParams)).containsExactly(mandate2.toEntity());
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactly(mandate2.toEntity());
     }
     
     @Test
     @Parameters({"STATEMENT123", "statement123", "ment"})
     public void searchByBankStatementReference(String searchString) {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID)
+        var searchParams = aMandateSearchParams()
                 .withMandateBankStatementReference(MandateBankStatementReference.valueOf(searchString)).build();
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(1);
-        assertThat(mandateSearchDao.search(searchParams)).containsExactly(mandate2.toEntity());
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactly(mandate2.toEntity());
     }
     
     @Test
     @Parameters({"joe.bloggs@example.com", "joe.bloggs@EXAMPLE.com", "joe.bloggs"})
     public void searchByEmail(String searchString) {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID).withEmail(searchString).build();
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        var searchParams = aMandateSearchParams().withEmail(searchString).build();
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(1);
-        assertThat(mandateSearchDao.search(searchParams)).containsExactly(mandate1.toEntity());
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactly(mandate1.toEntity());
     }
 
     @Test
     @Parameters({"JOe Bloggs", "joe bloggs", "bloggs"})
     public void searchByName(String searchString) {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID).withName(searchString).build();
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        var searchParams = aMandateSearchParams().withName(searchString).build();
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(1);
-        assertThat(mandateSearchDao.search(searchParams)).containsExactly(mandate1.toEntity());
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactly(mandate1.toEntity());
     }
     
     @Test
     public void searchByFromDate() {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID)
+        var searchParams = aMandateSearchParams()
                 .withFromDate(String.valueOf(now().minusHours(1)))
                 .build();
-        assertThat(mandateSearchDao.search(searchParams)).containsExactly(mandate1.toEntity());
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactly(mandate1.toEntity());
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(1);
 
-        searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID)
+        searchParams = aMandateSearchParams()
                 .withFromDate(String.valueOf(now().minusHours(7))).build();
-        assertThat(mandateSearchDao.search(searchParams)).containsExactlyInAnyOrder(mandate1.toEntity(), mandate2.toEntity());
-        total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactlyInAnyOrder(mandate1.toEntity(), mandate2.toEntity());
+        total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(2);
     }
     
     @Test
     public void searchByToDate() {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID)
+        var searchParams = aMandateSearchParams()
                 .withToDate(String.valueOf(now().minusHours(1))).build();
-        assertThat(mandateSearchDao.search(searchParams)).containsExactly(mandate2.toEntity());
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactly(mandate2.toEntity());
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(1);
 
-        searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID)
+        searchParams = aMandateSearchParams()
                 .withToDate(String.valueOf(now())).build();
-        assertThat(mandateSearchDao.search(searchParams)).containsExactlyInAnyOrder(mandate1.toEntity(), mandate2.toEntity());
-        total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactlyInAnyOrder(mandate1.toEntity(), mandate2.toEntity());
+        total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(2);
     }
     
     @Test
     public void searchByDateRange() {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID)
+        var searchParams = aMandateSearchParams()
                 .withToDate(String.valueOf(now().minusHours(1)))
                 .withFromDate(String.valueOf(now().minusHours(7)))
                 .build();
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(1);
-        assertThat(mandateSearchDao.search(searchParams)).containsExactly(mandate2.toEntity());
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactly(mandate2.toEntity());
     }
     
     @Test
@@ -155,40 +155,40 @@ public class MandateSearchDaoIT {
         LongStream.rangeClosed(101, 105).forEach(n -> {
             aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).withId(n).insert(testContext.getJdbi());
         });
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID)
+        var searchParams = aMandateSearchParams()
                 .withFromDate(String.valueOf(now().minusHours(1)))
                 .withPage(3)
                 .withDisplaySize(2)
                 .build();
-        List<Mandate> results = mandateSearchDao.search(searchParams);
+        List<Mandate> results = mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(results).hasSize(2);
         assertThat(results.get(0).getId()).isEqualTo(102L);
         assertThat(results.get(1).getId()).isEqualTo(101L);
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(6);
     }
     
     @Test
     public void searchByDisplaySize() {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID)
+        var searchParams = aMandateSearchParams()
                 .withToDate(String.valueOf(now()))
                 .withDisplaySize(1)
                 .build();
-        assertThat(mandateSearchDao.search(searchParams)).hasSize(1);
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).hasSize(1);
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(2);
     }
     
     @Test
     public void searchByMultipleParams() {
-        var searchParams = aMandateSearchParams(GATEWAY_ACCOUNT_ID)
+        var searchParams = aMandateSearchParams()
                 .withServiceReference("REF1234")
                 .withEmail("joe.bloggs@example.com")
                 .withName("bloggs")
                 .withFromDate(String.valueOf(now().minusHours(1)))
                 .build();
-        assertThat(mandateSearchDao.search(searchParams)).containsExactly(mandate1.toEntity());
-        var total = mandateSearchDao.countTotalMatchingMandates(searchParams);
+        assertThat(mandateSearchDao.search(searchParams, gatewayAccountFixture.getExternalId())).containsExactly(mandate1.toEntity());
+        var total = mandateSearchDao.countTotalMatchingMandates(searchParams, gatewayAccountFixture.getExternalId());
         assertThat(total).isEqualTo(1);
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParamsTest.java
@@ -27,7 +27,7 @@ public class MandateSearchParamsTest {
 
     @Test
     public void shouldCreateQueryWithAllParams() {
-        var mandateSearchParams = aMandateSearchParams(gatewayAccountExternalId)
+        var mandateSearchParams = aMandateSearchParams()
                 .withFromDate(fromDate)
                 .withToDate(toDate)
                 .withDisplaySize(displaySize)
@@ -54,7 +54,7 @@ public class MandateSearchParamsTest {
 
     @Test
     public void shouldCreateQueryWithNoParams() {
-        var mandateSearchParams = aMandateSearchParams(gatewayAccountExternalId).build();
+        var mandateSearchParams = aMandateSearchParams().build();
 
         String expectedQuery = "page=1&display_size=500";
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceSearchIT.java
@@ -32,7 +32,7 @@ import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGa
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
-public class MandateSearchResourceIT {
+public class MandateResourceSearchIT {
 
     @DropwizardTestContext
     private TestContext testContext;

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateQueryServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateQueryServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.exception.MandateNotFoundException;
+import uk.gov.pay.directdebit.mandate.dao.MandateSearchDao;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateLookupKey;
@@ -37,13 +38,16 @@ public class MandateQueryServiceTest {
     private MandateDao mockMandateDao;
     
     @Mock
+    private MandateSearchDao mockMandateSearchDao;
+    
+    @Mock
     private Mandate mockMandate;
 
     private MandateQueryService mandateQueryService;
 
     @Before
     public void setUp() {
-        mandateQueryService = new MandateQueryService(mockMandateDao);
+        mandateQueryService = new MandateQueryService(mockMandateDao, mockMandateSearchDao);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateQueryServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateQueryServiceTest.java
@@ -8,7 +8,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.exception.MandateNotFoundException;
-import uk.gov.pay.directdebit.mandate.dao.MandateSearchDao;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateLookupKey;
@@ -38,16 +37,13 @@ public class MandateQueryServiceTest {
     private MandateDao mockMandateDao;
     
     @Mock
-    private MandateSearchDao mockMandateSearchDao;
-    
-    @Mock
     private Mandate mockMandate;
 
     private MandateQueryService mandateQueryService;
 
     @Before
     public void setUp() {
-        mandateQueryService = new MandateQueryService(mockMandateDao, mockMandateSearchDao);
+        mandateQueryService = new MandateQueryService(mockMandateDao);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateSearchServiceTest.java
@@ -1,0 +1,70 @@
+package uk.gov.pay.directdebit.mandate.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.mandate.dao.MandateSearchDao;
+
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
+import static uk.gov.pay.directdebit.mandate.params.MandateSearchParams.MandateSearchParamsBuilder.aMandateSearchParams;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class MandateSearchServiceTest {
+
+    @Mock
+    private MandateSearchDao mockMandateSearchDao;
+
+    private MandateSearchService mandateSearchService;
+
+    @Before
+    public void setUp() {
+        mandateSearchService = new MandateSearchService(mockMandateSearchDao);
+    }
+
+    @Test
+    public void shouldReturnOneMandateForPageAndTotalOfTwoMatchingMandates() {
+        var params = aMandateSearchParams()
+                .withName("aName")
+                .build();
+
+        var expectedMandatesForRequestedPage = List.of(
+                aMandateFixture().withServiceReference("expectedReference").toEntity()
+        );
+
+        String gatewayAccountExternalId = "expectedGatewayId";
+
+        given(mockMandateSearchDao.countTotalMatchingMandates(params, gatewayAccountExternalId)).willReturn(2);
+        given(mockMandateSearchDao.search(params, gatewayAccountExternalId)).willReturn(expectedMandatesForRequestedPage);
+
+        var searchResults = mandateSearchService.search(params, gatewayAccountExternalId);
+
+        assertThat(searchResults.getTotalMatchingMandates(), is(2));
+        assertThat(searchResults.getMandatesForRequestedPage().size(), is(1));
+        assertThat(searchResults.getMandatesForRequestedPage().get(0).getServiceReference(), is("expectedReference"));
+    }
+
+    @Test
+    public void shouldReturnNoMandatesWhenThereAreNone() {
+        var params = aMandateSearchParams()
+                .withName("aName")
+                .build();
+
+        String gatewayAccountExternalId = "expectedGatewayId";
+
+        given(mockMandateSearchDao.countTotalMatchingMandates(params, gatewayAccountExternalId)).willReturn(0);
+
+        var searchResults = mandateSearchService.search(params, gatewayAccountExternalId);
+
+        assertThat(searchResults.getTotalMatchingMandates(), is(0));
+        assertThat(searchResults.getMandatesForRequestedPage().size(), is(0));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResultTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/model/LinksForSearchResultTest.java
@@ -39,7 +39,7 @@ public class LinksForSearchResultTest {
                 .withPage(1)
                 .withDisplaySize(500)
                 .build();
-        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120);
+        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120, gatewayAccountExternalId);
         assertThat(builder.getPrevLink(), is(nullValue()));
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
         assertThat(builder.getLastLink().getHref().contains("?page=1&display_size=500"), is(true));
@@ -53,7 +53,7 @@ public class LinksForSearchResultTest {
                 .withPage(777)
                 .withDisplaySize(500)
                 .build();
-        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120);
+        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120, gatewayAccountExternalId);
         assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=500"), is(true));
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
         assertThat(builder.getLastLink().getHref().contains("?page=1&display_size=500"), is(true));
@@ -66,7 +66,7 @@ public class LinksForSearchResultTest {
                 .withPage(2)
                 .withDisplaySize(50)
                 .build();
-        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120);
+        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120, gatewayAccountExternalId);
         assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=50"), is(true));
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=50"), is(true));
         assertThat(builder.getLastLink().getHref().contains("?page=3&display_size=50"), is(true));
@@ -80,7 +80,7 @@ public class LinksForSearchResultTest {
                 .withPage(3)
                 .withDisplaySize(10)
                 .build();
-        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120);
+        LinksForSearchResult builder = new LinksForSearchResult(searchParams, mockedUriInfo, 120, gatewayAccountExternalId);
         assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=10"), is(true));
         assertThat(builder.getLastLink().getHref().contains("?page=12&display_size=10"), is(true));
         assertThat(builder.getPrevLink().getHref().contains("?page=2&display_size=10"), is(true));


### PR DESCRIPTION
- Remove `GatwayAccountExternalId` from `MandateSearchParams` and `SearchParams` as it
is provided in the URL path and not the search params which means it cannot be added
to MandateSearchParams using `@QueryBean` deserialisation. Instead pass this value
to the necessary service and dao methods.
- Introduce `MandateResourceIT` tests for mandate search