### PR TITLE
PP-5432 Read all webhook events when updating sandbox payment state

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/dao/SandboxEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/SandboxEventDao.java
@@ -2,12 +2,19 @@ package uk.gov.pay.directdebit.events.dao;
 
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import uk.gov.pay.directdebit.events.model.SandboxEvent;
 import uk.gov.pay.directdebit.mandate.model.SandboxMandateIdArgumentFactory;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
 import uk.gov.pay.directdebit.payments.model.SandboxPaymentIdArgumentFactory;
+
+import java.util.Optional;
+import java.util.Set;
 
 @RegisterRowMapper(SandboxEventMapper.class)
 @RegisterArgumentFactory(SandboxMandateIdArgumentFactory.class)
@@ -18,4 +25,18 @@ public interface SandboxEventDao {
             "VALUES (:createdAt, :mandateId, :paymentId, :eventAction, :eventCause)")
     @GetGeneratedKeys
     Long insert(@BindBean SandboxEvent sandboxEvent);
+
+    @SqlQuery("SELECT id, " +
+            "created_at, " +
+            "mandate_id, " +
+            "payment_id, " +
+            "event_action, " +
+            "event_cause " +
+            "FROM sandbox_events " +
+            "WHERE payment_id = :paymentId " +
+            "AND event_action IN (<applicableActions>) " +
+            "ORDER BY created_at DESC " +
+            "LIMIT 1")
+    Optional<SandboxEvent> findLatestApplicableEventForPayment(@Bind("paymentId") SandboxPaymentId sandboxPaymentId,
+                                                               @BindList("applicableActions") Set<String> applicableActions);
 }

--- a/src/main/java/uk/gov/pay/directdebit/events/dao/SandboxEventMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/SandboxEventMapper.java
@@ -4,23 +4,29 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.directdebit.events.model.SandboxEvent;
 import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZonedDateTime;
+
+import static java.time.ZoneOffset.UTC;
 
 public class SandboxEventMapper implements RowMapper<SandboxEvent> {
 
     @Override
     public SandboxEvent map(ResultSet rs, StatementContext ctx) throws SQLException {
         var builder = SandboxEvent.SandboxEventBuilder.aSandboxEvent()
-                .withCreatedAt(ZonedDateTime.parse(rs.getString("created_at")))
+                .withCreatedAt(ZonedDateTime.ofInstant(rs.getTimestamp("created_at").toInstant(), UTC))
                 .withEventCause(rs.getString("event_cause"))
-                .withEventAction(rs.getString("event_action"))
-                .withEventAction(rs.getString("payment_id"));
+                .withEventAction(rs.getString("event_action"));
 
-        if (rs.getString("mandate_id") == null) {
+        if (rs.getString("mandate_id") != null) {
             builder.withMandateId(SandboxMandateId.valueOf(rs.getString("mandate_id")));
+        }
+
+        if (rs.getString("payment_id") != null) {
+            builder.withPaymentId(SandboxPaymentId.valueOf(rs.getString("payment_id")));
         }
 
         return builder.build();

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAID_OUT;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_SUBMITTED_TO_BANK;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.PAYMENT_SUBMITTED_TO_PROVIDER;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.CHARGE;
@@ -146,11 +145,7 @@ public class PaymentService {
         return directDebitEventService.registerPaymentFailedEventFor(payment);
     }
 
-    public DirectDebitEvent paymentPaidOutFor(Payment payment, boolean isSandbox) {
-        if (isSandbox) {
-            Payment updatedPayment = updateStateFor(payment, PAID_OUT);
-            return directDebitEventService.registerPaymentPaidOutEventFor(updatedPayment);
-        }
+    public DirectDebitEvent paymentPaidOutFor(Payment payment) {
         return directDebitEventService.registerPaymentPaidOutEventFor(payment);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateCalculator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateCalculator.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.directdebit.payments.services.sandbox;
+
+import uk.gov.pay.directdebit.events.dao.SandboxEventDao;
+import uk.gov.pay.directdebit.events.model.SandboxEvent;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+import uk.gov.pay.directdebit.webhook.sandbox.resources.WebhookSandboxResource;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static uk.gov.pay.directdebit.payments.model.PaymentState.SUCCESS;
+
+public class SandboxPaymentStateCalculator {
+
+    private final SandboxEventDao sandboxEventDao;
+
+    private static final Map<String, PaymentState> SANDBOX_ACTION_TO_PAYMENT_STATE = Map.of(
+            WebhookSandboxResource.SandboxEventAction.PAID_OUT.toString(), SUCCESS
+    );
+
+    static final Set<String> SANDBOX_ACTIONS_THAT_CHANGE_STATE = SANDBOX_ACTION_TO_PAYMENT_STATE.keySet();
+
+    @Inject
+    SandboxPaymentStateCalculator(SandboxEventDao sandboxEventDao) {
+        this.sandboxEventDao = sandboxEventDao;
+    }
+
+    Optional<PaymentState> calculate(SandboxPaymentId sandboxPaymentId) {
+        return sandboxEventDao.findLatestApplicableEventForPayment(sandboxPaymentId, SANDBOX_ACTIONS_THAT_CHANGE_STATE)
+                .map(SandboxEvent::getEventAction)
+                .map(SANDBOX_ACTION_TO_PAYMENT_STATE::get);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateUpdater.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateUpdater.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.directdebit.payments.services.sandbox;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+import uk.gov.pay.directdebit.payments.services.PaymentUpdateService;
+
+import javax.inject.Inject;
+
+import static java.lang.String.format;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
+
+public class SandboxPaymentStateUpdater {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SandboxPaymentStateUpdater.class);
+
+    private final PaymentUpdateService paymentUpdateService;
+    private final SandboxPaymentStateCalculator sandboxPaymentStateCalculator;
+
+    @Inject
+    SandboxPaymentStateUpdater(PaymentUpdateService paymentUpdateService, SandboxPaymentStateCalculator sandboxPaymentStateCalculator) {
+        this.paymentUpdateService = paymentUpdateService;
+        this.sandboxPaymentStateCalculator = sandboxPaymentStateCalculator;
+    }
+
+    public void updateState(SandboxPaymentId sandboxPaymentId) {
+        sandboxPaymentStateCalculator.calculate(sandboxPaymentId)
+                .ifPresentOrElse(state -> {
+                    int updated = paymentUpdateService.updateStateByProviderId(SANDBOX, sandboxPaymentId, state);
+                    if (updated == 1) {
+                        LOGGER.info(format("Updated status of sandbox payment %s to %s", sandboxPaymentId, state));
+                    } else {
+                        LOGGER.error(format("Could not update status of sandbox payment %s to %s because the payment was not found", sandboxPaymentId, state));
+                    }
+                }, () -> LOGGER.info(format("Asked to update the status for sandbox payment %s " +
+                                "but there appear to be no events stored that require it to be updated", sandboxPaymentId)));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookSandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookSandboxService.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.directdebit.webhook.gocardless.services;
+
+import uk.gov.pay.directdebit.events.model.SandboxEvent;
+import uk.gov.pay.directdebit.payments.services.sandbox.SandboxPaymentStateUpdater;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+
+public class WebhookSandboxService {
+
+    private final SandboxPaymentStateUpdater sandboxPaymentStateUpdater;
+
+    @Inject
+    WebhookSandboxService(SandboxPaymentStateUpdater sandboxPaymentStateUpdater) {
+        this.sandboxPaymentStateUpdater = sandboxPaymentStateUpdater;
+    }
+
+    public void updateStateOfPaymentsAffectedByEvents(List<SandboxEvent> events) {
+        events.stream()
+                .map(SandboxEvent::getPaymentId)
+                .flatMap(Optional::stream)
+                .distinct()
+                .forEach(sandboxPaymentStateUpdater::updateState);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/GoCardlessPaymentHandler.java
@@ -73,7 +73,7 @@ public class GoCardlessPaymentHandler extends GoCardlessHandler {
                         paymentService.findPaymentSubmittedEventFor(payment)
                                 .orElseThrow(() -> new InvalidStateException("Could not find payment submitted event for payment with id: " + payment.getExternalId())))
                 .put(GoCardlessPaymentAction.FAILED, (Payment payment) -> paymentService.paymentFailedWithEmailFor(payment))
-                .put(GoCardlessPaymentAction.PAID_OUT, payment -> paymentService.paymentPaidOutFor(payment, false))
+                .put(GoCardlessPaymentAction.PAID_OUT, paymentService::paymentPaidOutFor)
                 .put(GoCardlessPaymentAction.PAID, paymentService::payoutPaidFor)
                 .build();
     }

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/SandboxEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/SandboxEventDaoIT.java
@@ -18,9 +18,13 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
+import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.directdebit.events.model.SandboxEvent.SandboxEventBuilder.aSandboxEvent;
 import static uk.gov.pay.directdebit.util.ZonedDateTimeTimestampMatcher.isDate;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -41,7 +45,7 @@ public class SandboxEventDaoIT {
 
     @Test
     public void shouldInsertAnEvent() throws IOException {
-        SandboxEvent sandboxEvent = SandboxEvent.SandboxEventBuilder.aSandboxEvent()
+        SandboxEvent sandboxEvent = aSandboxEvent()
                 .withMandateId(SandboxMandateId.valueOf("aMandateId"))
                 .withPaymentId(SandboxPaymentId.valueOf("aPaymentId"))
                 .withEventAction("anEventAction")
@@ -58,5 +62,39 @@ public class SandboxEventDaoIT {
         assertThat(foundSandboxEvent.get("event_action"), is("anEventAction"));
         assertThat(foundSandboxEvent.get("event_cause"), is("anEventCause"));
         assertThat((Timestamp) foundSandboxEvent.get("created_at"), isDate(CREATED_AT));
+    }
+
+    @Test
+    public void shouldFindLatestApplicableEventForPayment() {
+        SandboxEvent latestEvent = aSandboxEvent().withPaymentId(SandboxPaymentId.valueOf("Payment ID we want"))
+                .withEventAction("Action we want")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 12, 15, 0, 0, 0, UTC))
+                .build();
+
+        SandboxEvent earlierEvent = aSandboxEvent().withPaymentId(SandboxPaymentId.valueOf("Payment ID we want"))
+                .withEventAction("Action we want")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 12, 14, 0, 0, 0, UTC))
+                .build();
+
+        SandboxEvent laterEventWrongAction = aSandboxEvent().withPaymentId(SandboxPaymentId.valueOf("Payment ID we want"))
+                .withEventAction("Different action")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 12, 16, 0, 0, 0, UTC))
+                .build();
+
+        SandboxEvent laterEventWrongPayment = aSandboxEvent().withPaymentId(SandboxPaymentId.valueOf("Different payment ID"))
+                .withEventAction("Action we want")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 12, 16, 0, 0, 0, UTC))
+                .build();
+
+        sandboxEventDao.insert(earlierEvent);
+        sandboxEventDao.insert(latestEvent);
+        sandboxEventDao.insert(laterEventWrongAction);
+        sandboxEventDao.insert(laterEventWrongPayment);
+
+        SandboxEvent event = sandboxEventDao.findLatestApplicableEventForPayment(SandboxPaymentId.valueOf("Payment ID we want"), Set.of("Action we want")).get();
+
+        assertThat(event.getPaymentId(), is(Optional.of(SandboxPaymentId.valueOf("Payment ID we want"))));
+        assertThat(event.getEventAction(), is("Action we want"));
+        assertThat(event.getCreatedAt(), is(ZonedDateTime.of(2019, 7, 12, 15, 0, 0, 0, UTC)));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
@@ -169,24 +169,9 @@ public class PaymentServiceTest {
                 .withState(PENDING)
                 .toEntity();
 
-        service.paymentPaidOutFor(payment, false);
+        service.paymentPaidOutFor(payment);
 
         verify(mockedDirectDebitEventService).registerPaymentPaidOutEventFor(payment);
-    }
-
-    @Test
-    public void paymentPaidOutFor_sandbox_shouldSetPaymentAsSucceeded_andRegisterAPaidOutEvent() {
-
-        Payment payment = PaymentFixture
-                .aPaymentFixture()
-                .withState(PENDING)
-                .toEntity();
-
-        service.paymentPaidOutFor(payment, true);
-
-        Payment updatedPayment = fromPayment(payment).withState(SUCCESS).build();
-        verify(mockedPaymentDao).updateState(updatedPayment.getId(), SUCCESS);
-        verify(mockedDirectDebitEventService).registerPaymentPaidOutEventFor(updatedPayment);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateCalculatorTest.java
@@ -1,0 +1,69 @@
+package uk.gov.pay.directdebit.payments.services.sandbox;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.events.dao.SandboxEventDao;
+import uk.gov.pay.directdebit.events.model.SandboxEvent;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+import uk.gov.pay.directdebit.webhook.sandbox.resources.WebhookSandboxResource.SandboxEventAction;
+
+import java.util.Optional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.directdebit.payments.services.sandbox.SandboxPaymentStateCalculator.SANDBOX_ACTIONS_THAT_CHANGE_STATE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SandboxPaymentStateCalculatorTest {
+
+    private static final SandboxPaymentId SANDBOX_PAYMENT_ID = SandboxPaymentId.valueOf("Sandbox payment ID");
+
+    @Mock
+    private SandboxEvent mockSandboxEvent;
+
+    @Mock
+    private SandboxEventDao mockSandboxEventDao;
+
+    private SandboxPaymentStateCalculator sandboxPaymentStateCalculator;
+
+    @Before
+    public void setUp() {
+        given(mockSandboxEventDao.findLatestApplicableEventForPayment(SANDBOX_PAYMENT_ID, SANDBOX_ACTIONS_THAT_CHANGE_STATE))
+                .willReturn(Optional.of(mockSandboxEvent));
+
+        sandboxPaymentStateCalculator = new SandboxPaymentStateCalculator(mockSandboxEventDao);
+    }
+
+    @Test
+    public void paidOutActionMapsToSuccessState() {
+        given(mockSandboxEvent.getEventAction()).willReturn(SandboxEventAction.PAID_OUT.toString());
+
+        Optional<PaymentState> paymentState = sandboxPaymentStateCalculator.calculate(SANDBOX_PAYMENT_ID);
+
+        assertThat(paymentState.get(), is(PaymentState.SUCCESS));
+    }
+
+    @Test
+    public void unrecognisedActionMapsToNothing() {
+        given(mockSandboxEvent.getEventAction()).willReturn("EATEN_BY_WOLVES");
+
+        Optional<PaymentState> paymentState = sandboxPaymentStateCalculator.calculate(SANDBOX_PAYMENT_ID);
+
+        assertThat(paymentState, is(Optional.empty()));
+    }
+
+    @Test
+    public void noApplicableEventsMapsToNothing() {
+        given(mockSandboxEventDao.findLatestApplicableEventForPayment(SANDBOX_PAYMENT_ID, SANDBOX_ACTIONS_THAT_CHANGE_STATE)).willReturn(Optional.empty());
+
+        Optional<PaymentState> paymentState = sandboxPaymentStateCalculator.calculate(SANDBOX_PAYMENT_ID);
+
+        assertThat(paymentState, is(Optional.empty()));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateUpdaterTest.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.directdebit.payments.services.sandbox;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+import uk.gov.pay.directdebit.payments.services.PaymentUpdateService;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.SUCCESS;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SandboxPaymentStateUpdaterTest {
+
+    private static final SandboxPaymentId SANDBOX_PAYMENT_ID = SandboxPaymentId.valueOf("Sandbox payment ID");
+
+    @Mock
+    private PaymentUpdateService mockPaymentUpdateService;
+
+    @Mock
+    private SandboxPaymentStateCalculator mockSandboxPaymentStateCalculator;
+
+    private SandboxPaymentStateUpdater mockSandboxPaymentStateUpdater;
+
+    @Before
+    public void setUp() {
+        mockSandboxPaymentStateUpdater = new SandboxPaymentStateUpdater(mockPaymentUpdateService, mockSandboxPaymentStateCalculator);
+    }
+
+    @Test
+    public void updatesPaymentWithStateReturnedByCalculator() {
+        given(mockSandboxPaymentStateCalculator.calculate(SANDBOX_PAYMENT_ID)).willReturn(Optional.of(SUCCESS));
+
+        mockSandboxPaymentStateUpdater.updateState(SANDBOX_PAYMENT_ID);
+
+        verify(mockPaymentUpdateService).updateStateByProviderId(SANDBOX, SANDBOX_PAYMENT_ID, SUCCESS);
+    }
+
+    @Test
+    public void updatesNothingIfCalculatorDoesNotReturnState() {
+        given(mockSandboxPaymentStateCalculator.calculate(SANDBOX_PAYMENT_ID)).willReturn(Optional.empty());
+
+        mockSandboxPaymentStateUpdater.updateState(SANDBOX_PAYMENT_ID);
+
+        verify(mockPaymentUpdateService, never()).updateStateByProviderId(any(), any(), any());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessPaymentHandlerTest.java
@@ -71,11 +71,11 @@ public class GoCardlessPaymentHandlerTest {
         when(mockedPaymentQueryService.findByProviderPaymentId(GOCARDLESS,
                         new GoCardlessPaymentIdAndOrganisationId(goCardlessEvent.getLinksPayment().get(), goCardlessEvent.getLinksOrganisation())))
                 .thenReturn(payment);
-        when(mockedPaymentService.paymentPaidOutFor(payment, false)).thenReturn(directDebitEvent);
+        when(mockedPaymentService.paymentPaidOutFor(payment)).thenReturn(directDebitEvent);
 
         goCardlessPaymentHandler.handle(goCardlessEvent);
 
-        verify(mockedPaymentService).paymentPaidOutFor(payment, false);
+        verify(mockedPaymentService).paymentPaidOutFor(payment);
         verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
         verify(mockedGoCardlessEventService).updateInternalEventId(geCaptor.capture());
         GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookSandboxServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookSandboxServiceTest.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.directdebit.webhook.gocardless.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.events.model.SandboxEvent;
+import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+import uk.gov.pay.directdebit.payments.services.sandbox.SandboxPaymentStateUpdater;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.directdebit.events.model.SandboxEvent.SandboxEventBuilder.aSandboxEvent;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WebhookSandboxServiceTest {
+    
+    @Mock
+    private SandboxPaymentStateUpdater mockSandboxPaymentStateUpdater;
+
+    private WebhookSandboxService webhookSandboxService;
+
+    @Before
+    public void setUp() {
+        webhookSandboxService = new WebhookSandboxService(mockSandboxPaymentStateUpdater);
+    }
+
+    @Test
+    public void shouldUpdateStatesForPaymentsAffectedByEvents() {
+        var sandboxPaymentId1 = SandboxPaymentId.valueOf("Sandbox Payment 1");
+        var sandboxPaymentId2 = SandboxPaymentId.valueOf("Sandbox Payment 2");
+        var sandboxMandateId1 = SandboxMandateId.valueOf("Sandbox Mandate 1");
+
+        SandboxEvent sandboxPayment1Event = aSandboxEvent()
+                .withPaymentId(sandboxPaymentId1)
+                .build();
+
+        SandboxEvent anotherSandboxPayment1Event = aSandboxEvent()
+                .withPaymentId(sandboxPaymentId1)
+                .build();
+
+        SandboxEvent sandboxPayment2Event = aSandboxEvent()
+                .withPaymentId(sandboxPaymentId2)
+                .build();
+
+        SandboxEvent sandboxMandate1Event = aSandboxEvent()
+                .withMandateId(sandboxMandateId1)
+                .build();
+
+        webhookSandboxService.updateStateOfPaymentsAffectedByEvents(List.of(
+                sandboxPayment1Event,
+                anotherSandboxPayment1Event,
+                sandboxPayment2Event,
+                sandboxMandate1Event
+        ));
+
+        verify(mockSandboxPaymentStateUpdater).updateState(sandboxPaymentId1);
+        verify(mockSandboxPaymentStateUpdater).updateState(sandboxPaymentId2);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/sandbox/resources/WebhookSandboxResourceIT.java
@@ -1,10 +1,9 @@
 package uk.gov.pay.directdebit.webhook.sandbox.resources;
 
-import java.util.Map;
-import javax.ws.rs.core.Response;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.directdebit.DirectDebitConnectorApp;
+import uk.gov.pay.directdebit.common.util.RandomIdGenerator;
 import uk.gov.pay.directdebit.junit.DropwizardConfig;
 import uk.gov.pay.directdebit.junit.DropwizardJUnitRunner;
 import uk.gov.pay.directdebit.junit.DropwizardTestContext;
@@ -13,11 +12,16 @@ import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
 
@@ -30,10 +34,15 @@ public class WebhookSandboxResourceIT {
 
     @Test
     public void handleWebhook_shouldChangeTheStateToSuccessAndReturn200() {
-        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().insert(testContext.getJdbi());
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture().withPaymentProvider(SANDBOX).withOrganisation(null).insert(testContext.getJdbi());
         MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
         PayerFixture.aPayerFixture().withMandateId(mandateFixture.getId()).insert(testContext.getJdbi());
-        Long transactionId = aPaymentFixture().withMandateFixture(mandateFixture)
+
+        String sandboxPaymentExternalAndProviderId = RandomIdGenerator.newId();
+        Long paymentId = aPaymentFixture()
+                .withExternalId(sandboxPaymentExternalAndProviderId)
+                .withPaymentProviderId(SandboxPaymentId.valueOf(sandboxPaymentExternalAndProviderId))
+                .withMandateFixture(mandateFixture)
                 .withState(PaymentState.PENDING).insert(testContext.getJdbi()).getId();
 
         String requestPath = "/v1/webhooks/sandbox";
@@ -44,7 +53,7 @@ public class WebhookSandboxResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode());
 
-        Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(transactionId);
+        Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentId);
         assertThat(payment.get("state"), is("SUCCESS"));
     }
 


### PR DESCRIPTION
After processing a sandbox webhook, update the states of the affected payments (which is really all of them) by examining all stored events rather than the one we just received. No state transition restrictions are enforced.

This brings sandbox into line with GoCardless in terms of its (theoretical) ability to handle out-of-order webhooks.