### PR TITLE
PP-5442 Update mandate state, cause and description from GC event

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/model/DirectDebitStateWithDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/DirectDebitStateWithDetails.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.directdebit.common.model;
+
+import uk.gov.pay.directdebit.payments.model.DirectDebitState;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class DirectDebitStateWithDetails<T extends DirectDebitState> {
+
+    private final T state;
+    private final String details;
+    private final String detailsDescription;
+
+    public DirectDebitStateWithDetails(T state, String details, String detailsDescription) {
+        this.state = Objects.requireNonNull(state);
+        this.details = details;
+        this.detailsDescription = detailsDescription;
+    }
+
+    public T getState() {
+        return state;
+    }
+
+    public Optional<String> getDetails() {
+        return Optional.ofNullable(details);
+    }
+
+    public Optional<String> getDetailsDescription() {
+        return Optional.ofNullable(detailsDescription);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        DirectDebitStateWithDetails<?> that = (DirectDebitStateWithDetails<?>) other;
+        return state.equals(that.state) &&
+                Objects.equals(details, that.details) &&
+                Objects.equals(detailsDescription, that.detailsDescription);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(state, details, detailsDescription);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(state.toString());
+        getDetails().ifPresent(details -> sb.append(" :").append(details));
+        getDetailsDescription().ifPresent(details -> sb.append(" (").append(details).append(')'));
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateDao.java
@@ -64,6 +64,8 @@ public interface MandateDao {
             "  m.gateway_account_id AS mandate_gateway_account_id," +
             "  m.return_url AS mandate_return_url," +
             "  m.state AS mandate_state," +
+            "  m.state_details AS mandate_state_details," +
+            "  m.state_details_description AS mandate_state_details_description," +
             "  m.created_date AS mandate_created_date," +
             "  m.payment_provider_id AS mandate_payment_provider_id," +
             "  g.id AS gateway_account_id," +
@@ -118,18 +120,24 @@ public interface MandateDao {
     @SqlUpdate("UPDATE mandates m SET state = :state WHERE m.id = :id")
     int updateState(@Bind("id") Long id, @Bind("state") MandateState mandateState);
 
-    @SqlUpdate("UPDATE mandates m SET state = :state FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
+    @SqlUpdate("UPDATE mandates m SET state = :state, state_details = :stateDetails, state_details_description = :stateDetailsDescription " +
+            "FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
             "AND g.id = m.gateway_account_id AND g.organisation = :goCardlessOrganisationId AND g.payment_provider = :provider")
     int updateStateByProviderIdAndOrganisationId(@Bind("provider") PaymentProvider paymentProvider,
                                                  @Bind("goCardlessOrganisationId") GoCardlessOrganisationId goCardlessOrganisationId,
                                                  @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
-                                                 @Bind("state") MandateState mandateState);
+                                                 @Bind("state") MandateState mandateState,
+                                                 @Bind("stateDetails") String details,
+                                                 @Bind("stateDetailsDescription") String detailsDescription);
 
-    @SqlUpdate("UPDATE mandates m SET state = :state FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
+    @SqlUpdate("UPDATE mandates m SET state = :state, state_details = :stateDetails, state_details_description = :stateDetailsDescription " +
+            "FROM gateway_accounts g WHERE m.payment_provider_id = :providerMandateId " +
             "AND g.id = m.gateway_account_id AND g.organisation IS NULL AND g.payment_provider = :provider")
     int updateStateByProviderId(@Bind("provider") PaymentProvider paymentProvider,
                                 @Bind("providerMandateId") PaymentProviderMandateId paymentProviderMandateId,
-                                @Bind("state") MandateState mandateState);
+                                @Bind("state") MandateState mandateState,
+                                @Bind("stateDetails") String details,
+                                @Bind("stateDetailsDescription") String detailsDescription);
 
     @SqlUpdate("UPDATE mandates m SET mandate_reference = :mandateBankStatementReference, payment_provider_id = :paymentProviderMandateId WHERE m.id = :id")
     int updateReferenceAndPaymentProviderId(@BindBean Mandate mandate);

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDao.java
@@ -63,6 +63,8 @@ public class MandateSearchDao {
                     "  m.gateway_account_id AS mandate_gateway_account_id," +
                     "  m.return_url AS mandate_return_url," +
                     "  m.state AS mandate_state," +
+                    "  m.state_details AS mandate_state_details," +
+                    "  m.state_details_description AS mandate_state_details_description," +
                     "  m.created_date AS mandate_created_date," +
                     "  m.payment_provider_id AS mandate_payment_provider_id," +
                     "  g.id AS gateway_account_id," +

--- a/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/dao/mapper/MandateMapper.java
@@ -29,6 +29,8 @@ public class MandateMapper implements RowMapper<Mandate> {
     private static final String ID_COLUMN = "mandate_id";
     private static final String EXTERNAL_ID_COLUMN = "mandate_external_id";
     private static final String STATE_COLUMN = "mandate_state";
+    private static final String STATE_DETAILS_COLUMN = "mandate_state_details";
+    private static final String STATE_DETAILS_DESCRIPTION_COLUMN = "mandate_state_details_description";
     private static final String PAYMENT_PROVIDER_ID = "mandate_payment_provider_id";
     private static final String MANDATE_MANDATE_REFERENCE_COLUMN = "mandate_mandate_reference";
     private static final String MANDATE_SERVICE_REFERENCE_COLUMN = "mandate_service_reference";
@@ -106,6 +108,9 @@ public class MandateMapper implements RowMapper<Mandate> {
         Optional.ofNullable(resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN))
                 .map(MandateBankStatementReference::valueOf)
                 .ifPresent(mandateBuilder::withMandateBankStatementReference);
+
+        Optional.ofNullable(resultSet.getString(STATE_DETAILS_COLUMN)).ifPresent(mandateBuilder::withStateDetails);
+        Optional.ofNullable(resultSet.getString(STATE_DETAILS_DESCRIPTION_COLUMN)).ifPresent(mandateBuilder::withStateDetailsDescription);
 
         return mandateBuilder.build();
     }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
@@ -13,6 +13,8 @@ public class Mandate {
     private final Long id;
     private final MandateExternalId externalId;
     private final MandateState state;
+    private final String stateDetails;
+    private final String stateDetailsDescription;
     private final GatewayAccount gatewayAccount;
     private final String returnUrl;
     private final MandateBankStatementReference mandateBankStatementReference;
@@ -33,6 +35,8 @@ public class Mandate {
         this.mandateBankStatementReference = builder.mandateBankStatementReference;
         this.paymentProviderMandateId = builder.paymentProviderId;
         this.description = builder.description;
+        this.stateDetails = builder.stateDetails;
+        this.stateDetailsDescription = builder.stateDetailsDescription;
     }
 
     public Optional<String> getDescription() {
@@ -65,6 +69,14 @@ public class Mandate {
 
     public MandateState getState() {
         return state;
+    }
+
+    public Optional<String> getStateDetails() {
+        return Optional.ofNullable(stateDetails);
+    }
+
+    public Optional<String> getStateDetailsDescription() {
+        return Optional.ofNullable(stateDetailsDescription);
     }
 
     public Optional<MandateBankStatementReference> getMandateBankStatementReference() {
@@ -106,6 +118,8 @@ public class Mandate {
         private Long id;
         private MandateExternalId externalId;
         private MandateState state;
+        private String stateDetails;
+        private String stateDetailsDescription;
         private GatewayAccount gatewayAccount;
         private String returnUrl;
         private MandateBankStatementReference mandateBankStatementReference;
@@ -130,6 +144,8 @@ public class Mandate {
             .withMandateBankStatementReference(mandate.mandateBankStatementReference)
             .withServiceReference(mandate.serviceReference)
             .withState(mandate.state)
+            .withStateDetails(mandate.stateDetails)
+            .withStateDetailsDescription(mandate.stateDetailsDescription)
             .withReturnUrl(mandate.returnUrl)
             .withCreatedDate(mandate.createdDate)
             .withPayer(mandate.payer)
@@ -149,6 +165,16 @@ public class Mandate {
 
         public MandateBuilder withState(MandateState state) {
             this.state = state;
+            return this;
+        }
+
+        public MandateBuilder withStateDetails(String stateDetails) {
+            this.stateDetails = stateDetails;
+            return this;
+        }
+
+        public MandateBuilder withStateDetailsDescription(String stateDetailsDescription) {
+            this.stateDetailsDescription = stateDetailsDescription;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateService.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.directdebit.mandate.services;
 
+import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.model.MandateLookupKey;
@@ -19,14 +20,17 @@ public class MandateUpdateService {
         this.mandateDao = mandateDao;
     }
 
-    public int updateStateByPaymentProviderMandateId(PaymentProvider paymentProvider, MandateLookupKey mandateLookupKey, MandateState mandateState) {
+    public int updateStateByPaymentProviderMandateId(PaymentProvider paymentProvider, MandateLookupKey mandateLookupKey,
+                                                     DirectDebitStateWithDetails<MandateState> stateAndDetails) {
         if (mandateLookupKey.getClass() == GoCardlessMandateIdAndOrganisationId.class) {
             var goCardlessMandateIdAndOrganisationId = (GoCardlessMandateIdAndOrganisationId) mandateLookupKey;
             return mandateDao.updateStateByProviderIdAndOrganisationId(paymentProvider, goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId(),
-                    goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(), mandateState);
+                    goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(), stateAndDetails.getState(), stateAndDetails.getDetails().orElse(null),
+                    stateAndDetails.getDetailsDescription().orElse(null));
         } else if (mandateLookupKey.getClass() == SandboxMandateId.class) {
             var paymentProviderMandateId = (PaymentProviderMandateId) mandateLookupKey;
-            return mandateDao.updateStateByProviderId(paymentProvider, paymentProviderMandateId, mandateState);
+            return mandateDao.updateStateByProviderId(paymentProvider, paymentProviderMandateId, stateAndDetails.getState(),
+                    stateAndDetails.getDetails().orElse(null), stateAndDetails.getDetailsDescription().orElse(null));
         }
         throw new IllegalArgumentException("Unrecognised MandateLookupKey of type " + mandateLookupKey.getClass());
     }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdater.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdater.java
@@ -25,17 +25,17 @@ public class GoCardlessMandateStateUpdater {
 
     public void updateState(GoCardlessMandateIdAndOrganisationId goCardlessMandateIdAndOrganisationId) {
         goCardlessMandateStateCalculator.calculate(goCardlessMandateIdAndOrganisationId)
-                .ifPresentOrElse(state -> {
-                    int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, goCardlessMandateIdAndOrganisationId, state);
+                .ifPresentOrElse(stateAndDetails -> {
+                    int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, goCardlessMandateIdAndOrganisationId, stateAndDetails);
                     if (updated == 1) {
                         LOGGER.info(format("Updated status of GoCardless mandate %s for organisation %s to %s", 
                                 goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(),
                                 goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId(),
-                                state));
+                                stateAndDetails.getState()));
                     } else {
                         LOGGER.error(format("Could not update status of GoCardless mandate %s for organisation %s to %s because the mandate was not found",
                                 goCardlessMandateIdAndOrganisationId.getGoCardlessMandateId(),
-                                goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId(), state));
+                                goCardlessMandateIdAndOrganisationId.getGoCardlessOrganisationId(), stateAndDetails.getState()));
                     }
                 }, () -> LOGGER.info(format("Asked to update the status for GoCardless mandate %s for organisation %s " +
                                 "but there appear to be no events stored that require it to be updated",

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -388,12 +388,40 @@ public class MandateDaoIT {
                 .insert(testContext.getJdbi());
 
         int numOfUpdatedMandates = mandateDao.updateStateByProviderIdAndOrganisationId(GOCARDLESS, GoCardlessOrganisationId.valueOf("Organisation ID we want"),
-                GoCardlessMandateId.valueOf("Mandate ID we want"), MandateState.PENDING);
+                GoCardlessMandateId.valueOf("Mandate ID we want"), MandateState.PENDING, "state details","state details description");
 
         assertThat(numOfUpdatedMandates, is(1));
 
         Mandate mandate = mandateDao.findByExternalId(MandateExternalId.valueOf("Mandate we want")).get();
         assertThat(mandate.getState(), is(MandateState.PENDING));
+        assertThat(mandate.getStateDetails(), is(Optional.of("state details")));
+        assertThat(mandate.getStateDetailsDescription(), is(Optional.of("state details description")));
+    }
+
+    @Test
+    public void shouldUpdateStateByProviderIdAndOrganisationWithNoDetailsAndDescriptionAndReturnNumberOfAffectedRows() {
+        GatewayAccountFixture goCardlessGatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()
+                .withPaymentProvider(GOCARDLESS)
+                .withOrganisation(GoCardlessOrganisationId.valueOf("Organisation ID we want"))
+                .insert(testContext.getJdbi());
+
+        MandateFixture.aMandateFixture()
+                .withGatewayAccountFixture(goCardlessGatewayAccountFixture)
+                .withExternalId(MandateExternalId.valueOf("Mandate we want"))
+                .withPaymentProviderId(GoCardlessMandateId.valueOf("Mandate ID we want"))
+                .withStateDetails("state details before update")
+                .withStateDetailsDescription("state details description before update")
+                .insert(testContext.getJdbi());
+
+        int numOfUpdatedMandates = mandateDao.updateStateByProviderIdAndOrganisationId(GOCARDLESS, GoCardlessOrganisationId.valueOf("Organisation ID we want"),
+                GoCardlessMandateId.valueOf("Mandate ID we want"), MandateState.PENDING, null, null);
+
+        assertThat(numOfUpdatedMandates, is(1));
+
+        Mandate mandate = mandateDao.findByExternalId(MandateExternalId.valueOf("Mandate we want")).get();
+        assertThat(mandate.getState(), is(MandateState.PENDING));
+        assertThat(mandate.getStateDetails(), is(Optional.empty()));
+        assertThat(mandate.getStateDetails(), is(Optional.empty()));
     }
 
     @Test
@@ -426,12 +454,43 @@ public class MandateDaoIT {
 
         int numOfUpdatedMandates = mandateDao.updateStateByProviderId(SANDBOX,
                 SandboxMandateId.valueOf("Mandate ID we want"),
-                MandateState.PENDING);
+                MandateState.PENDING,
+                "state details",
+                "state details description");
 
         assertThat(numOfUpdatedMandates, is(1));
 
         Mandate mandate = mandateDao.findByExternalId(MandateExternalId.valueOf("Mandate we want")).get();
         assertThat(mandate.getState(), is(MandateState.PENDING));
+        assertThat(mandate.getStateDetails(), is(Optional.of("state details")));
+        assertThat(mandate.getStateDetailsDescription(), is(Optional.of("state details description")));
+    }
+
+    @Test
+    public void shouldUpdateStateByProviderIdAndNoOrganisationWithNoDetailsOrDescriptionAndReturnNumberOfAffectedRows() {
+        GatewayAccountFixture gatewayAccountFixtureWithNoOrganisation = GatewayAccountFixture.aGatewayAccountFixture()
+                .withPaymentProvider(SANDBOX)
+                .withOrganisation(null)
+                .insert(testContext.getJdbi());
+
+        MandateFixture.aMandateFixture()
+                .withGatewayAccountFixture(gatewayAccountFixtureWithNoOrganisation)
+                .withExternalId(MandateExternalId.valueOf("Mandate we want"))
+                .withPaymentProviderId(SandboxMandateId.valueOf("Mandate ID we want"))
+                .withStateDetails("state details before update")
+                .withStateDetailsDescription("state details description before update")
+                .insert(testContext.getJdbi());
+
+        int numOfUpdatedMandates = mandateDao.updateStateByProviderId(SANDBOX,
+                SandboxMandateId.valueOf("Mandate ID we want"),
+                MandateState.PENDING, null, null);
+
+        assertThat(numOfUpdatedMandates, is(1));
+
+        Mandate mandate = mandateDao.findByExternalId(MandateExternalId.valueOf("Mandate we want")).get();
+        assertThat(mandate.getState(), is(MandateState.PENDING));
+        assertThat(mandate.getStateDetails(), is(Optional.empty()));
+        assertThat(mandate.getStateDetailsDescription(), is(Optional.empty()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
@@ -26,6 +26,8 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
     private MandateBankStatementReference mandateReference = MandateBankStatementReference.valueOf(RandomStringUtils.randomAlphanumeric(18));
     private String serviceReference = RandomStringUtils.randomAlphanumeric(18);
     private MandateState state = MandateState.CREATED;
+    private String stateDetails = null;
+    private String stateDetailsDescription = null;
     private String returnUrl = "http://service.test/success-page";
     private GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture();
     private PayerFixture payerFixture = null;
@@ -97,6 +99,24 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
 
     public MandateFixture withState(MandateState state) {
         this.state = state;
+        return this;
+    }
+
+    public String getStateDetails() {
+        return stateDetails;
+    }
+
+    public MandateFixture withStateDetails(String stateDetails) {
+        this.stateDetailsDescription = stateDetails;
+        return this;
+    }
+
+    public String getStateDetailsDescription() {
+        return stateDetailsDescription;
+    }
+
+    public MandateFixture withStateDetailsDescription(String stateDetailsDescription) {
+        this.stateDetailsDescription = stateDetailsDescription;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateServiceTest.java
@@ -5,10 +5,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.mandate.model.MandateLookupKey;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 
@@ -29,6 +31,11 @@ public class MandateUpdateServiceTest {
     private static final GoCardlessOrganisationId GOCARDLESS_ORGANISATION_ID = GoCardlessOrganisationId.valueOf("OR123");
     private static final GoCardlessMandateIdAndOrganisationId GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID =
             new GoCardlessMandateIdAndOrganisationId(GOCARDLESS_MANDATE_ID, GOCARDLESS_ORGANISATION_ID);
+    
+    private static final String MANDATE_STATE_DETAILS = "state details";
+    private static final String MANDATE_STATE_DETAILS_DESCRIPTION = "state details description";
+    private static final DirectDebitStateWithDetails<MandateState> MANDATE_STATE_WITH_DETAILS = new DirectDebitStateWithDetails<>(PENDING,
+            MANDATE_STATE_DETAILS, MANDATE_STATE_DETAILS_DESCRIPTION);
 
     @Mock
     private MandateDao mockMandateDao;
@@ -42,9 +49,9 @@ public class MandateUpdateServiceTest {
 
     @Test
     public void updateStateByPaymentProviderMandateIdWithSandboxMandateIdReturnsUpdateCount() {
-        given(mockMandateDao.updateStateByProviderId(SANDBOX, SANDBOX_MANDATE_ID, PENDING)).willReturn(1);
+        given(mockMandateDao.updateStateByProviderId(SANDBOX, SANDBOX_MANDATE_ID, PENDING, MANDATE_STATE_DETAILS, MANDATE_STATE_DETAILS_DESCRIPTION)).willReturn(1);
 
-        int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(SANDBOX, SANDBOX_MANDATE_ID, PENDING);
+        int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(SANDBOX, SANDBOX_MANDATE_ID, MANDATE_STATE_WITH_DETAILS);
 
         assertThat(updated, is(1));
 
@@ -54,9 +61,10 @@ public class MandateUpdateServiceTest {
     @Test
     public void updateStateByPaymentProviderMandateIdWithGoCardlessMandateIdAndOrganisationIdReturnsUpdateCount() {
         given(mockMandateDao.updateStateByProviderIdAndOrganisationId(GOCARDLESS, GOCARDLESS_ORGANISATION_ID, GOCARDLESS_MANDATE_ID,
-                PENDING)).willReturn(1);
+                PENDING, MANDATE_STATE_DETAILS, MANDATE_STATE_DETAILS_DESCRIPTION)).willReturn(1);
 
-        int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID, PENDING);
+        int updated = mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID,
+                MANDATE_STATE_WITH_DETAILS);
 
         assertThat(updated, is(1));
 
@@ -66,7 +74,8 @@ public class MandateUpdateServiceTest {
     @Test(expected = IllegalArgumentException.class)
     public void updateStateByPaymentProviderMandateIdWithUnrecognisedTypeThrowsException() {
         
-        mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, new UnrecognisedMandateLookupKeyImplementation(), PENDING);
+        mandateUpdateService.updateStateByPaymentProviderMandateId(GOCARDLESS, new UnrecognisedMandateLookupKeyImplementation(),
+                MANDATE_STATE_WITH_DETAILS);
     }
     
     private static class UnrecognisedMandateLookupKeyImplementation implements MandateLookupKey {

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
 import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
 import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.payments.model.GoCardlessEvent;
@@ -43,54 +44,66 @@ public class GoCardlessMandateStateCalculatorTest {
     public void createdActionMapsToCreatedState() {
         given(mockGoCardlessEvent.getAction()).willReturn("created");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
+        Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
         
-        assertThat(mandateState.get(), is(MandateState.CREATED));
+        assertThat(result.get().getState(), is(MandateState.CREATED));
     }
 
     @Test
     public void submittedActionMapsToSubmittedState() {
         given(mockGoCardlessEvent.getAction()).willReturn("submitted");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
+        Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
-        assertThat(mandateState.get(), is(MandateState.SUBMITTED));
+        assertThat(result.get().getState(), is(MandateState.SUBMITTED));
     }
 
     @Test
     public void activeActionMapsToActiveState() {
         given(mockGoCardlessEvent.getAction()).willReturn("active");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
+        Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
-        assertThat(mandateState.get(), is(MandateState.ACTIVE));
+        assertThat(result.get().getState(), is(MandateState.ACTIVE));
     }
 
     @Test
     public void cancelledActionMapsToCancelledState() {
         given(mockGoCardlessEvent.getAction()).willReturn("cancelled");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
+        Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
-        assertThat(mandateState.get(), is(MandateState.CANCELLED));
+        assertThat(result.get().getState(), is(MandateState.CANCELLED));
     }
 
     @Test
     public void failedActionMapsToFailedState() {
         given(mockGoCardlessEvent.getAction()).willReturn("failed");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
+        Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
-        assertThat(mandateState.get(), is(MandateState.FAILED));
+        assertThat(result.get().getState(), is(MandateState.FAILED));
+    }
+
+    @Test
+    public void detailsCauseAndDescriptionReturned() {
+        given(mockGoCardlessEvent.getAction()).willReturn("failed");
+        given(mockGoCardlessEvent.getDetailsCause()).willReturn("details_cause");
+        given(mockGoCardlessEvent.getDetailsDescription()).willReturn("This is a description.");
+
+        Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
+
+        assertThat(result.get().getDetails(), is(Optional.of("details_cause")));
+        assertThat(result.get().getDetailsDescription(), is(Optional.of("This is a description.")));
     }
 
     @Test
     public void unrecognisedActionMapsToNothing() {
         given(mockGoCardlessEvent.getAction()).willReturn("eaten_by_wolves");
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
+        Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
-        assertThat(mandateState, is(Optional.empty()));
+        assertThat(result, is(Optional.empty()));
     }
 
     @Test
@@ -98,9 +111,9 @@ public class GoCardlessMandateStateCalculatorTest {
         given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(mockGoCardlessMandateIdAndOrganisationId, GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
                 .willReturn(Optional.empty());
 
-        Optional<MandateState> mandateState = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
+        Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mockGoCardlessMandateIdAndOrganisationId);
 
-        assertThat(mandateState, is(Optional.empty()));
+        assertThat(result, is(Optional.empty()));
     }
 
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateUpdaterTest.java
@@ -5,8 +5,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.services.MandateUpdateService;
 import uk.gov.pay.directdebit.payments.model.GoCardlessMandateIdAndOrganisationId;
 
@@ -17,13 +19,15 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.PENDING;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GoCardlessMandateStateUpdaterTest {
 
     private static final GoCardlessMandateIdAndOrganisationId GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID = new GoCardlessMandateIdAndOrganisationId(
             GoCardlessMandateId.valueOf("MD123"), GoCardlessOrganisationId.valueOf("OR123"));
+
+    @Mock
+    private DirectDebitStateWithDetails<MandateState> mockMandateStateWithDetails;
 
     @Mock
     private MandateUpdateService mockMandateUpdateService;
@@ -40,11 +44,13 @@ public class GoCardlessMandateStateUpdaterTest {
 
     @Test
     public void updatesMandateWithStateReturnedByCalculator() {
-        given(mockGoCardlessMandateStateCalculator.calculate(GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID)).willReturn(Optional.of(PENDING));
+        given(mockGoCardlessMandateStateCalculator.calculate(GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID))
+                .willReturn(Optional.of(mockMandateStateWithDetails));
 
         mockGoCardlessMandateStateUpdater.updateState(GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID);
 
-        verify(mockMandateUpdateService).updateStateByPaymentProviderMandateId(GOCARDLESS, GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID, PENDING);
+        verify(mockMandateUpdateService).updateStateByPaymentProviderMandateId(GOCARDLESS, GOCARDLESS_MANDATE_ID_AND_ORGANISATION_ID,
+                mockMandateStateWithDetails);
     }
 
     @Test


### PR DESCRIPTION
When processing a GoCardless webhook that changes the state of a mandate, store the cause and description if GoCardless supply them.