### PR TITLE
PP-5431 Add payment status updater that reads GoCardless events

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -120,16 +120,16 @@ public interface MandateDao {
 
     @SqlUpdate("UPDATE mandates m SET state = :state FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
             "AND g.id = m.gateway_account_id AND g.organisation = :goCardlessOrganisationId AND g.payment_provider = :provider")
-    int updateStateByPaymentProviderMandateIdAndOrganisationId(@Bind("provider") PaymentProvider paymentProvider,
-                                                               @Bind("goCardlessOrganisationId") GoCardlessOrganisationId goCardlessOrganisationId,
-                                                               @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
-                                                               @Bind("state") MandateState mandateState);
+    int updateStateByProviderIdAndOrganisationId(@Bind("provider") PaymentProvider paymentProvider,
+                                                 @Bind("goCardlessOrganisationId") GoCardlessOrganisationId goCardlessOrganisationId,
+                                                 @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
+                                                 @Bind("state") MandateState mandateState);
 
     @SqlUpdate("UPDATE mandates m SET state = :state FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
             "AND g.id = m.gateway_account_id AND g.organisation IS NULL AND g.payment_provider = :provider")
-    int updateStateByPaymentProviderMandateIdAndOrganisationId(@Bind("provider") PaymentProvider paymentProvider,
-                                                               @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
-                                                               @Bind("state") MandateState mandateState);
+    int updateStateByProviderId(@Bind("provider") PaymentProvider paymentProvider,
+                                @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
+                                @Bind("state") MandateState mandateState);
 
     @SqlUpdate("UPDATE mandates m SET mandate_reference = :mandateBankStatementReference, payment_provider_id = :paymentProviderMandateId WHERE m.id = :id")
     int updateReferenceAndPaymentProviderId(@BindBean Mandate mandate);

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateService.java
@@ -22,11 +22,11 @@ public class MandateUpdateService {
     public int updateStateByPaymentProviderMandateId(PaymentProvider paymentProvider, MandateLookupKey mandateLookupKey, MandateState mandateState) {
         if (mandateLookupKey.getClass() == GoCardlessMandateIdAndOrganisationId.class) {
             var goCardlessMandateIdAndOrganisationId = (GoCardlessMandateIdAndOrganisationId) mandateLookupKey;
-            return mandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(paymentProvider, goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId(),
+            return mandateDao.updateStateByProviderIdAndOrganisationId(paymentProvider, goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId(),
                     goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(), mandateState);
         } else if (mandateLookupKey.getClass() == SandboxMandateId.class) {
             var paymentProviderMandateId = (PaymentProviderMandateId) mandateLookupKey;
-            return mandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(paymentProvider, paymentProviderMandateId, mandateState);
+            return mandateDao.updateStateByProviderId(paymentProvider, paymentProviderMandateId, mandateState);
         }
         throw new IllegalArgumentException("Unrecognised MandateLookupKey of type " + mandateLookupKey.getClass());
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentDao.java
@@ -108,4 +108,16 @@ public interface PaymentDao {
     @SqlQuery(joinQuery + " WHERE p.payment_provider_id = :providerId AND g.organisation IS NULL AND g.payment_provider = :provider")
     Optional<Payment> findPaymentByProviderId(@Bind("provider") PaymentProvider paymentProvider,
                                                                @Bind("providerId") PaymentProviderPaymentId providerId);
+
+    @SqlUpdate("UPDATE payments p SET state = :state FROM mandates m, gateway_accounts g WHERE p.payment_provider_id = :providerPaymentId " +
+            "AND m.id = p.mandate_id AND g.id = m.gateway_account_id AND g.organisation = :goCardlessOrganisationId AND g.payment_provider = :provider")
+    int updateStateByProviderIdAndOrganisationId(@Bind("provider") PaymentProvider paymentProvider,
+                                                               @Bind("goCardlessOrganisationId") GoCardlessOrganisationId goCardlessOrganisationId,
+                                                               @Bind("providerPaymentId") PaymentProviderPaymentId paymentProviderPaymentId,
+                                                               @Bind("state") PaymentState mandateState);
+
+    @SqlUpdate("UPDATE payments p SET state = :state FROM mandates m, gateway_accounts g WHERE p.payment_provider_id = :providerPaymentId " +
+            "AND m.id = p.mandate_id AND g.id = m.gateway_account_id AND g.organisation IS NULL AND g.payment_provider = :provider")
+    int updateStateByProviderId(@Bind("provider") PaymentProvider paymentProvider, @Bind("providerPaymentId") PaymentProviderPaymentId paymentProviderPaymentId,
+                                                               @Bind("state") PaymentState mandateState);
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentUpdateService.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.directdebit.payments.services;
+
+import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
+import uk.gov.pay.directdebit.payments.dao.PaymentDao;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdAndOrganisationId;
+import uk.gov.pay.directdebit.payments.model.PaymentLookupKey;
+import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentId;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+
+import javax.inject.Inject;
+
+public class PaymentUpdateService {
+
+    private final PaymentDao paymentDao;
+
+    @Inject
+    PaymentUpdateService(PaymentDao paymentDao) {
+        this.paymentDao = paymentDao;
+    }
+
+    public int updateStateByProviderId(PaymentProvider paymentProvider, PaymentLookupKey paymentLookupKey, PaymentState paymentState) {
+        if (paymentLookupKey.getClass() == GoCardlessPaymentIdAndOrganisationId.class) {
+            var goCardlessPaymentIdAndOrganisationId = (GoCardlessPaymentIdAndOrganisationId) paymentLookupKey;
+            return paymentDao.updateStateByProviderIdAndOrganisationId(paymentProvider, goCardlessPaymentIdAndOrganisationId.getGoCardlessOrganisationId(),
+                    goCardlessPaymentIdAndOrganisationId.getGoCardlessPaymentId(), paymentState);
+        } else if (paymentLookupKey.getClass() == SandboxPaymentId.class) {
+            var paymentProviderPaymentId = (PaymentProviderPaymentId) paymentLookupKey;
+            return paymentDao.updateStateByProviderId(paymentProvider, paymentProviderPaymentId, paymentState);
+        }
+        throw new IllegalArgumentException("Unrecognised PaymentLooupKey of type " + paymentLookupKey.getClass());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -387,7 +387,7 @@ public class MandateDaoIT {
                 .withPaymentProviderId(GoCardlessMandateId.valueOf("Mandate ID we want"))
                 .insert(testContext.getJdbi());
 
-        int numOfUpdatedMandates = mandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(GOCARDLESS, GoCardlessOrganisationId.valueOf("Organisation ID we want"),
+        int numOfUpdatedMandates = mandateDao.updateStateByProviderIdAndOrganisationId(GOCARDLESS, GoCardlessOrganisationId.valueOf("Organisation ID we want"),
                 GoCardlessMandateId.valueOf("Mandate ID we want"), MandateState.PENDING);
 
         assertThat(numOfUpdatedMandates, is(1));
@@ -424,7 +424,7 @@ public class MandateDaoIT {
                 .withPaymentProviderId(SandboxMandateId.valueOf("Mandate ID we want"))
                 .insert(testContext.getJdbi());
 
-        int numOfUpdatedMandates = mandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(SANDBOX,
+        int numOfUpdatedMandates = mandateDao.updateStateByProviderId(SANDBOX,
                 SandboxMandateId.valueOf("Mandate ID we want"),
                 MandateState.PENDING);
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateServiceTest.java
@@ -42,7 +42,7 @@ public class MandateUpdateServiceTest {
 
     @Test
     public void updateStateByPaymentProviderMandateIdWithSandboxMandateIdReturnsUpdateCount() {
-        given(mockMandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(SANDBOX, SANDBOX_MANDATE_ID, PENDING)).willReturn(1);
+        given(mockMandateDao.updateStateByProviderId(SANDBOX, SANDBOX_MANDATE_ID, PENDING)).willReturn(1);
 
         int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(SANDBOX, SANDBOX_MANDATE_ID, PENDING);
 
@@ -53,7 +53,8 @@ public class MandateUpdateServiceTest {
 
     @Test
     public void updateStateByPaymentProviderMandateIdWithGoCardlessMandateIdAndOrganisationIdReturnsUpdateCount() {
-        given(mockMandateDao.updateStateByPaymentProviderMandateIdAndOrganisationId(GOCARDLESS, GOCARDLESS_ORGANISATION_ID, GOCARDLESS_MANDATE_ID, PENDING)).willReturn(1);
+        given(mockMandateDao.updateStateByProviderIdAndOrganisationId(GOCARDLESS, GOCARDLESS_ORGANISATION_ID, GOCARDLESS_MANDATE_ID,
+                PENDING)).willReturn(1);
 
         int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID, PENDING);
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentUpdateServiceTest.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.directdebit.payments.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+import uk.gov.pay.directdebit.payments.dao.PaymentDao;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentId;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdAndOrganisationId;
+import uk.gov.pay.directdebit.payments.model.PaymentLookupKey;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.ignoreStubs;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.PENDING;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaymentUpdateServiceTest {
+
+    private static final SandboxPaymentId SANDBOX_MANDATE_ID = SandboxPaymentId.valueOf("Sandy");
+    private static final GoCardlessPaymentId GOCARDLESS_PAYMENT_ID = GoCardlessPaymentId.valueOf("PM123");
+    private static final GoCardlessOrganisationId GOCARDLESS_ORGANISATION_ID = GoCardlessOrganisationId.valueOf("OR123");
+    private static final GoCardlessPaymentIdAndOrganisationId GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID =
+            new GoCardlessPaymentIdAndOrganisationId(GOCARDLESS_PAYMENT_ID, GOCARDLESS_ORGANISATION_ID);
+
+    @Mock
+    private PaymentDao mockPaymentDao;
+
+    private PaymentUpdateService paymentUpdateService;
+
+    @Before
+    public void setUp() {
+        paymentUpdateService = new PaymentUpdateService(mockPaymentDao);
+    }
+
+    @Test
+    public void updateStateByPaymentProviderMandateIdWithSandboxMandateIdReturnsUpdateCount() {
+        given(mockPaymentDao.updateStateByProviderId(SANDBOX, SANDBOX_MANDATE_ID, PENDING)).willReturn(1);
+
+        int updated = paymentUpdateService.updateStateByProviderId(SANDBOX, SANDBOX_MANDATE_ID, PENDING);
+
+        assertThat(updated, is(1));
+
+        verifyZeroInteractions(ignoreStubs(mockPaymentDao));
+    }
+
+    @Test
+    public void updateStateByPaymentProviderMandateIdWithGoCardlessMandateIdAndOrganisationIdReturnsUpdateCount() {
+        given(mockPaymentDao.updateStateByProviderIdAndOrganisationId(GOCARDLESS, GOCARDLESS_ORGANISATION_ID, GOCARDLESS_PAYMENT_ID, PENDING)).willReturn(1);
+
+        int updated = paymentUpdateService.updateStateByProviderId(GOCARDLESS, GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID, PENDING);
+
+        assertThat(updated, is(1));
+
+        verifyZeroInteractions(ignoreStubs(mockPaymentDao));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void updateStateByPaymentProviderMandateIdWithUnrecognisedTypeThrowsException() {
+
+        paymentUpdateService.updateStateByProviderId(GOCARDLESS, new UnrecognisedPaymentLookupKeyImplementation(), PENDING);
+    }
+
+    private static class UnrecognisedPaymentLookupKeyImplementation implements PaymentLookupKey {
+
+    }
+
+}


### PR DESCRIPTION
Add a payment status updater that works by querying for stored GoCardless webhook events. It always uses the latest dated (not received/stored) event that has a relevant action and doesn’t enforce any idea of valid state transitions.

Note that this isn’t actually hooked up to anything yet.