### PR TITLE
PP-5442 Expose mandate/payment granular state details in responses

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
@@ -17,15 +17,10 @@ public enum ExternalMandateState {
 
     private final String value;
     private final boolean finished;
-    private final String details = "example details";
     
     ExternalMandateState(String value, boolean finished) {
         this.value = value;
         this.finished = finished;
-    }
-
-    public String getDetails() {
-        return details;
     }
 
     @JsonProperty("status")

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateStateWithDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateStateWithDetails.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.directdebit.mandate.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ExternalMandateStateWithDetails {
+
+    @JsonUnwrapped
+    private final ExternalMandateState mandateState;
+
+    private final String details;
+
+    public ExternalMandateStateWithDetails(ExternalMandateState mandateState, String details) {
+        this.mandateState = mandateState;
+        this.details = details;
+    }
+
+    public ExternalMandateState getMandateState() {
+        return mandateState;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalPaymentStateWithDetails{" +
+                "mandateState=" + mandateState +
+                ", details='" + details + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        ExternalMandateStateWithDetails that = (ExternalMandateStateWithDetails) other;
+        return mandateState == that.mandateState && Objects.equals(details, that.details);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mandateState, details);
+    }
+ 
+}

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/MandateResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/MandateResponse.java
@@ -32,7 +32,7 @@ public class MandateResponse {
     private final List<Map<String, Object>> dataLinks;
 
     @JsonProperty
-    private final ExternalMandateState state;
+    private ExternalMandateStateWithDetails state;
 
     @JsonProperty("service_reference")
     private final String serviceReference;
@@ -63,14 +63,14 @@ public class MandateResponse {
         mandateId = mandate.getExternalId();
         returnUrl = mandate.getReturnUrl();
         this.dataLinks = dataLinks;
-        state = mandate.getState().toExternal();
+        state = new ExternalMandateStateWithDetails(mandate.getState().toExternal(), mandate.getStateDetails().orElse(null));
         serviceReference = mandate.getServiceReference();
         mandateReference = mandate.getMandateBankStatementReference().orElse(null);
         paymentProviderId = mandate.getPaymentProviderMandateId().orElse(null);
         createdDate = mandate.getCreatedDate();
         paymentProvider = mandate.getGatewayAccount().getPaymentProvider();
         description = mandate.getDescription().orElse(null);
-        payer = mandate.getPayer().map(p -> Payer.from(p)).orElse(null);
+        payer = mandate.getPayer().map(Payer::from).orElse(null);
     }
 
     public Optional<URI> getLink(String rel) {
@@ -92,7 +92,7 @@ public class MandateResponse {
         return dataLinks;
     }
 
-    public ExternalMandateState getState() {
+    public ExternalMandateStateWithDetails getState() {
         return state;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
@@ -97,8 +97,7 @@ public class PaymentResponse {
     public static PaymentResponse from(Payment payment) {
         PaymentResponseBuilder paymentResponseBuilder = aPaymentResponse()
                 .withPaymentExternalId(payment.getExternalId())
-                // TODO: should extract state details (go cardless cause details) from events table somehow
-                .withState(new ExternalPaymentStateWithDetails(payment.getState().toExternal(), "example_details"))
+                .withState(new ExternalPaymentStateWithDetails(payment.getState().toExternal(), payment.getStateDetails().orElse(null)))
                 .withAmount(payment.getAmount())
                 .withMandateId(payment.getMandate().getExternalId())
                 .withDescription(payment.getDescription())

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentDao.java
@@ -50,6 +50,8 @@ public interface PaymentDao {
             "  m.gateway_account_id AS mandate_gateway_account_id," +
             "  m.return_url AS mandate_return_url," +
             "  m.state AS mandate_state," +
+            "  m.state_details AS mandate_state_details," +
+            "  m.state_details_description AS mandate_state_details_description," +
             "  m.created_date AS mandate_created_date," +
             "  g.id AS gateway_account_id," +
             "  g.external_id AS gateway_account_external_id," +

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
@@ -19,6 +19,7 @@ public class PaymentViewDao {
             "p.created_date as created_date, " +
             "p.state AS state, " +
             "p.state_details AS state_details, " +
+            "p.state_details_description AS state_details_description, " +
             "pa.name AS name, " +
             "pa.email AS email, " +
             "ga.payment_provider as payment_provider, " +

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentMapper.java
@@ -63,6 +63,8 @@ public class PaymentMapper implements RowMapper<Payment> {
     private static final String MANDATE_EXTERNAL_ID_COLUMN = "mandate_external_id";
     private static final String MANDATE_RETURN_URL_COLUMN = "mandate_return_url";
     private static final String MANDATE_STATE_COLUMN = "mandate_state";
+    private static final String MANDATE_STATE_DETAILS_COLUMN = "mandate_state_details";
+    private static final String MANDATE_STATE_DETAILS_DESCRIPTION_COLUMN = "mandate_state_details_description";
     private static final String MANDATE_MANDATE_REFERENCE_COLUMN = "mandate_mandate_reference";
     private static final String MANDATE_SERVICE_REFERENCE_COLUMN = "mandate_service_reference";
     private static final String MANDATE_CREATED_DATE_COLUMN = "mandate_created_date";
@@ -108,6 +110,8 @@ public class PaymentMapper implements RowMapper<Payment> {
                 .withMandateBankStatementReference(MandateBankStatementReference.valueOf(resultSet.getString(MANDATE_MANDATE_REFERENCE_COLUMN)))
                 .withServiceReference(resultSet.getString(MANDATE_SERVICE_REFERENCE_COLUMN))
                 .withState(MandateState.valueOf(resultSet.getString(MANDATE_STATE_COLUMN)))
+                .withStateDetails(resultSet.getString(MANDATE_STATE_DETAILS_COLUMN))
+                .withStateDetailsDescription(resultSet.getString(MANDATE_STATE_DETAILS_DESCRIPTION_COLUMN))
                 .withReturnUrl(resultSet.getString(MANDATE_RETURN_URL_COLUMN))
                 .withCreatedDate(ZonedDateTime.ofInstant(resultSet.getTimestamp(MANDATE_CREATED_DATE_COLUMN).toInstant(), ZoneOffset.UTC))
                 .withPayer(payer)

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentResponseMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/mapper/PaymentResponseMapper.java
@@ -27,7 +27,7 @@ public class PaymentResponseMapper implements RowMapper<PaymentResponse> {
         PaymentResponse.PaymentResponseBuilder paymentResponse = aPaymentResponse()
                 .withState(
                         new ExternalPaymentStateWithDetails(
-                                PaymentState.valueOf(rs.getString("state")).toExternal(), ""))
+                                PaymentState.valueOf(rs.getString("state")).toExternal(), rs.getString("state_details")))
                 .withAmount(rs.getLong("amount"))
                 .withPaymentExternalId(rs.getString("payment_external_id"))
                 .withDescription(rs.getString("description"))

--- a/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/fixtures/MandateFixture.java
@@ -107,7 +107,7 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
     }
 
     public MandateFixture withStateDetails(String stateDetails) {
-        this.stateDetailsDescription = stateDetails;
+        this.stateDetails = stateDetails;
         return this;
     }
 
@@ -155,10 +155,12 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
                                 "  service_reference,\n" +
                                 "  return_url,\n" +
                                 "  state,\n" +
+                                "  state_details,\n" +
+                                "  state_details_description,\n" +
                                 "  created_date,\n" +
                                 "  payment_provider_id\n" +
                                 ") VALUES (\n" +
-                                "  ?, ?, ?, ?, ?, ?, ?, ?, ?\n" +
+                                "  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?\n" +
                                 ")\n",
                         id,
                         gatewayAccountFixture.getId(),
@@ -167,6 +169,8 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
                         serviceReference,
                         returnUrl,
                         state.toString(),
+                        stateDetails,
+                        stateDetailsDescription,
                         createdDate,
                         paymentProviderId
                 )
@@ -188,6 +192,8 @@ public class MandateFixture implements DbFixture<MandateFixture, Mandate> {
                 .withMandateBankStatementReference(mandateReference)
                 .withServiceReference(serviceReference)
                 .withState(state)
+                .withStateDetails(stateDetails)
+                .withStateDetailsDescription(stateDetailsDescription)
                 .withReturnUrl(returnUrl)
                 .withCreatedDate(createdDate)
                 .withPayer(payer)

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -284,6 +284,7 @@ public class MandateResourceIT {
                 .body("return_url", is(returnUrl))
                 .body("created_date", is(notNullValue()))
                 .body("state.status", is("created"))
+                .body("state.details", is(nullValue()))
                 .body("state.finished", is(false))
                 .body("service_reference", is("test-service-reference"))
                 .body("payment_provider", is(gatewayAccountFixture.getPaymentProvider().toString().toLowerCase()))
@@ -313,6 +314,7 @@ public class MandateResourceIT {
         String accountExternalId = gatewayAccountFixture.getExternalId();
         PayerFixture payerFixture = PayerFixture.aPayerFixture();
         MandateFixture mandateFixture = aMandateFixture()
+                .withStateDetails("state details")
                 .withPayerFixture(payerFixture)
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .insert(testContext.getJdbi());
@@ -333,7 +335,7 @@ public class MandateResourceIT {
                 .body("gateway_account_id", isNumber(gatewayAccountFixture.getId()))
                 .body("gateway_account_external_id", is(gatewayAccountFixture.getExternalId()))
                 .body("state.status", is(mandateFixture.getState().toExternal().getState()))
-                .body("state.details", is("example details"))
+                .body("state.details", is(mandateFixture.getStateDetails()))
                 .body("internal_state", is(mandateFixture.getState().toString()))
                 .body("mandate_reference", is(mandateFixture.getMandateReference().toString()))
                 .body("created_date", is(mandateFixture.getCreatedDate().format(ISO_INSTANT_MILLISECOND_PRECISION)))
@@ -353,6 +355,7 @@ public class MandateResourceIT {
         String accountExternalId = gatewayAccountFixture.getExternalId();
         PayerFixture payerFixture = PayerFixture.aPayerFixture();
         MandateFixture mandateFixture = aMandateFixture()
+                .withStateDetails("state details")
                 .withPayerFixture(payerFixture)
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .insert(testContext.getJdbi());
@@ -371,7 +374,7 @@ public class MandateResourceIT {
                 .body("gateway_account_id", isNumber(gatewayAccountFixture.getId()))
                 .body("gateway_account_external_id", is(gatewayAccountFixture.getExternalId()))
                 .body("state.status", is(mandateFixture.getState().toExternal().getState()))
-                .body("state.details", is("example details"))
+                .body("state.details", is(mandateFixture.getStateDetails()))
                 .body("internal_state", is(mandateFixture.getState().toString()))
                 .body("mandate_reference", is(mandateFixture.getMandateReference().toString()))
                 .body("created_date", is(mandateFixture.getCreatedDate().format(ISO_INSTANT_MILLISECOND_PRECISION)))
@@ -387,6 +390,7 @@ public class MandateResourceIT {
         String accountExternalId = gatewayAccountFixture.getExternalId();
         PayerFixture payerFixture = PayerFixture.aPayerFixture();
         MandateFixture mandateFixture = aMandateFixture()
+                .withStateDetails("state details")
                 .withPayerFixture(payerFixture)
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .insert(testContext.getJdbi());
@@ -405,7 +409,7 @@ public class MandateResourceIT {
                 .body("return_url", is(mandateFixture.getReturnUrl()))
                 .body("state.status", is(mandateFixture.getState().toExternal().getState()))
                 .body("state.finished", is(mandateFixture.getState().toExternal().isFinished()))
-                .body("state.details", is("example details"))
+                .body("state.details", is(mandateFixture.getStateDetails()))
                 .body("service_reference", is(mandateFixture.getServiceReference()))
                 .body("mandate_reference", is(notNullValue()))
                 .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"));

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceSearchIT.java
@@ -82,6 +82,7 @@ public class MandateResourceSearchIT {
                 .withExternalId(MandateExternalId.valueOf("expectedExternalId"))
                 .withMandateBankStatementReference(MandateBankStatementReference.valueOf("bankRef"))
                 .withState(MandateState.PENDING)
+                .withStateDetails("state_details")
                 .withCreatedDate(ZonedDateTime.now().minusDays(2))
                 .insert(testContext.getJdbi())
                 .toEntity();
@@ -119,6 +120,7 @@ public class MandateResourceSearchIT {
                 .body("results", hasSize(1))
                 .body("results[0].service_reference", is("expectedReference"))
                 .body("results[0].mandate_id", is("expectedExternalId"))
+                .body("results[0].state.details", is("state_details"))
                 .statusCode(HttpStatus.SC_OK);
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -30,7 +30,6 @@ import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
-import uk.gov.pay.directdebit.payments.api.ExternalPaymentStateWithDetails;
 import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentFixture;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
@@ -150,7 +149,7 @@ public class MandateServiceTest {
         MandateResponse getMandateResponse = service.populateGetMandateResponse(mandate.getGatewayAccount().getExternalId(), mandate.getExternalId(), uriInfo);
         assertThat(getMandateResponse.getReturnUrl(), is(mandate.getReturnUrl()));
         assertThat(getMandateResponse.getMandateId(), is(mandate.getExternalId()));
-        assertThat(getMandateResponse.getState(), is(mandate.getState().toExternal()));
+        assertThat(getMandateResponse.getState().getMandateState(), is(mandate.getState().toExternal()));
     }
 
     @Test
@@ -175,7 +174,8 @@ public class MandateServiceTest {
                 .withState(AWAITING_DIRECT_DEBIT_DETAILS);
         PaymentFixture paymentFixture = PaymentFixture
                 .aPaymentFixture()
-                .withMandateFixture(mandateFixture);
+                .withMandateFixture(mandateFixture)
+                .withStateDetails("state details");
         Mandate mandate = mandateFixture.toEntity();
         when(paymentService.findPaymentForExternalId(mandateFixture.getExternalId().toString())).thenReturn(paymentFixture.toEntity());
         DirectDebitInfoFrontendResponse mandateResponseForFrontend = service.populateGetMandateWithPaymentResponseForFrontend(mandate.getGatewayAccount().getExternalId(), mandate.getExternalId().toString());
@@ -191,7 +191,7 @@ public class MandateServiceTest {
         assertThat(mandateResponseForFrontend.getPayment().getAmount(), is(paymentFixture.getAmount()));
         assertThat(mandateResponseForFrontend.getPayment().getDescription(), is(paymentFixture.getDescription()));
         assertThat(mandateResponseForFrontend.getPayment().getExternalId(), is(paymentFixture.getExternalId()));
-        assertThat(mandateResponseForFrontend.getPayment().getState(), is(new ExternalPaymentStateWithDetails(paymentFixture.getState().toExternal(), "example_details")));
+        assertThat(mandateResponseForFrontend.getPayment().getState().getPaymentState(), is(paymentFixture.getState().toExternal()));
         assertThat(mandateResponseForFrontend.getPayment().getReference(), is(paymentFixture.getReference()));
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentDaoIT.java
@@ -59,7 +59,7 @@ public class PaymentDaoIT {
     public void setup() {
         paymentDao = testContext.getJdbi().onDemand(PaymentDao.class);
         testGatewayAccount = aGatewayAccountFixture().insert(testContext.getJdbi());
-        testMandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(testGatewayAccount).insert(testContext.getJdbi());
+        testMandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(testGatewayAccount).withStateDetails("state details").insert(testContext.getJdbi());
         testPayment = generateNewPaymentFixture(testMandate, STATE, AMOUNT);
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentFixture.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/fixtures/PaymentFixture.java
@@ -151,18 +151,22 @@ public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
                                 "        external_id,\n" +
                                 "        amount,\n" +
                                 "        state,\n" +
+                                "        state_details,\n" +
+                                "        state_details_description,\n" +
                                 "        reference,\n" +
                                 "        description,\n" +
                                 "        created_date,\n" +
                                 "        payment_provider_id,\n" +
                                 "        charge_date\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
                         id,
                         mandateFixture.getId(),
                         externalId,
                         amount,
-                        state,
+                        state.toString(),
+                        stateDetails,
+                        stateDetailsDescription,
                         reference,
                         description,
                         createdDate,
@@ -180,6 +184,8 @@ public class PaymentFixture implements DbFixture<PaymentFixture, Payment> {
                 .withExternalId(externalId)
                 .withAmount(amount)
                 .withState(state)
+                .withStateDetails(stateDetails)
+                .withStateDetailsDescription(stateDetailsDescription)
                 .withDescription(description)
                 .withReference(reference)
                 .withMandate(mandateFixture.toEntity())

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -32,7 +32,10 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -292,7 +295,7 @@ public class PaymentResourceIT {
                 .withGatewayAccountFixture(testGatewayAccount)
                 .insert(testContext.getJdbi());
 
-        PaymentFixture paymentFixture = createTransactionFixtureWith(mandateFixture, PaymentState.NEW);
+        PaymentFixture paymentFixture = createTransactionFixtureWith(mandateFixture, PaymentState.NEW, "state details");
 
         String requestPath = CHARGE_API_PATH
                 .replace("{accountId}", accountExternalId)
@@ -308,7 +311,7 @@ public class PaymentResourceIT {
                 .body(JSON_DESCRIPTION_KEY, is(paymentFixture.getDescription()))
                 .body(JSON_STATE_STATUS_KEY, is(paymentFixture.getState().toExternal().getStatus()))
                 .body(JSON_STATE_FINISHED_KEY, is(false))
-                .body(JSON_STATE_DETAILS_KEY, is("example_details"));
+                .body(JSON_STATE_DETAILS_KEY, is(paymentFixture.getStateDetails()));
     }
     
     @Test
@@ -341,10 +344,12 @@ public class PaymentResourceIT {
 
     }
     
-    private PaymentFixture createTransactionFixtureWith(MandateFixture mandateFixture, PaymentState paymentState) {
+    private PaymentFixture createTransactionFixtureWith(MandateFixture mandateFixture, PaymentState paymentState,
+                                                        String paymentStateDetails) {
         return aPaymentFixture()
                 .withMandateFixture(mandateFixture)
                 .withState(paymentState)
+                .withStateDetails(paymentStateDetails)
                 .insert(testContext.getJdbi());
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResourceIT.java
@@ -369,12 +369,14 @@ public class PaymentSearchResourceIT { //TODO merge with PaymentResource
                 aPaymentFixture()
                         .withMandateFixture(mandateFixture)
                         .withState(PaymentState.CANCELLED)
+                        .withStateDetails("state_details")
                         .insert(testContext.getJdbi());
                 continue;
             }
             aPaymentFixture()
                     .withMandateFixture(mandateFixture)
                     .withState(PaymentState.EXPIRED)
+                    .withStateDetails("state_details")
                     .insert(testContext.getJdbi());
         }
         String requestPath = "/v1/api/accounts/{accountId}/payments?state=:state"
@@ -388,7 +390,8 @@ public class PaymentSearchResourceIT { //TODO merge with PaymentResource
                 .body("count", is(6))
                 .body("results", hasSize(6))
                 .body("results[0].state.finished", is(true))
-                .body("results[0].state.status", is("failed"));
+                .body("results[0].state.status", is("failed"))
+                .body("results[0].state.details", is("state_details"));
     }
 
     private RequestSpecification givenSetup() {


### PR DESCRIPTION
In mandate and payment responses (single and search results), include the `state_details` (granular information about the state provided by the payment provider) as `state.details`.