### PR TITLE
PP-5302 Validate external state on mandate search

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/exception/validation/ExternalMandateStateValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/validation/ExternalMandateStateValidator.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.directdebit.common.exception.validation;
+
+import uk.gov.pay.directdebit.mandate.api.ExternalMandateState;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ExternalMandateStateValidator implements ConstraintValidator<ValidExternalMandateState, String> {
+
+    private Set<String> validExternalMandateStateValues;
+
+    @Override
+    public void initialize(ValidExternalMandateState annotation) {
+        validExternalMandateStateValues = Arrays.stream(ExternalMandateState.values())
+                .map(ExternalMandateState::getState)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        return validExternalMandateStateValues.contains(value);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/validation/ValidExternalMandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/validation/ValidExternalMandateState.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.directdebit.common.exception.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {ExternalMandateStateValidator.class})
+@Documented
+public @interface ValidExternalMandateState {
+
+    String message() default "Must be a valid mandate external state";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
@@ -7,13 +7,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExternalMandateState {
-    EXTERNAL_CREATED("created", false),
-    EXTERNAL_STARTED("started", false),
-    EXTERNAL_PENDING("pending", false),
-    EXTERNAL_SUBMITTED("submitted", false),
-    EXTERNAL_ACTIVE("active", true),
-    EXTERNAL_INACTIVE("inactive", true),
-    EXTERNAL_CANCELLED("cancelled", true);
+    CREATED("created", false),
+    STARTED("started", false),
+    PENDING("pending", false),
+    SUBMITTED("submitted", false),
+    ACTIVE("active", true),
+    INACTIVE("inactive", true),
+    CANCELLED("cancelled", true);
 
     private final String value;
     private final boolean finished;

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDao.java
@@ -114,10 +114,10 @@ public class MandateSearchDao {
             sqlParams.put("email", "%" + email + "%");
         });
 
-        params.getExternalMandateState().ifPresent(mandateState -> {
+        if (!params.getInternalStates().isEmpty()) {
             sql.append(" AND m.state IN (<states>)");
             sqlParams.put("states", params.getInternalStates());
-        });
+        }
 
         params.getFromDate().ifPresent(fromDate -> {
             sql.append(" AND m.created_date > :createdDateFrom");

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateState.java
@@ -3,24 +3,20 @@ package uk.gov.pay.directdebit.mandate.model;
 import uk.gov.pay.directdebit.mandate.api.ExternalMandateState;
 import uk.gov.pay.directdebit.payments.model.DirectDebitState;
 
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_ACTIVE;
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_CANCELLED;
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_CREATED;
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_INACTIVE;
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_PENDING;
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_STARTED;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.INACTIVE;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.STARTED;
 
 
 public enum MandateState implements DirectDebitState {
-    CREATED(EXTERNAL_CREATED),
-    AWAITING_DIRECT_DEBIT_DETAILS(EXTERNAL_STARTED),
-    USER_CANCEL_NOT_ELIGIBLE(EXTERNAL_CANCELLED),
-    SUBMITTED(EXTERNAL_PENDING),
-    PENDING(EXTERNAL_PENDING),
-    ACTIVE(EXTERNAL_ACTIVE),
-    FAILED(EXTERNAL_INACTIVE),
-    CANCELLED(EXTERNAL_INACTIVE),
-    EXPIRED(EXTERNAL_INACTIVE);
+    CREATED(ExternalMandateState.CREATED),
+    AWAITING_DIRECT_DEBIT_DETAILS(STARTED),
+    USER_CANCEL_NOT_ELIGIBLE(ExternalMandateState.CANCELLED),
+    SUBMITTED(ExternalMandateState.PENDING),
+    PENDING(ExternalMandateState.PENDING),
+    ACTIVE(ExternalMandateState.ACTIVE),
+    FAILED(INACTIVE),
+    CANCELLED(INACTIVE),
+    EXPIRED(INACTIVE);
 
     private ExternalMandateState externalState;
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParams.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.directdebit.mandate.params;
 
 import uk.gov.pay.commons.validation.ValidDate;
+import uk.gov.pay.directdebit.common.exception.validation.ValidExternalMandateState;
 import uk.gov.pay.directdebit.common.model.SearchParams;
 import uk.gov.pay.directdebit.mandate.model.MandateBankStatementReference;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
@@ -31,6 +32,7 @@ public class MandateSearchParams implements SearchParams {
     private String serviceReference;
 
     @QueryParam(STATE)
+    @ValidExternalMandateState(message = "Invalid attribute value: state is not a valid mandate external state")
     private String externalMandateState;
 
     @QueryParam(BANK_STATEMENT_REFERENCE)

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -13,6 +13,7 @@ import uk.gov.pay.directdebit.gatewayaccounts.model.GatewayAccount;
 import uk.gov.pay.directdebit.mandate.api.ConfirmMandateRequest;
 import uk.gov.pay.directdebit.mandate.api.CreateMandateRequest;
 import uk.gov.pay.directdebit.mandate.api.DirectDebitInfoFrontendResponse;
+import uk.gov.pay.directdebit.mandate.api.ExternalMandateState;
 import uk.gov.pay.directdebit.mandate.api.MandateResponse;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.exception.MandateNotFoundException;
@@ -45,7 +46,6 @@ import static uk.gov.pay.directdebit.common.util.URIBuilder.createLink;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.nextUrl;
 import static uk.gov.pay.directdebit.common.util.URIBuilder.selfUriFor;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_CREATED;
 import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
 import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.fromMandate;
 import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
@@ -202,7 +202,7 @@ public class MandateService {
                 accountExternalId,
                 mandate.getExternalId().toString())));
 
-        if (mandate.getState().toExternal() == EXTERNAL_CREATED) {
+        if (mandate.getState().toExternal() == ExternalMandateState.CREATED) {
             Token token = tokenService.generateNewTokenFor(mandate);
             dataLinks.add(createLink("next_url",
                     GET,

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
@@ -346,7 +346,7 @@ public class GatewayAccountResourceIT {
                 .post(GATEWAY_ACCOUNTS_API_PATH)
                 .then()
                 .contentType(JSON)
-                .statusCode(422).log().body()
+                .statusCode(422)
                 .body("error_identifier", is("GENERIC"))
                 .body("message", contains("Field [description] must have a maximum length of 255"));
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParamsTest.java
@@ -22,7 +22,7 @@ public class MandateSearchParamsTest {
         String serviceReference = "aServiceReference";
         String toDate = LocalDate.now().toString();
         String fromDate = LocalDate.now().minusDays(3).toString();
-        String mandateState = ExternalMandateState.EXTERNAL_CREATED.getState();
+        String mandateState = ExternalMandateState.CREATED.getState();
         MandateBankStatementReference mandateBankStatementReference = 
                 MandateBankStatementReference.valueOf("bankReference");
         

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -327,7 +327,6 @@ public class MandateResourceIT {
                 .then()
                 .statusCode(OK.getStatusCode())
                 .contentType(JSON)
-                .log().body()
                 .body("external_id", is(mandateFixture.getExternalId().toString()))
                 .body("gateway_account_id", isNumber(gatewayAccountFixture.getId()))
                 .body("gateway_account_external_id", is(gatewayAccountFixture.getExternalId()))
@@ -397,7 +396,7 @@ public class MandateResourceIT {
 
         ValidatableResponse getMandateResponse = givenSetup()
                 .get(requestPath)
-                .then().log().body()
+                .then()
                 .statusCode(OK.getStatusCode())
                 .contentType(JSON)
                 .body("mandate_id", is(mandateFixture.getExternalId().toString()))

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceSearchIT.java
@@ -50,7 +50,8 @@ public class MandateResourceSearchIT {
             "to_date, 2018-14-05T15:00Z, Invalid attribute value: to_date. Must be a valid date", 
             "page, -1, Invalid attribute value: page. Must be greater than or equal to 1", 
             "display_size, 0, Invalid attribute value: display_size. Must be greater than or equal to 1", 
-            "display_size, 501, Invalid attribute value: display_size. Must be less than or equal to 500"
+            "display_size, 501, Invalid attribute value: display_size. Must be less than or equal to 500",
+            "state, INVALID, Invalid attribute value: state is not a valid mandate external state"
     })
     public void searchWithInvalidParams(String param, String value, String expectedErrorMessage) {
         givenSetup()
@@ -139,7 +140,6 @@ public class MandateResourceSearchIT {
         givenSetup()
                 .get(format("/v1/api/accounts/%s/mandates", gatewayAccountFixture.getExternalId()))
                 .then()
-                .log().body()
                 .body("total", is(2))
                 .body("count", is(2))
                 .body("page", is(1))

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceIT.java
@@ -214,7 +214,6 @@ public class WebhookGoCardlessResourceIT {
                 .accept(APPLICATION_JSON)
                 .post(REQUEST_PATH)
                 .then()
-                .log().body()
                 .statusCode(Response.Status.OK.getStatusCode());
 
         List<Map<String, Object>> events = testContext.getDatabaseTestHelper().getAllGoCardlessEvents();


### PR DESCRIPTION
- Remove `EXTERNAL` prefix to `ExternalMandateState` values to aid deserialisation.
- Add `ValidExternalMandateState` annotation with validator.
- Add tests for when `state` parameter is an invalid `ExternalMandateState`.
- Modify `MandateSearchDao` to not add `WHERE clause if the list of internal
mandate states is empty since this results in a binding exception. Add test
to assert this.
