### PR TITLE
PP-5433 Include GovUkPayEvents in GoCardless payment state calculation

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/dao/GovUkPayEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/GovUkPayEventDao.java
@@ -60,4 +60,18 @@ public interface GovUkPayEventDao {
             "ORDER BY event_date DESC " +
             "LIMIT 1")
     Optional<GovUkPayEvent> findLatestEventForPayment(@Bind("paymentId") Long paymentId);
+
+    @SqlQuery("SELECT id, " +
+            "mandate_id, " +
+            "payment_id, " +
+            "event_date, " +
+            "resource_type, " +
+            "event_type " +
+            "FROM govukpay_events " +
+            "WHERE payment_id = :paymentId " +
+            "AND event_type IN (<applicableEventTypes>) " +
+            "ORDER BY event_date DESC " +
+            "LIMIT 1")
+    Optional<GovUkPayEvent> findLatestApplicableEventForPayment(@Bind("paymentId") Long paymentId,
+                                                                @BindList("applicableEventTypes") Set<GovUkPayEventType> applicableEventTypes);
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculator.java
@@ -2,7 +2,11 @@ package uk.gov.pay.directdebit.payments.services.gocardless;
 
 import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
 import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.events.dao.GovUkPayEventDao;
+import uk.gov.pay.directdebit.events.model.Event;
 import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.events.model.GovUkPayEvent;
+import uk.gov.pay.directdebit.events.model.GovUkPayEventType;
 import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountMissingOrganisationIdException;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentId;
@@ -11,16 +15,21 @@ import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.services.PaymentStateCalculator;
 
 import javax.inject.Inject;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import static java.lang.String.format;
+import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.PAYMENT_SUBMITTED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.FAILED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.SUCCESS;
 
 public class GoCardlessPaymentStateCalculator implements PaymentStateCalculator {
 
     private final GoCardlessEventDao goCardlessEventDao;
+    private final GovUkPayEventDao govUkPayEventDao;
 
     private static final Map<String, PaymentState> GOCARDLESS_ACTION_TO_PAYMENT_STATE = Map.of(
             "failed", FAILED,
@@ -28,20 +37,30 @@ public class GoCardlessPaymentStateCalculator implements PaymentStateCalculator 
     );
 
     static final Set<String> GOCARDLESS_ACTIONS_THAT_CHANGE_STATE = GOCARDLESS_ACTION_TO_PAYMENT_STATE.keySet();
+    
+    private static final Map<GovUkPayEventType, PaymentState> GOV_UK_PAY_EVENT_TYPE_TO_PAYMENT_STATE = Map.of(
+            PAYMENT_SUBMITTED, PaymentState.PENDING
+    );
+    
+    static final Set<GovUkPayEventType> GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE = GOV_UK_PAY_EVENT_TYPE_TO_PAYMENT_STATE.keySet();
 
     @Inject
-    GoCardlessPaymentStateCalculator(GoCardlessEventDao goCardlessEventDao) {
+    GoCardlessPaymentStateCalculator(GoCardlessEventDao goCardlessEventDao,
+                                     GovUkPayEventDao govUkPayEventDao) {
         this.goCardlessEventDao = goCardlessEventDao;
+        this.govUkPayEventDao = govUkPayEventDao;
     }
 
     public Optional<DirectDebitStateWithDetails<PaymentState>> calculate(Payment payment) {
-        return getLatestApplicableGoCardlessEvent(payment)
-                .filter(goCardlessEvent -> GOCARDLESS_ACTION_TO_PAYMENT_STATE.get(goCardlessEvent.getAction()) != null)
-                .map(goCardlessEvent -> new DirectDebitStateWithDetails<>(
-                        GOCARDLESS_ACTION_TO_PAYMENT_STATE.get(goCardlessEvent.getAction()),
-                        goCardlessEvent.getDetailsCause(),
-                        goCardlessEvent.getDetailsDescription())
-                );
+        Optional<GoCardlessEvent> latestApplicableGoCardlessEvent = getLatestApplicableGoCardlessEvent(payment);
+
+        Optional<GovUkPayEvent> latestApplicableGovUkPayEvent 
+                = govUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE);
+        
+        return Stream.of(latestApplicableGoCardlessEvent,latestApplicableGovUkPayEvent)
+                .flatMap(Optional::stream)
+                .max(Comparator.comparing(Event::getTimestamp))
+                .map(this::mapEventToState);
     }
 
     private Optional<GoCardlessEvent> getLatestApplicableGoCardlessEvent(Payment payment) {
@@ -55,5 +74,27 @@ public class GoCardlessPaymentStateCalculator implements PaymentStateCalculator 
                             goCardlessOrganisationId,
                             GOCARDLESS_ACTIONS_THAT_CHANGE_STATE);
                 });
+    }
+
+    private DirectDebitStateWithDetails<PaymentState> mapEventToState(Event event) {
+        if (event instanceof GoCardlessEvent) {
+            return mapGoCardlessEventToState((GoCardlessEvent) event);
+        } else if (event instanceof GovUkPayEvent) {
+            return mapGovUkPayEventToState((GovUkPayEvent) event);
+        } else {
+            throw new IllegalArgumentException(format("Unexpected Event of type %s", event.getClass()));
+        }
+    }
+
+    private DirectDebitStateWithDetails<PaymentState> mapGoCardlessEventToState(GoCardlessEvent goCardlessEvent) {
+        return new DirectDebitStateWithDetails<>(
+                GOCARDLESS_ACTION_TO_PAYMENT_STATE.get(goCardlessEvent.getAction()),
+                goCardlessEvent.getDetailsCause(),
+                goCardlessEvent.getDetailsDescription());
+    }
+    
+    private DirectDebitStateWithDetails<PaymentState> mapGovUkPayEventToState(GovUkPayEvent govUkPayEvent) {
+        return new DirectDebitStateWithDetails<>(
+                GOV_UK_PAY_EVENT_TYPE_TO_PAYMENT_STATE.get(govUkPayEvent.getEventType()));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculatorTest.java
@@ -5,6 +5,7 @@ import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -12,7 +13,11 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
 import uk.gov.pay.directdebit.events.dao.GoCardlessEventDao;
+import uk.gov.pay.directdebit.events.dao.GovUkPayEventDao;
 import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.events.model.GovUkPayEvent;
+import uk.gov.pay.directdebit.events.model.GovUkPayEventType;
+import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountMissingOrganisationIdException;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
@@ -21,16 +26,22 @@ import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentId;
 import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.PAYMENT_SUBMITTED;
+import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture.aGoCardlessEventFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.GovUkPayEventFixture.aGovUkPayEventFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
 import static uk.gov.pay.directdebit.payments.services.gocardless.GoCardlessPaymentStateCalculator.GOCARDLESS_ACTIONS_THAT_CHANGE_STATE;
+import static uk.gov.pay.directdebit.payments.services.gocardless.GoCardlessPaymentStateCalculator.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE;
 
 @RunWith(JUnitParamsRunner.class)
 public class GoCardlessPaymentStateCalculatorTest {
@@ -41,8 +52,14 @@ public class GoCardlessPaymentStateCalculatorTest {
     @Mock
     private GoCardlessEventDao mockGoCardlessEventDao;
 
+    @Mock
+    private GovUkPayEventDao mockGovUkPayEventDao;
+
     @InjectMocks
     private GoCardlessPaymentStateCalculator goCardlessPaymentStateCalculator;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     private GoCardlessOrganisationId goCardlessOrganisationId = GoCardlessOrganisationId.valueOf("an-organisation-id");
 
@@ -81,6 +98,21 @@ public class GoCardlessPaymentStateCalculatorTest {
     }
 
     @Test
+    @Parameters({
+            "PAYMENT_SUBMITTED, PENDING"
+    })
+    public void govUkPayEventTypeMapsToState(String eventType, String expectedState) {
+        GovUkPayEventType govUkPayEventType = GovUkPayEventType.valueOf(eventType);
+        GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture().withEventType(govUkPayEventType).toEntity();
+        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+                .willReturn(Optional.of(govUkPayEvent));
+
+        Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);
+
+        assertThat(result.get().getState(), is(PaymentState.valueOf(expectedState)));
+    }
+
+    @Test
     public void detailsCauseAndDescriptionReturned() {
         GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture().withAction("failed")
                 .withDetailsCause("details_cause")
@@ -98,16 +130,47 @@ public class GoCardlessPaymentStateCalculatorTest {
     }
 
     @Test
-    public void unrecognisedActionMapsToNothing() {
-        GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture().withAction("eaten_by_wolves").toEntity();
-        
+    public void resolvesStateFromGovUkPayEventWhenIsLaterThanLatestGoCardlessEvent() {
+        GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture()
+                .withAction("failed")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 22, 9, 0, 0, 0, UTC))
+                .toEntity();
         given(mockGoCardlessEventDao.findLatestApplicableEventForPayment(goCardlessPaymentId, goCardlessOrganisationId,
                 GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
                 .willReturn(Optional.of(goCardlessEvent));
 
+        GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture()
+                .withEventType(PAYMENT_SUBMITTED)
+                .withEventDate(ZonedDateTime.of(2019, 7, 22, 10, 0, 0, 0, UTC))
+                .toEntity();
+        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+                .willReturn(Optional.of(govUkPayEvent));
+
         Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);
 
-        assertThat(result, is(Optional.empty()));
+        assertThat(result.get().getState(), is(PaymentState.PENDING));
+    }
+
+    @Test
+    public void resolvesStateFromGoCardlessEventWhenIsLaterThanLatestGovUkPayEvent() {
+        GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture()
+                .withAction("failed")
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 22, 10, 0, 0, 0, UTC))
+                .toEntity();
+        given(mockGoCardlessEventDao.findLatestApplicableEventForPayment(goCardlessPaymentId, goCardlessOrganisationId,
+                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                .willReturn(Optional.of(goCardlessEvent));
+
+        GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture()
+                .withEventType(PAYMENT_SUBMITTED)
+                .withEventDate(ZonedDateTime.of(2019, 7, 22, 9, 0, 0, 0, UTC))
+                .toEntity();
+        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+                .willReturn(Optional.of(govUkPayEvent));
+
+        Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);
+
+        assertThat(result.get().getState(), is(PaymentState.FAILED));
     }
 
     @Test
@@ -119,6 +182,26 @@ public class GoCardlessPaymentStateCalculatorTest {
         Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);
 
         assertThat(result, is(Optional.empty()));
+    }
+
+
+    @Test
+    public void gatewayAccountMissingOrganisationIdThrowsException() {
+        GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
+                .withPaymentProvider(GOCARDLESS)
+                .withOrganisation(null);
+
+        var mandateFixture = aMandateFixture()
+                .withGatewayAccountFixture(gatewayAccountFixture);
+
+        Payment payment = aPaymentFixture()
+                .withMandateFixture(mandateFixture)
+                .withPaymentProviderId(goCardlessPaymentId)
+                .toEntity();
+
+        thrown.expect(GatewayAccountMissingOrganisationIdException.class);
+
+        goCardlessPaymentStateCalculator.calculate(payment);
     }
 
 }


### PR DESCRIPTION
When calculating the state of a GoCardless payment, find the most recent GoCardlessEvent and GovUkPayEvent then use whichever has a later timestamp to calculate the state.