### PR TITLE
PP-5354 Only expire mandates before SUBMITTED state

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/tasks/services/ExpireService.java
+++ b/src/main/java/uk/gov/pay/directdebit/tasks/services/ExpireService.java
@@ -25,7 +25,7 @@ public class ExpireService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExpireService.class);
     private final long MIN_EXPIRY_AGE_MINUTES = 90L;
     private final PaymentState PAYMENT_EXPIRY_CUTOFF_STATUS = PaymentState.PENDING;
-    private final MandateState MANDATE_EXPIRY_CUTOFF_STATUS = MandateState.PENDING;
+    private final MandateState MANDATE_EXPIRY_CUTOFF_STATUS = MandateState.SUBMITTED;
     private final MandateQueryService mandateQueryService;
     private final MandateStateUpdateService mandateStateUpdateService;
 

--- a/src/test/java/uk/gov/pay/directdebit/tasks/services/ExpireServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/tasks/services/ExpireServiceTest.java
@@ -9,7 +9,6 @@ import uk.gov.pay.directdebit.junit.DropwizardTestContext;
 import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
-import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
 import uk.gov.pay.directdebit.mandate.services.MandateStateUpdateService;
@@ -19,7 +18,6 @@ import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.PaymentStatesGraph;
 import uk.gov.pay.directdebit.payments.services.PaymentService;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -28,6 +26,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.AWAITING_DIRECT_DEBIT_DETAILS;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -64,9 +65,9 @@ public class ExpireServiceTest {
 
     @Test
     public void expireMandates_shouldCallMandateServiceWithPriorStatesToPending() {
-        Mandate mandate = MandateFixture.aMandateFixture().withState(MandateState.CREATED).toEntity();
+        Mandate mandate = MandateFixture.aMandateFixture().withState(CREATED).toEntity();
         when(mandateQueryService
-                .findAllMandatesBySetOfStatesAndMaxCreationTime(eq(mandateStatesGraph.getPriorStates(MandateState.PENDING)), any()))
+                .findAllMandatesBySetOfStatesAndMaxCreationTime(eq(mandateStatesGraph.getPriorStates(SUBMITTED)), any()))
                 .thenReturn(Collections.singletonList(mandate));
         int numberOfExpiredMandates = expireService.expireMandates();
         assertEquals(1, numberOfExpiredMandates);
@@ -81,10 +82,8 @@ public class ExpireServiceTest {
 
     @Test
     public void shouldGetCorrectMandateStatesPriorToPending() {
-        Set<MandateState> paymentStates = mandateStatesGraph.getPriorStates(MandateState.PENDING);
-        Set<MandateState> expectedPaymentStates = new HashSet<>(Arrays.asList(MandateState.CREATED, 
-                                                                              MandateState.AWAITING_DIRECT_DEBIT_DETAILS,
-                                                                              MandateState.SUBMITTED));
+        var paymentStates = mandateStatesGraph.getPriorStates(SUBMITTED);
+        var expectedPaymentStates = Set.of(CREATED, AWAITING_DIRECT_DEBIT_DETAILS);
         assertEquals(expectedPaymentStates, paymentStates);
     }
 }


### PR DESCRIPTION
This includes CREATED and AWAITING_DIRECT_DEBIT_DETAILS.

## WHAT YOU DID
This should stop the following in prod. I intend to simplify this process next week (I don't have time today).
```
2019-07-19T14:48:36+00:00 ip6-localhost ecs-production-2_directdebit-connector-249-directdebit-connector-d0c4eebe98b6c1d4f801[1362]: uk.gov.pay.directdebit.events.exception.InvalidGovUkPayEventInsertionException: GOV.UK Pay event MANDATE_EXPIRED_BY_SYSTEM is invalid following event MANDATE_SUBMITTED
```