### PR TITLE
PP-5358 Update mandate state after inserting GovUkPayEvent

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdateService.java
@@ -1,17 +1,9 @@
 package uk.gov.pay.directdebit.mandate.services;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.gov.pay.directdebit.events.services.DirectDebitEventService;
 import uk.gov.pay.directdebit.events.services.GovUkPayEventService;
 import uk.gov.pay.directdebit.mandate.dao.MandateDao;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
-import uk.gov.pay.directdebit.mandate.model.MandateState;
-import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
 import uk.gov.pay.directdebit.notifications.services.UserNotificationService;
-import uk.gov.pay.directdebit.payments.exception.InvalidStateTransitionException;
-import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
-import uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent;
 
 import javax.inject.Inject;
 
@@ -21,124 +13,59 @@ import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_CREA
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_EXPIRED_BY_SYSTEM;
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_SUBMITTED;
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_TOKEN_EXCHANGED;
-import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.fromMandate;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.DIRECT_DEBIT_DETAILS_CONFIRMED;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent.TOKEN_EXCHANGED;
 
 
 public class MandateStateUpdateService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MandateService.class);
     private final MandateDao mandateDao;
-    private final DirectDebitEventService directDebitEventService;
     private final UserNotificationService userNotificationService;
     private final GovUkPayEventService govUkPayEventService;
 
     @Inject
     public MandateStateUpdateService(
             MandateDao mandateDao,
-            DirectDebitEventService directDebitEventService,
             UserNotificationService userNotificationService,
             GovUkPayEventService govUkPayEventService) {
-        this.directDebitEventService = directDebitEventService;
         this.mandateDao = mandateDao;
         this.userNotificationService = userNotificationService;
         this.govUkPayEventService = govUkPayEventService;
     }
     
-    void mandateCreatedFor(Mandate mandate) {
-        directDebitEventService.registerMandateCreatedEventFor(mandate);
-        govUkPayEventService.storeEventForMandate(mandate, MANDATE_CREATED);
+    Mandate mandateCreatedFor(Mandate mandate) {
+        return govUkPayEventService.storeEventAndUpdateStateForMandate(mandate, MANDATE_CREATED);
     }
 
     Mandate confirmedDirectDebitDetailsFor(Mandate mandate) {
-        Mandate updatedMandate = confirmedDetailsFor(mandate);
-        userNotificationService.sendMandateCreatedEmailFor(updatedMandate);
-        directDebitEventService.registerDirectDebitConfirmedEventFor(updatedMandate);
-        govUkPayEventService.storeEventForMandate(mandate, MANDATE_SUBMITTED);
-        return updatedMandate;
+        confirmedDetailsFor(mandate);
+        userNotificationService.sendMandateCreatedEmailFor(mandate);
+        return govUkPayEventService.storeEventAndUpdateStateForMandate(mandate, MANDATE_SUBMITTED);
     }
 
-    void changePaymentMethodFor(Mandate mandate) {
-        Mandate newMandate = updateStateFor(mandate, SupportedEvent.PAYMENT_CANCELLED_BY_USER_NOT_ELIGIBLE);
-        directDebitEventService.registerPaymentMethodChangedEventFor(newMandate);
-        govUkPayEventService.storeEventForMandate(mandate, MANDATE_CANCELLED_BY_USER_NOT_ELIGIBLE);
+    Mandate changePaymentMethodFor(Mandate mandate) {
+        return govUkPayEventService.storeEventAndUpdateStateForMandate(mandate, MANDATE_CANCELLED_BY_USER_NOT_ELIGIBLE);
     }
 
-    void cancelMandateCreation(Mandate mandate) {
-        Mandate newMandate = updateStateFor(mandate, SupportedEvent.PAYMENT_CANCELLED_BY_USER);
-        directDebitEventService.registerMandateCancelledEventFor(newMandate);
-        govUkPayEventService.storeEventForMandate(mandate, MANDATE_CANCELLED_BY_USER);
+    Mandate cancelMandateCreation(Mandate mandate) {
+        return govUkPayEventService.storeEventAndUpdateStateForMandate(mandate, MANDATE_CANCELLED_BY_USER);
     }
 
-    public DirectDebitEvent mandateActiveFor(Mandate mandate) {
-        return directDebitEventService.registerMandateActiveEventFor(mandate);
+    public Mandate mandateExpiredFor(Mandate mandate) {
+        return govUkPayEventService.storeEventAndUpdateStateForMandate(mandate, MANDATE_EXPIRED_BY_SYSTEM);
     }
 
-    public void mandateExpiredFor(Mandate mandate) {
-        Mandate updatedMandate = updateStateFor(mandate, SupportedEvent.MANDATE_EXPIRED_BY_SYSTEM);
-        directDebitEventService.registerMandateExpiredEventFor(updatedMandate);
-        govUkPayEventService.storeEventForMandate(mandate, MANDATE_EXPIRED_BY_SYSTEM);
+    Mandate tokenExchangedFor(Mandate mandate) {
+        return govUkPayEventService.storeEventAndUpdateStateForMandate(mandate, MANDATE_TOKEN_EXCHANGED);
     }
 
-    public DirectDebitEvent mandateFailedFor(Mandate mandate) {
-        userNotificationService.sendMandateFailedEmailFor(mandate);
-        return directDebitEventService.registerMandateFailedEventFor(mandate);
-    }
-
-    public DirectDebitEvent mandateCancelledFor(Mandate mandate) {
-        userNotificationService.sendMandateCancelledEmailFor(mandate);
-        return directDebitEventService.registerMandateCancelledEventFor(mandate);
-    }
-
-    public DirectDebitEvent mandatePendingFor(Mandate mandate) {
-        return directDebitEventService.registerMandatePendingEventFor(mandate);
-    }
-
-    public Mandate receiveDirectDebitDetailsFor(Mandate mandate) {
-        directDebitEventService.registerDirectDebitReceivedEventFor(mandate);
-        return mandate;
-    }
-
-    public void payerCreatedFor(Mandate mandate) {
-        directDebitEventService.registerPayerCreatedEventFor(mandate);
-    }
-
-    public void payerEditedFor(Mandate mandate) {
-        directDebitEventService.registerPayerEditedEventFor(mandate);
-    }
-
-    public Mandate tokenExchangedFor(Mandate mandate) {
-        Mandate newMandate = updateStateFor(mandate, TOKEN_EXCHANGED);
-        directDebitEventService.registerTokenExchangedEventFor(newMandate);
-        govUkPayEventService.storeEventForMandate(mandate, MANDATE_TOKEN_EXCHANGED);
-        return newMandate;
-    }
-
-    private Mandate updateStateFor(Mandate mandate, DirectDebitEvent.SupportedEvent event) {
-        MandateState newState = MandateStatesGraph
-                .getStates()
-                .getNextStateForEvent(mandate.getState(), event)
-                .orElseThrow(() -> new InvalidStateTransitionException(event.toString(), mandate.getState().toString()));
-
-                mandateDao.updateState(mandate.getId(), newState);
-        LOGGER.info("Updating mandate {} - from {} to {}",
-                mandate.getExternalId(),
-                mandate.getState(),
-                newState);
-
-        return fromMandate(mandate)
-                .withState(newState)
-                .build();
-    }
-
-    boolean canUpdateStateFor(Mandate mandate, DirectDebitEvent.SupportedEvent event) {
-        return MandateStatesGraph.getStates().getNextStateForEvent(mandate.getState(), event).isPresent();
-    }
-
-    private Mandate confirmedDetailsFor(Mandate mandate) {
-        updateStateFor(mandate, DIRECT_DEBIT_DETAILS_CONFIRMED);
+    private void confirmedDetailsFor(Mandate mandate) {
         mandateDao.updateReferenceAndPaymentProviderId(mandate);
-        return mandate;
+    }
+
+    public void mandateFailedFor(Mandate mandate) {
+        userNotificationService.sendMandateFailedEmailFor(mandate);
+    }
+
+    public void mandateCancelledFor(Mandate mandate) {
+        userNotificationService.sendMandateCancelledEmailFor(mandate);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdater.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdater.java
@@ -29,12 +29,15 @@ public class MandateStateUpdater {
         this.sandboxMandateStateCalculator = sandboxMandateStateCalculator;
     }
 
-    public void updateState(Mandate mandate) {
-        getStateCalculator(mandate)
+    public Mandate updateStateIfNecessary(Mandate mandate) {
+        return getStateCalculator(mandate)
                 .calculate(mandate)
-                .ifPresentOrElse(stateAndDetails -> mandateUpdateService.updateState(mandate, stateAndDetails),
-                        () -> LOGGER.info(format("Asked to update the status for mandate %s but there appear to be " +
-                                "no events stored that require it to be updated", mandate.getExternalId())));
+                .map(stateAndDetails -> mandateUpdateService.updateState(mandate, stateAndDetails))
+                .orElseGet(() -> {
+                    LOGGER.info(format("Asked to update the status for mandate %s but there appear to be " +
+                            "no events stored that require it to be updated", mandate.getExternalId()));
+                    return mandate;
+                });
     }
 
     private MandateStateCalculator getStateCalculator(Mandate mandate) {

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateService.java
@@ -22,14 +22,23 @@ public class MandateUpdateService {
         this.mandateDao = mandateDao;
     }
 
-    public void updateState(Mandate mandate,
-                           DirectDebitStateWithDetails<MandateState> stateAndDetails) {
+    public Mandate updateState(Mandate mandate, DirectDebitStateWithDetails<MandateState> stateAndDetails) {
+        
+        String details = stateAndDetails.getDetails().orElse(null);
+        String description = stateAndDetails.getDetailsDescription().orElse(null);
+        
         mandateDao.updateStateAndDetails(mandate.getId(),
                 stateAndDetails.getState(),
-                stateAndDetails.getDetails().orElse(null),
-                stateAndDetails.getDetailsDescription().orElse(null));
+                details,
+                description);
 
         LOGGER.info(format("Updated status of mandate %s to %s", mandate.getExternalId(), stateAndDetails.getState()));
-    }
 
+        return Mandate.MandateBuilder.fromMandate(mandate)
+                .withState(stateAndDetails.getState())
+                .withStateDetails(details)
+                .withStateDetailsDescription(description)
+                .build();
+    }
+    
 }

--- a/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/services/PayerService.java
@@ -6,7 +6,6 @@ import uk.gov.pay.directdebit.mandate.exception.PayerNotFoundException;
 import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
-import uk.gov.pay.directdebit.mandate.services.MandateStateUpdateService;
 import uk.gov.pay.directdebit.payers.api.PayerParser;
 import uk.gov.pay.directdebit.payers.dao.PayerDao;
 import uk.gov.pay.directdebit.payers.model.Payer;
@@ -20,16 +19,14 @@ public class PayerService {
     private final PayerDao payerDao;
     private final MandateQueryService mandateQueryService;
     private final PayerParser payerParser;
-    private final MandateStateUpdateService mandateStateUpdateService;
 
     @Inject
     public PayerService(PayerDao payerDao,
                         MandateQueryService mandateQueryService,
-                        PayerParser payerParser, MandateStateUpdateService mandateStateUpdateService) {
+                        PayerParser payerParser) {
         this.payerDao = payerDao;
         this.mandateQueryService = mandateQueryService;
         this.payerParser = payerParser;
-        this.mandateStateUpdateService = mandateStateUpdateService;
     }
     
     public Payer getPayerFor(Mandate mandate) {
@@ -39,27 +36,24 @@ public class PayerService {
     }
     public Payer createOrUpdatePayer(MandateExternalId mandateExternalId, Map<String, String> createPayerRequest) {
         Mandate mandate = mandateQueryService.findByExternalId(mandateExternalId);
-        mandateStateUpdateService.receiveDirectDebitDetailsFor(mandate);
         Payer payerDetails = payerParser.parse(createPayerRequest, mandate.getId());
 
         return payerDao
                 .findByMandateId(mandate.getId())
-                .map(oldPayer -> editPayer(mandate, oldPayer, payerDetails))
-                .orElseGet(() -> create(mandate, payerDetails));
+                .map(oldPayer -> editPayer(oldPayer, payerDetails))
+                .orElseGet(() -> create(payerDetails));
     }
     
-    private Payer editPayer(Mandate mandate, Payer oldPayer, Payer newPayer) {
+    private Payer editPayer(Payer oldPayer, Payer newPayer) {
         LOGGER.info("Updating payer with external id {}", oldPayer.getExternalId());
         payerDao.updatePayerDetails(oldPayer.getId(), newPayer);
-        mandateStateUpdateService.payerEditedFor(mandate);
         return newPayer;
     }
 
-    public Payer create(Mandate mandate, Payer payer) {
+    public Payer create(Payer payer) {
         Long id = payerDao.insert(payer);
         payer.setId(id);
         LOGGER.info("Created Payer with external id {}", payer.getExternalId());
-        mandateStateUpdateService.payerCreatedFor(mandate);
         return payer;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
@@ -76,7 +76,7 @@ public class WebhookGoCardlessService {
                 .distinct()
                 .map(this::getMandate)
                 .flatMap(Optional::stream)
-                .forEach(mandateStateUpdater::updateState);
+                .forEach(mandateStateUpdater::updateStateIfNecessary);
     }
 
     private Optional<Pair<GoCardlessMandateId, GoCardlessOrganisationId>> toGoCardlessMandateIdAndOrganisationId(GoCardlessEvent goCardlessEvent) {

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateServiceTest.java
@@ -221,7 +221,6 @@ public class MandateServiceTest {
                 SandboxMandateId.valueOf(mandate.getExternalId().toString()),
                 MandateBankStatementReference.valueOf(RandomStringUtils.randomAlphanumeric(5)));
 
-        when(mandateStateUpdateService.canUpdateStateFor(mandate, DIRECT_DEBIT_DETAILS_CONFIRMED)).thenReturn(true);
         when(paymentProviderFactory.getCommandServiceFor(SANDBOX)).thenReturn(sandboxService);
         when(sandboxService.confirmMandate(mandate, bankAccountDetails)).thenReturn(confirmMandateResponse);
 
@@ -234,29 +233,6 @@ public class MandateServiceTest {
                 .build();
 
         verify(mandateStateUpdateService).confirmedDirectDebitDetailsFor(expectedMandateWithStateDetailsConfirmed);
-    }
-
-    @Test
-    public void confirm_shouldNotConfirmOnDemandMandateForInvalidState() {
-        GatewayAccount gatewayAccount = aGatewayAccountFixture().withPaymentProvider(SANDBOX).toEntity();
-        Mandate mandate = aMandate()
-                .withGatewayAccount(gatewayAccount)
-                .withExternalId(MandateExternalId.valueOf(RandomIdGenerator.newId()))
-                .withMandateBankStatementReference(MandateBankStatementReference.valueOf("mandateReference"))
-                .withServiceReference("reference")
-                .withState(MandateState.CANCELLED)
-                .withReturnUrl("http://returnUrl")
-                .withCreatedDate(ZonedDateTime.now(ZoneOffset.UTC))
-                .build();
-
-        Map<String, String> confirmMandateRequest = Map.of("sort_code", "123456", "account_number", "12345678");
-        ConfirmMandateRequest mandateConfirmationRequest = ConfirmMandateRequest.of(confirmMandateRequest);
-
-        when(mandateStateUpdateService.canUpdateStateFor(mandate, DIRECT_DEBIT_DETAILS_CONFIRMED)).thenReturn(false);
-        thrown.expect(InvalidStateTransitionException.class);
-        thrown.expectMessage("Transition DIRECT_DEBIT_DETAILS_CONFIRMED from state CANCELLED is not valid");
-
-        service.confirm(gatewayAccount, mandate, mandateConfirmationRequest);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateStateUpdaterTest.java
@@ -48,7 +48,7 @@ public class MandateStateUpdaterTest {
         given(mockGoCardlessMandateStateCalculator.calculate(mandate))
                 .willReturn(Optional.of(mockMandateStateWithDetails));
 
-        mockMandateStateUpdater.updateState(mandate);
+        mockMandateStateUpdater.updateStateIfNecessary(mandate);
 
         verify(mockMandateUpdateService).updateState(mandate, mockMandateStateWithDetails);
     }
@@ -61,7 +61,7 @@ public class MandateStateUpdaterTest {
         given(mockSandboxStateCalculator.calculate(mandate))
                 .willReturn(Optional.of(mockMandateStateWithDetails));
 
-        mockMandateStateUpdater.updateState(mandate);
+        mockMandateStateUpdater.updateStateIfNecessary(mandate);
         
         verify(mockMandateUpdateService).updateState(mandate, mockMandateStateWithDetails);
     }
@@ -73,7 +73,7 @@ public class MandateStateUpdaterTest {
 
         given(mockGoCardlessMandateStateCalculator.calculate(mandate)).willReturn(Optional.empty());
 
-        mockMandateStateUpdater.updateState(mandate);
+        mockMandateStateUpdater.updateStateIfNecessary(mandate);
 
         verify(mockMandateUpdateService, never()).updateState(any(), any());
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/MandateUpdateServiceTest.java
@@ -1,0 +1,62 @@
+package uk.gov.pay.directdebit.mandate.services;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
+import uk.gov.pay.directdebit.mandate.dao.MandateDao;
+import uk.gov.pay.directdebit.mandate.model.Mandate;
+import uk.gov.pay.directdebit.mandate.model.MandateState;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MandateUpdateServiceTest {
+    
+    @Mock
+    MandateDao mockMandateDao;
+    
+    @InjectMocks
+    MandateUpdateService mandateUpdateService;
+    
+    private Mandate mandate = aMandateFixture().toEntity();
+    
+    @Test
+    public void callsToUpdateStateAndReturnsUpdatedMandate_whenDetailsAndDescriptionAreEmpty() {
+        MandateState state = MandateState.PENDING;
+        DirectDebitStateWithDetails<MandateState> stateWithDetails = new DirectDebitStateWithDetails<>(state);
+
+        Mandate updatedMandate = mandateUpdateService.updateState(mandate, stateWithDetails);
+
+        verify(mockMandateDao).updateStateAndDetails(mandate.getId(), state, null, null);
+        
+        assertThat(updatedMandate.getExternalId(), is(mandate.getExternalId()));
+        assertThat(updatedMandate.getState(), is(state));
+        assertThat(updatedMandate.getStateDetails(), is(Optional.empty()));
+        assertThat(updatedMandate.getStateDetailsDescription(), is(Optional.empty()));
+    }
+
+    @Test
+    public void callsToUpdateStateAndReturnsUpdatedMandate_withDetailsAndDescription() {
+        MandateState state = MandateState.PENDING;
+        String details = "a-details";
+        String description = "a-description";
+        DirectDebitStateWithDetails<MandateState> stateWithDetails = new DirectDebitStateWithDetails<>(state, details, description);
+
+        Mandate updatedMandate = mandateUpdateService.updateState(mandate, stateWithDetails);
+
+        verify(mockMandateDao).updateStateAndDetails(mandate.getId(), state, details, description);
+
+        assertThat(updatedMandate.getExternalId(), is(mandate.getExternalId()));
+        assertThat(updatedMandate.getState(), is(state));
+        assertThat(updatedMandate.getStateDetails(), is(Optional.of(details)));
+        assertThat(updatedMandate.getStateDetailsDescription(), is(Optional.of(description)));
+    }
+}

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/GoCardlessMandateHandlerTest.java
@@ -6,12 +6,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.events.exception.GoCardlessEventHasNoMandateIdException;
-import uk.gov.pay.directdebit.events.services.DirectDebitEventService;
+import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.events.services.GoCardlessEventService;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
@@ -23,38 +22,33 @@ import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentFixture;
 import uk.gov.pay.directdebit.payments.model.DirectDebitEvent;
-import uk.gov.pay.directdebit.payments.model.DirectDebitEvent.SupportedEvent;
-import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.payments.services.PaymentService;
 import uk.gov.pay.directdebit.webhook.gocardless.services.handlers.GoCardlessMandateHandler;
 
 import java.util.Optional;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.directdebit.payments.model.DirectDebitEvent.Type.MANDATE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GoCardlessMandateHandlerTest {
 
     @Mock
-    private PaymentService paymentService;
+    private PaymentService mockPaymentService;
+    
     @Mock
-    private MandateQueryService mandateQueryService;
+    private MandateQueryService mockMandateQueryService;
+    
     @Mock
-    private MandateStateUpdateService mandateStateUpdateService;
-    @Mock
-    private DirectDebitEventService directDebitEventService;
-    @Mock
-    private GoCardlessEventService goCardlessService;
+    private MandateStateUpdateService mockMandateStateUpdateService;
 
-    @Captor
-    private ArgumentCaptor<GoCardlessEvent> geCaptor;
+    @Mock
+    private GoCardlessEventService mockGoCardlessService;
+    
+    @InjectMocks
+    private GoCardlessMandateHandler goCardlessMandateHandler;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -70,223 +64,69 @@ public class GoCardlessMandateHandlerTest {
             .withPayerFixture(payerFixture);
     private PaymentFixture paymentFixture = PaymentFixture.aPaymentFixture()
             .withMandateFixture(mandateFixture);
-    private GoCardlessMandateHandler goCardlessMandateHandler;
     private GoCardlessEventFixture goCardlessEventFixture = GoCardlessEventFixture.aGoCardlessEventFixture()
             .withLinksOrganisation(organisationIdentifier);
 
     @Before
     public void setUp() {
-        goCardlessMandateHandler = new GoCardlessMandateHandler(paymentService, goCardlessService, directDebitEventService,
-                mandateStateUpdateService, mandateQueryService);
-        when(paymentService.findPaymentsForMandate(mandateFixture.getExternalId())).thenReturn(ImmutableList
+        when(mockPaymentService.findPaymentsForMandate(mandateFixture.getExternalId())).thenReturn(ImmutableList
                 .of(paymentFixture.toEntity()));
-    }
-
-    @Test
-    public void handle_onCreateMandateGoCardlessEvent_shouldRegisterEventAsMandatePending_whenDoesNotPreviouslyExist() {
-        GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("created").toEntity());
-
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
-                goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
-                .thenReturn(mandateFixture.toEntity());
-        when(mandateStateUpdateService.mandatePendingFor(mandateFixture.toEntity())).thenReturn(
-                directDebitEvent);
-
-        goCardlessMandateHandler.handle(goCardlessEvent);
-        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
-        verify(goCardlessService).updateInternalEventId(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
-        assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
-    }
-
-    @Test
-    public void handle_onCreateMandateGoCardlessEvent_shouldNotRegisterAnEventAsMandatePending_whenAPreviousMandatePendingEventExists() {
-        GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("created").toEntity());
-
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
-                goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
-                .thenReturn(mandateFixture.toEntity());
-        when(directDebitEventService.findBy(mandateFixture.getId(), MANDATE, SupportedEvent.MANDATE_PENDING)).thenReturn(Optional
-                .of(
-                        directDebitEvent));
-        goCardlessMandateHandler.handle(goCardlessEvent);
-
-        verify(mandateStateUpdateService, never()).mandatePendingFor(mandateFixture.toEntity());
-        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
-        verify(goCardlessService).updateInternalEventId(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
-        assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
-    }
-
-    @Test
-    public void handle_onActiveMandateGoCardlessEvent_shouldSetAPayEventAsMandateActive_whenDoesNotPreviouslyExist() {
-        GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("active").toEntity());
-
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
-                goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
-                .thenReturn(mandateFixture.toEntity());
-        when(mandateStateUpdateService.mandateActiveFor(mandateFixture.toEntity())).thenReturn(
-                directDebitEvent);
-        goCardlessMandateHandler.handle(goCardlessEvent);
-
-        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
-        verify(goCardlessService).updateInternalEventId(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
-        assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
-    }
-
-    @Test
-    public void handle_onActiveMandateGoCardlessEvent_shouldNotRegisterAnEventAsMandatePending_whenAPreviousMandatePendingEventExists() {
-        GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("active").toEntity());
-
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
-                goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
-                .thenReturn(mandateFixture.toEntity());
-
-        when(mandateStateUpdateService.mandateActiveFor(mandateFixture.toEntity())).thenReturn(
-                directDebitEvent);
-
-        goCardlessMandateHandler.handle(goCardlessEvent);
-
-        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
-        verify(mandateStateUpdateService, never()).mandatePendingFor(mandateFixture.toEntity());
-        verify(goCardlessService).updateInternalEventId(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
-        assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
-    }
-
-    @Test
-    public void handle_onSubmittedMandateGoCardlessEvent_shouldSetAPayEventAsMandatePending_whenDoesNotPreviouslyExist() {
-        GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("submitted").toEntity());
-
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
-                goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
-                .thenReturn(mandateFixture.toEntity());
-        when(mandateStateUpdateService.mandatePendingFor(mandateFixture.toEntity())).thenReturn(
-                directDebitEvent);
-
-        goCardlessMandateHandler.handle(goCardlessEvent);
-
-        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
-        verify(goCardlessService).updateInternalEventId(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
-        assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
-    }
-
-    @Test
-    public void handle_onSubmittedMandateGoCardlessEvent_shouldNotRegisterAnEventAsMandatePending_whenAPreviousMandatePendingEventExists() {
-        GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("submitted").toEntity());
-
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
-                goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
-                .thenReturn(mandateFixture.toEntity());
-        when(directDebitEventService.findBy(mandateFixture.getId(), MANDATE, SupportedEvent.MANDATE_PENDING)).thenReturn(Optional.of(
-                directDebitEvent));
-        goCardlessMandateHandler.handle(goCardlessEvent);
-
-        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
-        verify(mandateStateUpdateService, never()).mandatePendingFor(mandateFixture.toEntity());
-        verify(goCardlessService).updateInternalEventId(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
-        assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
     }
 
     @Test
     public void handle_onAFailedMandateGoCardlessEvent_shouldRegisterAPayEventAsMandateFailed() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("failed").toEntity());
 
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
+        when(mockMandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
                 goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
                 .thenReturn(mandateFixture.toEntity());
-        when(mandateStateUpdateService.mandateFailedFor(mandateFixture.toEntity())).thenReturn(
-                directDebitEvent);
-        when(paymentService.paymentFailedWithoutEmailFor(paymentFixture.toEntity())).thenReturn(
+        when(mockPaymentService.paymentFailedWithoutEmailFor(paymentFixture.toEntity())).thenReturn(
                 directDebitEvent);
 
         goCardlessMandateHandler.handle(goCardlessEvent);
 
-        verify(paymentService).paymentFailedWithoutEmailFor(paymentFixture.toEntity());
-        verify(mandateStateUpdateService).mandateFailedFor(mandateFixture.toEntity());
-        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
-        verify(goCardlessService).updateInternalEventId(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
-        assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
+        verify(mockPaymentService).paymentFailedWithoutEmailFor(paymentFixture.toEntity());
+        verify(mockMandateStateUpdateService).mandateFailedFor(mandateFixture.toEntity());
     }
 
     @Test
     public void handle_onACancelledMandateGoCardlessEvent_shouldRegisterAPayEventAsMandateCancelled_AndFailPaymentIfNotSubmittedToGC() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("cancelled").toEntity());
 
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
+        when(mockMandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
                 goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
                 .thenReturn(mandateFixture.toEntity());
-        when(paymentService.findPaymentSubmittedEventFor(paymentFixture.toEntity())).thenReturn(Optional.empty());
-        when(mandateStateUpdateService.mandateCancelledFor(mandateFixture.toEntity())).thenReturn(
-                directDebitEvent);
-        when(paymentService.paymentFailedWithoutEmailFor(paymentFixture.toEntity())).thenReturn(
+        when(mockPaymentService.findPaymentSubmittedEventFor(paymentFixture.toEntity())).thenReturn(Optional.empty());
+        when(mockPaymentService.paymentFailedWithoutEmailFor(paymentFixture.toEntity())).thenReturn(
                 directDebitEvent);
 
         goCardlessMandateHandler.handle(goCardlessEvent);
 
-        verify(paymentService).paymentFailedWithoutEmailFor(paymentFixture.toEntity());
-        verify(mandateStateUpdateService).mandateCancelledFor(mandateFixture.toEntity());
-        verify(goCardlessEvent).setInternalEventId(directDebitEvent.getId());
-        verify(goCardlessService).updateInternalEventId(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
-        assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
+        verify(mockPaymentService).paymentFailedWithoutEmailFor(paymentFixture.toEntity());
+        verify(mockMandateStateUpdateService).mandateCancelledFor(mandateFixture.toEntity());
     }
 
     @Test
     public void handle_onACancelledMandateGoCardlessEvent_shouldRegisterAPayEventAsMandateCancelled_withoutFailingPaymentIfSubmittedToGC() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture.withAction("cancelled").toEntity());
 
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
+        when(mockMandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
                 goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
                 .thenReturn(mandateFixture.toEntity());
-        when(paymentService.findPaymentSubmittedEventFor(paymentFixture.toEntity())).thenReturn(Optional.of(
+        when(mockPaymentService.findPaymentSubmittedEventFor(paymentFixture.toEntity())).thenReturn(Optional.of(
                 directDebitEvent));
-        when(mandateStateUpdateService.mandateCancelledFor(mandateFixture.toEntity())).thenReturn(
-                directDebitEvent);
 
         goCardlessMandateHandler.handle(goCardlessEvent);
 
-        verify(paymentService, never()).paymentFailedWithoutEmailFor(paymentFixture.toEntity());
-        verify(mandateStateUpdateService).mandateCancelledFor(mandateFixture.toEntity());
-        verify(goCardlessService).updateInternalEventId(geCaptor.capture());
-        GoCardlessEvent storedGoCardlessEvent = geCaptor.getValue();
-        assertThat(storedGoCardlessEvent.getInternalEventId(), is(directDebitEvent.getId()));
-        assertThat(storedGoCardlessEvent.getGoCardlessEventId(), is(goCardlessEvent.getGoCardlessEventId()));
-    }
-
-    @Test
-    public void handle_onCreateMandateGoCardlessEvent_shouldNotRegisterEventAsMandatePending_whenOrganisationDoesNotExist() {
-        GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture
-                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("does_not_exist"))
-                .withAction("created")
-                .toEntity());
-
-        when(mandateQueryService.findByGoCardlessMandateIdAndOrganisationId(
-                goCardlessEvent.getLinksMandate().get(), goCardlessEventFixture.getLinksOrganisation()))
-                .thenReturn(mandateFixture.toEntity());
-
-        goCardlessMandateHandler.handle(goCardlessEvent);
-        verify(goCardlessEvent, never()).setInternalEventId(anyLong());
-        verify(goCardlessService, never()).storeEvent(goCardlessEvent);
+        verify(mockPaymentService, never()).paymentFailedWithoutEmailFor(paymentFixture.toEntity());
+        verify(mockMandateStateUpdateService).mandateCancelledFor(mandateFixture.toEntity());
     }
 
     @Test
     public void handle_onCreateMandateGoCardlessEvent_shouldThrowExceptionWhenEventHasNoLinkedMandate() {
         GoCardlessEvent goCardlessEvent = spy(goCardlessEventFixture
                 .withLinksOrganisation(GoCardlessOrganisationId.valueOf("does_not_exist"))
-                .withAction("created")
+                .withAction("cancelled")
                 .withLinksMandate(null)
                 .toEntity());
 

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
@@ -223,9 +223,9 @@ public class WebhookGoCardlessServiceTest {
                 goCardlessOrganisation1Payment2Event,
                 goCardlessOrganisation2Mandate1Event));
 
-        verify(mockedMandateStateUpdater).updateState(mandate1);
-        verify(mockedMandateStateUpdater).updateState(mandate2);
-        verify(mockedMandateStateUpdater).updateState(mandate3);
+        verify(mockedMandateStateUpdater).updateStateIfNecessary(mandate1);
+        verify(mockedMandateStateUpdater).updateStateIfNecessary(mandate2);
+        verify(mockedMandateStateUpdater).updateStateIfNecessary(mandate3);
         verify(mockedGoCardlessPaymentStateUpdater).updateState(new GoCardlessPaymentIdAndOrganisationId(goCardlessPaymentId1, goCardlessOrganisationId1));
         verify(mockedGoCardlessPaymentStateUpdater).updateState(new GoCardlessPaymentIdAndOrganisationId(goCardlessPaymentId2, goCardlessOrganisationId1));
     }
@@ -267,7 +267,7 @@ public class WebhookGoCardlessServiceTest {
                 cursedMandateEventNotLinkedToMandate,
                 cursedPaymentEventNotLinkedToPayment));
 
-        verify(mockedMandateStateUpdater).updateState(mandate);
+        verify(mockedMandateStateUpdater).updateStateIfNecessary(mandate);
         verify(mockedGoCardlessPaymentStateUpdater).updateState(new GoCardlessPaymentIdAndOrganisationId(GoCardlessPaymentId.valueOf("PM123"),
                 GoCardlessOrganisationId.valueOf("OR123")));
     }


### PR DESCRIPTION
Calculate and update the state of mandate if necessary after inserting a GovUkPayEvent.

No longer store DirectDebitEvents for mandate or use them to update the state.