### PR TITLE
PP-5431 Payment status updater that reads GoCardless webhook events

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
@@ -143,13 +143,15 @@ public class PaymentService {
     }
 
     private DirectDebitEvent paymentFailedFor(Payment payment) {
-        Payment updatedPayment = updateStateFor(payment, SupportedEvent.PAYMENT_FAILED);
-        return directDebitEventService.registerPaymentFailedEventFor(updatedPayment);
+        return directDebitEventService.registerPaymentFailedEventFor(payment);
     }
 
-    public DirectDebitEvent paymentPaidOutFor(Payment payment) {
-        Payment updatedPayment = updateStateFor(payment, PAID_OUT);
-        return directDebitEventService.registerPaymentPaidOutEventFor(updatedPayment);
+    public DirectDebitEvent paymentPaidOutFor(Payment payment, boolean isSandbox) {
+        if (isSandbox) {
+            Payment updatedPayment = updateStateFor(payment, PAID_OUT);
+            return directDebitEventService.registerPaymentPaidOutEventFor(updatedPayment);
+        }
+        return directDebitEventService.registerPaymentPaidOutEventFor(payment);
     }
 
     public DirectDebitEvent paymentAcknowledgedFor(Payment payment) {

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateUpdater.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateUpdater.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.directdebit.payments.services.gocardless;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdAndOrganisationId;
+import uk.gov.pay.directdebit.payments.services.PaymentUpdateService;
+
+import javax.inject.Inject;
+
+import static java.lang.String.format;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
+
+public class GoCardlessPaymentStateUpdater {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoCardlessPaymentStateUpdater.class);
+
+    private final PaymentUpdateService paymentUpdateService;
+    private final GoCardlessPaymentStateCalculator goCardlessPaymentStateCalculator;
+
+    @Inject
+    GoCardlessPaymentStateUpdater(PaymentUpdateService paymentUpdateService, GoCardlessPaymentStateCalculator goCardlessPaymentStateCalculator) {
+        this.paymentUpdateService = paymentUpdateService;
+        this.goCardlessPaymentStateCalculator = goCardlessPaymentStateCalculator;
+    }
+
+    public void updateState(GoCardlessPaymentIdAndOrganisationId goCardlessPaymentIdAndOrganisationId) {
+        goCardlessPaymentStateCalculator.calculate(goCardlessPaymentIdAndOrganisationId)
+                .ifPresentOrElse(state -> {
+                    int updated = paymentUpdateService.updateStateByProviderId(GOCARDLESS, goCardlessPaymentIdAndOrganisationId, state);
+                    if (updated == 1) {
+                        LOGGER.info(format("Updated status of GoCardless payment %s for organisation %s to %s",
+                                goCardlessPaymentIdAndOrganisationId.getGoCardlessPaymentId(),
+                                goCardlessPaymentIdAndOrganisationId.getGoCardlessOrganisationId(),
+                                state));
+                    } else {
+                        LOGGER.error(format("Could not update status of GoCardless payment %s for organisation %s to %s because the payment was not found",
+                                goCardlessPaymentIdAndOrganisationId.getGoCardlessPaymentId(),
+                                goCardlessPaymentIdAndOrganisationId.getGoCardlessOrganisationId(), state));
+                    }
+                }, () -> LOGGER.info(format("Asked to update the status for GoCardless payment %s for organisation %s " +
+                                "but there appear to be no events stored that require it to be updated",
+                        goCardlessPaymentIdAndOrganisationId.getGoCardlessPaymentId(), goCardlessPaymentIdAndOrganisationId.getGoCardlessOrganisationId())));
+    }
+    
+}

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -73,7 +73,7 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
                         paymentService.findPaymentSubmittedEventFor(payment)
                                 .orElseThrow(() -> new InvalidStateException("Could not find payment submitted event for payment with id: " + payment.getExternalId())))
                 .put(GoCardlessPaymentAction.FAILED, (Payment payment) -> paymentService.paymentFailedWithEmailFor(payment))
-                .put(GoCardlessPaymentAction.PAID_OUT, paymentService::paymentPaidOutFor)
+                .put(GoCardlessPaymentAction.PAID_OUT, payment -> paymentService.paymentPaidOutFor(payment, false))
                 .put(GoCardlessPaymentAction.PAID, paymentService::payoutPaidFor)
                 .build();
     }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResource.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.directdebit.webhook.sandbox.resources;
 
 import com.codahale.metrics.annotation.Timed;
+import uk.gov.pay.directdebit.events.model.SandboxEvent;
+import uk.gov.pay.directdebit.events.services.SandboxEventService;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
-import uk.gov.pay.directdebit.events.model.SandboxEvent;
-import uk.gov.pay.directdebit.events.services.SandboxEventService;
 import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
 import uk.gov.pay.directdebit.payments.services.PaymentService;
 
@@ -48,7 +48,7 @@ public class WebhookSandboxResource {
 
     private void processPayment(Payment payment) {
         sandboxEventService.insertEvent(createSandboxEventFromPayment(payment));
-        paymentService.paymentPaidOutFor(payment);
+        paymentService.paymentPaidOutFor(payment, true);
     }
 
     private SandboxEvent createSandboxEventFromPayment(Payment payment){

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateUpdaterTest.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.directdebit.payments.services.gocardless;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentId;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentIdAndOrganisationId;
+import uk.gov.pay.directdebit.payments.services.PaymentUpdateService;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.PENDING;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoCardlessPaymentStateUpdaterTest {
+
+    private static final GoCardlessPaymentIdAndOrganisationId GOCARDLESS_PAYMENT_ID_AND_ORGANISATION_ID = new GoCardlessPaymentIdAndOrganisationId(
+            GoCardlessPaymentId.valueOf("PM123"), GoCardlessOrganisationId.valueOf("OR123"));
+
+    @Mock
+    private PaymentUpdateService mockPaymentUpdateService;
+
+    @Mock
+    private GoCardlessPaymentStateCalculator mockGoCardlessPaymentStateCalculator;
+
+    private GoCardlessPaymentStateUpdater mockGoCardlessPaymentStateUpdater;
+
+    @Before
+    public void setUp() {
+        mockGoCardlessPaymentStateUpdater = new GoCardlessPaymentStateUpdater(mockPaymentUpdateService, mockGoCardlessPaymentStateCalculator);
+    }
+
+    @Test
+    public void updatesPaymentWithStateReturnedByCalculator() {
+        given(mockGoCardlessPaymentStateCalculator.calculate(GOCARDLESS_PAYMENT_ID_AND_ORGANISATION_ID)).willReturn(Optional.of(PENDING));
+
+        mockGoCardlessPaymentStateUpdater.updateState(GOCARDLESS_PAYMENT_ID_AND_ORGANISATION_ID);
+
+        verify(mockPaymentUpdateService).updateStateByProviderId(GOCARDLESS, GOCARDLESS_PAYMENT_ID_AND_ORGANISATION_ID, PENDING);
+    }
+
+    @Test
+    public void updatesNothingIfCalculatorDoesNotReturnState() {
+        given(mockGoCardlessPaymentStateCalculator.calculate(GOCARDLESS_PAYMENT_ID_AND_ORGANISATION_ID)).willReturn(Optional.empty());
+
+        mockGoCardlessPaymentStateUpdater.updateState(GOCARDLESS_PAYMENT_ID_AND_ORGANISATION_ID);
+
+        verify(mockPaymentUpdateService, never()).updateStateByProviderId(any(), any(), any());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
@@ -173,7 +173,7 @@ public class WebhookGoCardlessResourceIT {
     }
 
     @Test
-    public void handleWebhook_whenAMandateFailedWebhookArrives_shouldInsertGoCardlessEventsUpdatePaymentToFailedAndReturn200() {
+    public void handleWebhook_whenAMandateFailedWebhookArrives_shouldInsertGoCardlessEventsUpdateMandateToFailedAndReturn200() {
 
         MandateFixture mandateFixture = MandateFixture.aMandateFixture()
                 .withGatewayAccountFixture(testGatewayAccount)
@@ -181,7 +181,7 @@ public class WebhookGoCardlessResourceIT {
                 .withPaymentProviderId(GoCardlessMandateId.valueOf("MD00008Q30R2BR"))
                 .insert(testContext.getJdbi());
 
-        PaymentFixture paymentFixture = aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixture)
                 .withPaymentProviderId(GoCardlessPaymentId.valueOf("PM00008Q30R2BR"))
                 .withState(PaymentState.PENDING)
@@ -231,8 +231,6 @@ public class WebhookGoCardlessResourceIT {
 
         Map<String, Object> mandate = testContext.getDatabaseTestHelper().getMandateById(mandateFixture.getId());
         MatcherAssert.assertThat(mandate.get("state"), is("FAILED"));
-
-        Map<String, Object> transaction = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
-        MatcherAssert.assertThat(transaction.get("state"), is("FAILED"));
     }
+
 }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
@@ -71,11 +71,11 @@ public class GoCardlessPaymentHandlerTest {
         when(mockedPaymentQueryService.findByProviderPaymentId(GOCARDLESS,
                         new GoCardlessPaymentIdAndOrganisationId(goCardlessEvent.getLinksPayment().get(), goCardlessEvent.getLinksOrganisation())))
                 .thenReturn(payment);
-        when(mockedPaymentService.paymentPaidOutFor(payment)).thenReturn(directDebitEvent);
+        when(mockedPaymentService.paymentPaidOutFor(payment, false)).thenReturn(directDebitEvent);
 
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
-        verify(mockedPaymentService).paymentPaidOutFor(payment);
+        verify(mockedPaymentService).paymentPaidOutFor(payment, false);
         verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessEventService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();


### PR DESCRIPTION
After receiving a GoCardless webhook event, update the state of any affected payments by looking at the latest stored event (not just the one that was just received) and calculating the state from the
event’s action. This doesn’t enforce any idea of valid state transitions.

Bypass code that caused us to set all payments as failed if we received an event with a mandate failed action; we should get a separate payment event from GoCardless so this is unnecessary.