### PR TITLE
PP-5433 Include GovUkPayEvents in Sandbox payment state calculation

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/GovUkPayEventToMandateStateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/GovUkPayEventToMandateStateMapper.java
@@ -16,11 +16,11 @@ import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_EXPI
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_SUBMITTED;
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_TOKEN_EXCHANGED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.AWAITING_DIRECT_DEBIT_DETAILS;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.USER_SETUP_CANCELLED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.USER_SETUP_EXPIRED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED_TO_PROVIDER;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.USER_CANCEL_NOT_ELIGIBLE;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.USER_SETUP_CANCELLED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.USER_SETUP_EXPIRED;
 
 public class GovUkPayEventToMandateStateMapper {
     private static final Map<GovUkPayEventType, MandateState> GOV_UK_PAY_EVENT_TYPE_TO_MANDATE_STATE = Map.of(
@@ -32,9 +32,9 @@ public class GovUkPayEventToMandateStateMapper {
             MANDATE_CANCELLED_BY_USER_NOT_ELIGIBLE, USER_CANCEL_NOT_ELIGIBLE
     );
 
-    public static final Set<GovUkPayEventType> GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE = GOV_UK_PAY_EVENT_TYPE_TO_MANDATE_STATE.keySet();
+    public static final Set<GovUkPayEventType> GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE = GOV_UK_PAY_EVENT_TYPE_TO_MANDATE_STATE.keySet();
 
-    public static Optional<DirectDebitStateWithDetails<MandateState>> mapGovUkPayEventToState(GovUkPayEvent govUkPayEvent) {
+    public static Optional<DirectDebitStateWithDetails<MandateState>> mapGovUkPayEventToMandateState(GovUkPayEvent govUkPayEvent) {
         return Optional.ofNullable(GOV_UK_PAY_EVENT_TYPE_TO_MANDATE_STATE.get(govUkPayEvent.getEventType()))
                 .map(DirectDebitStateWithDetails::new);
     }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessEventToMandateStateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessEventToMandateStateMapper.java
@@ -9,10 +9,10 @@ import java.util.Optional;
 import java.util.Set;
 
 import static uk.gov.pay.directdebit.mandate.model.MandateState.ACTIVE;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.USER_SETUP_CANCELLED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.FAILED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED_TO_PROVIDER;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.USER_SETUP_CANCELLED;
 
 class GoCardlessEventToMandateStateMapper {
     private static final Map<String, MandateState> GOCARDLESS_ACTION_TO_MANDATE_STATE = Map.of(
@@ -23,9 +23,9 @@ class GoCardlessEventToMandateStateMapper {
             "failed", FAILED
     );
 
-    static final Set<String> GOCARDLESS_ACTIONS_THAT_CHANGE_STATE = GOCARDLESS_ACTION_TO_MANDATE_STATE.keySet();
-    
-    static Optional<DirectDebitStateWithDetails<MandateState>> mapGoCardlessEventToState(GoCardlessEvent goCardlessEvent) {
+    static final Set<String> GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE = GOCARDLESS_ACTION_TO_MANDATE_STATE.keySet();
+
+    static Optional<DirectDebitStateWithDetails<MandateState>> mapGoCardlessEventToMandateState(GoCardlessEvent goCardlessEvent) {
         return Optional.ofNullable(GOCARDLESS_ACTION_TO_MANDATE_STATE.get(goCardlessEvent.getAction()))
                 .map(mandateState -> new DirectDebitStateWithDetails<>(
                         mandateState, goCardlessEvent.getDetailsCause(), goCardlessEvent.getDetailsDescription()));

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculator.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculator.java
@@ -19,10 +19,10 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
-import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE;
-import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.mapGovUkPayEventToState;
-import static uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessEventToMandateStateMapper.GOCARDLESS_ACTIONS_THAT_CHANGE_STATE;
-import static uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessEventToMandateStateMapper.mapGoCardlessEventToState;
+import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE;
+import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.mapGovUkPayEventToMandateState;
+import static uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessEventToMandateStateMapper.GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE;
+import static uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessEventToMandateStateMapper.mapGoCardlessEventToMandateState;
 
 public class GoCardlessMandateStateCalculator implements MandateStateCalculator {
 
@@ -40,7 +40,7 @@ public class GoCardlessMandateStateCalculator implements MandateStateCalculator 
         Optional<GoCardlessEvent> latestApplicableGoCardlessEvent = getLatestApplicableGoCardlessEvent(mandate);
 
         Optional<GovUkPayEvent> latestApplicableGovUkPayEvent
-                = govUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE);
+                = govUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE);
 
         return Stream.of(latestApplicableGoCardlessEvent, latestApplicableGovUkPayEvent)
                 .flatMap(Optional::stream)
@@ -57,15 +57,15 @@ public class GoCardlessMandateStateCalculator implements MandateStateCalculator 
                     return goCardlessEventDao.findLatestApplicableEventForMandate(
                             (GoCardlessMandateId) paymentProviderMandateId,
                             goCardlessOrganisationId,
-                            GOCARDLESS_ACTIONS_THAT_CHANGE_STATE);
+                            GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE);
                 });
     }
 
     private Optional<DirectDebitStateWithDetails<MandateState>> mapEventToState(Event event) {
         if (event instanceof GoCardlessEvent) {
-            return mapGoCardlessEventToState((GoCardlessEvent) event);
+            return mapGoCardlessEventToMandateState((GoCardlessEvent) event);
         } else if (event instanceof GovUkPayEvent) {
-            return mapGovUkPayEventToState((GovUkPayEvent) event);
+            return mapGovUkPayEventToMandateState((GovUkPayEvent) event);
         } else {
             throw new IllegalArgumentException(format("Unexpected Event of type %s", event.getClass()));
         }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/sandbox/SandboxMandateStateCalculator.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/sandbox/SandboxMandateStateCalculator.java
@@ -10,7 +10,7 @@ import uk.gov.pay.directdebit.mandate.services.MandateStateCalculator;
 import javax.inject.Inject;
 import java.util.Optional;
 
-import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE;
+import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE;
 
 public class SandboxMandateStateCalculator implements MandateStateCalculator {
     private final GovUkPayEventDao govUkPayEventDao;
@@ -21,7 +21,7 @@ public class SandboxMandateStateCalculator implements MandateStateCalculator {
     }
 
     public Optional<DirectDebitStateWithDetails<MandateState>> calculate(Mandate mandate) {
-        return govUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE)
-                .flatMap(GovUkPayEventToMandateStateMapper::mapGovUkPayEventToState);
+        return govUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE)
+                .flatMap(GovUkPayEventToMandateStateMapper::mapGovUkPayEventToMandateState);
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/GovUkPayEventToPaymentStateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/GovUkPayEventToPaymentStateMapper.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.directdebit.payments.services;
+
+import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
+import uk.gov.pay.directdebit.events.model.GovUkPayEvent;
+import uk.gov.pay.directdebit.events.model.GovUkPayEventType;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.PAYMENT_SUBMITTED;
+
+public class GovUkPayEventToPaymentStateMapper {
+    private static final Map<GovUkPayEventType, PaymentState> GOV_UK_PAY_EVENT_TYPE_TO_PAYMENT_STATE = Map.of(
+            PAYMENT_SUBMITTED, PaymentState.SUBMITTED_TO_PROVIDER
+    );
+
+    public static final Set<GovUkPayEventType> GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE = GOV_UK_PAY_EVENT_TYPE_TO_PAYMENT_STATE.keySet();
+
+    public static Optional<DirectDebitStateWithDetails<PaymentState>> mapGovUkPayEventToPaymentState(GovUkPayEvent govUkPayEvent) {
+        return Optional.ofNullable(GOV_UK_PAY_EVENT_TYPE_TO_PAYMENT_STATE.get(govUkPayEvent.getEventType()))
+                .map(DirectDebitStateWithDetails::new);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessEventToPaymentStateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessEventToPaymentStateMapper.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.directdebit.payments.services.gocardless;
+
+import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
+import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static uk.gov.pay.directdebit.payments.model.PaymentState.FAILED;
+import static uk.gov.pay.directdebit.payments.model.PaymentState.PAID_OUT;
+
+public class GoCardlessEventToPaymentStateMapper {
+    private static final Map<String, PaymentState> GOCARDLESS_ACTION_TO_PAYMENT_STATE = Map.of(
+            "failed", FAILED,
+            "paid_out", PAID_OUT
+    );
+
+    static final Set<String> GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE = GOCARDLESS_ACTION_TO_PAYMENT_STATE.keySet();
+
+
+    static Optional<DirectDebitStateWithDetails<PaymentState>> mapGoCardlessEventToPaymentState(GoCardlessEvent goCardlessEvent) {
+        return Optional.ofNullable(GOCARDLESS_ACTION_TO_PAYMENT_STATE.get(goCardlessEvent.getAction()))
+                .map(paymentState -> new DirectDebitStateWithDetails<>(
+                        paymentState, goCardlessEvent.getDetailsCause(), goCardlessEvent.getDetailsDescription()));
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculator.java
@@ -6,7 +6,6 @@ import uk.gov.pay.directdebit.events.dao.GovUkPayEventDao;
 import uk.gov.pay.directdebit.events.model.Event;
 import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
 import uk.gov.pay.directdebit.events.model.GovUkPayEvent;
-import uk.gov.pay.directdebit.events.model.GovUkPayEventType;
 import uk.gov.pay.directdebit.gatewayaccounts.exception.GatewayAccountMissingOrganisationIdException;
 import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentId;
@@ -16,33 +15,20 @@ import uk.gov.pay.directdebit.payments.services.PaymentStateCalculator;
 
 import javax.inject.Inject;
 import java.util.Comparator;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
-import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.PAYMENT_SUBMITTED;
-import static uk.gov.pay.directdebit.payments.model.PaymentState.FAILED;
+import static uk.gov.pay.directdebit.payments.services.GovUkPayEventToPaymentStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE;
+import static uk.gov.pay.directdebit.payments.services.GovUkPayEventToPaymentStateMapper.mapGovUkPayEventToPaymentState;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.PAID_OUT;
+import static uk.gov.pay.directdebit.payments.services.gocardless.GoCardlessEventToPaymentStateMapper.GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE;
+import static uk.gov.pay.directdebit.payments.services.gocardless.GoCardlessEventToPaymentStateMapper.mapGoCardlessEventToPaymentState;
 
 public class GoCardlessPaymentStateCalculator implements PaymentStateCalculator {
 
     private final GoCardlessEventDao goCardlessEventDao;
     private final GovUkPayEventDao govUkPayEventDao;
-
-    private static final Map<String, PaymentState> GOCARDLESS_ACTION_TO_PAYMENT_STATE = Map.of(
-            "failed", FAILED,
-            "paid_out", PAID_OUT
-    );
-
-    static final Set<String> GOCARDLESS_ACTIONS_THAT_CHANGE_STATE = GOCARDLESS_ACTION_TO_PAYMENT_STATE.keySet();
-    
-    private static final Map<GovUkPayEventType, PaymentState> GOV_UK_PAY_EVENT_TYPE_TO_PAYMENT_STATE = Map.of(
-            PAYMENT_SUBMITTED, PaymentState.SUBMITTED_TO_PROVIDER
-    );
-    
-    static final Set<GovUkPayEventType> GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE = GOV_UK_PAY_EVENT_TYPE_TO_PAYMENT_STATE.keySet();
 
     @Inject
     GoCardlessPaymentStateCalculator(GoCardlessEventDao goCardlessEventDao,
@@ -54,13 +40,13 @@ public class GoCardlessPaymentStateCalculator implements PaymentStateCalculator 
     public Optional<DirectDebitStateWithDetails<PaymentState>> calculate(Payment payment) {
         Optional<GoCardlessEvent> latestApplicableGoCardlessEvent = getLatestApplicableGoCardlessEvent(payment);
 
-        Optional<GovUkPayEvent> latestApplicableGovUkPayEvent 
-                = govUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE);
-        
-        return Stream.of(latestApplicableGoCardlessEvent,latestApplicableGovUkPayEvent)
+        Optional<GovUkPayEvent> latestApplicableGovUkPayEvent
+                = govUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE);
+
+        return Stream.of(latestApplicableGoCardlessEvent, latestApplicableGovUkPayEvent)
                 .flatMap(Optional::stream)
                 .max(Comparator.comparing(Event::getTimestamp))
-                .map(this::mapEventToState);
+                .flatMap(this::mapEventToState);
     }
 
     private Optional<GoCardlessEvent> getLatestApplicableGoCardlessEvent(Payment payment) {
@@ -72,29 +58,17 @@ public class GoCardlessPaymentStateCalculator implements PaymentStateCalculator 
                     return goCardlessEventDao.findLatestApplicableEventForPayment(
                             (GoCardlessPaymentId) providerId,
                             goCardlessOrganisationId,
-                            GOCARDLESS_ACTIONS_THAT_CHANGE_STATE);
+                            GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE);
                 });
     }
 
-    private DirectDebitStateWithDetails<PaymentState> mapEventToState(Event event) {
+    private Optional<DirectDebitStateWithDetails<PaymentState>> mapEventToState(Event event) {
         if (event instanceof GoCardlessEvent) {
-            return mapGoCardlessEventToState((GoCardlessEvent) event);
+            return mapGoCardlessEventToPaymentState((GoCardlessEvent) event);
         } else if (event instanceof GovUkPayEvent) {
-            return mapGovUkPayEventToState((GovUkPayEvent) event);
+            return mapGovUkPayEventToPaymentState((GovUkPayEvent) event);
         } else {
             throw new IllegalArgumentException(format("Unexpected Event of type %s", event.getClass()));
         }
-    }
-
-    private DirectDebitStateWithDetails<PaymentState> mapGoCardlessEventToState(GoCardlessEvent goCardlessEvent) {
-        return new DirectDebitStateWithDetails<>(
-                GOCARDLESS_ACTION_TO_PAYMENT_STATE.get(goCardlessEvent.getAction()),
-                goCardlessEvent.getDetailsCause(),
-                goCardlessEvent.getDetailsDescription());
-    }
-    
-    private DirectDebitStateWithDetails<PaymentState> mapGovUkPayEventToState(GovUkPayEvent govUkPayEvent) {
-        return new DirectDebitStateWithDetails<>(
-                GOV_UK_PAY_EVENT_TYPE_TO_PAYMENT_STATE.get(govUkPayEvent.getEventType()));
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxEventToPaymentStateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxEventToPaymentStateMapper.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.directdebit.payments.services.sandbox;
+
+import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
+import uk.gov.pay.directdebit.events.model.SandboxEvent;
+import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.directdebit.webhook.gocardless.services.handlers.GoCardlessPaymentHandler;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class SandboxEventToPaymentStateMapper {
+    private static final Map<String, PaymentState> SANDBOX_ACTION_TO_PAYMENT_STATE = Map.of(
+            GoCardlessPaymentHandler.GoCardlessPaymentAction.PAID_OUT.toString(), PaymentState.PAID_OUT
+    );
+
+    static final Set<String> SANDBOX_ACTIONS_THAT_CHANGE_PAYMENT_STATE = SANDBOX_ACTION_TO_PAYMENT_STATE.keySet();
+
+    public static Optional<DirectDebitStateWithDetails<PaymentState>> mapSandboxEventToPaymentState(SandboxEvent sandboxEvent) {
+        return Optional.ofNullable(SANDBOX_ACTION_TO_PAYMENT_STATE.get(sandboxEvent.getEventAction()))
+                .map(DirectDebitStateWithDetails::new);
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateCalculator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateCalculator.java
@@ -1,49 +1,66 @@
 package uk.gov.pay.directdebit.payments.services.sandbox;
 
 import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
+import uk.gov.pay.directdebit.events.dao.GovUkPayEventDao;
 import uk.gov.pay.directdebit.events.dao.SandboxEventDao;
+import uk.gov.pay.directdebit.events.model.Event;
+import uk.gov.pay.directdebit.events.model.GovUkPayEvent;
 import uk.gov.pay.directdebit.events.model.SandboxEvent;
 import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
 import uk.gov.pay.directdebit.payments.services.PaymentStateCalculator;
-import uk.gov.pay.directdebit.webhook.sandbox.resources.WebhookSandboxResource;
 
 import javax.inject.Inject;
-import java.util.Map;
+import java.util.Comparator;
 import java.util.Optional;
-import java.util.Set;
+import java.util.stream.Stream;
 
 import static uk.gov.pay.directdebit.payments.model.PaymentState.PAID_OUT;
+import static java.lang.String.format;
+import static uk.gov.pay.directdebit.payments.services.GovUkPayEventToPaymentStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE;
+import static uk.gov.pay.directdebit.payments.services.GovUkPayEventToPaymentStateMapper.mapGovUkPayEventToPaymentState;
+import static uk.gov.pay.directdebit.payments.services.sandbox.SandboxEventToPaymentStateMapper.SANDBOX_ACTIONS_THAT_CHANGE_PAYMENT_STATE;
+import static uk.gov.pay.directdebit.payments.services.sandbox.SandboxEventToPaymentStateMapper.mapSandboxEventToPaymentState;
 
 public class SandboxPaymentStateCalculator implements PaymentStateCalculator {
 
     private final SandboxEventDao sandboxEventDao;
-
-    private static final Map<String, PaymentState> SANDBOX_ACTION_TO_PAYMENT_STATE = Map.of(
-            WebhookSandboxResource.SandboxEventAction.PAID_OUT.toString(), PAID_OUT
-    );
-
-    static final Set<String> SANDBOX_ACTIONS_THAT_CHANGE_STATE = SANDBOX_ACTION_TO_PAYMENT_STATE.keySet();
+    private final GovUkPayEventDao govUkPayEventDao;
 
     @Inject
-    SandboxPaymentStateCalculator(SandboxEventDao sandboxEventDao) {
+    SandboxPaymentStateCalculator(SandboxEventDao sandboxEventDao,
+                                  GovUkPayEventDao govUkPayEventDao) {
         this.sandboxEventDao = sandboxEventDao;
+        this.govUkPayEventDao = govUkPayEventDao;
     }
 
     public Optional<DirectDebitStateWithDetails<PaymentState>> calculate(Payment payment) {
-        return getLatestApplicableSandboxEvent(payment)
-                .filter(sandboxEvent -> SANDBOX_ACTION_TO_PAYMENT_STATE.get(sandboxEvent.getEventAction()) != null)
-                .map(sandboxEvent -> new DirectDebitStateWithDetails<>(
-                        SANDBOX_ACTION_TO_PAYMENT_STATE.get(sandboxEvent.getEventAction())
-                ));
+        Optional<SandboxEvent> latestApplicableSandboxEvent = getLatestApplicableSandboxEvent(payment);
+
+        Optional<GovUkPayEvent> latestApplicableGovUkPayEvent
+                = govUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE);
+
+        return Stream.of(latestApplicableSandboxEvent, latestApplicableGovUkPayEvent)
+                .flatMap(Optional::stream)
+                .max(Comparator.comparing(Event::getTimestamp))
+                .flatMap(this::mapEventToState);
     }
 
     private Optional<SandboxEvent> getLatestApplicableSandboxEvent(Payment payment) {
         return payment.getProviderId().flatMap(providerId ->
                 sandboxEventDao.findLatestApplicableEventForPayment(
                         (SandboxPaymentId) providerId,
-                        SANDBOX_ACTIONS_THAT_CHANGE_STATE));
+                        SANDBOX_ACTIONS_THAT_CHANGE_PAYMENT_STATE));
     }
 
+    private Optional<DirectDebitStateWithDetails<PaymentState>> mapEventToState(Event event) {
+        if (event instanceof SandboxEvent) {
+            return mapSandboxEventToPaymentState((SandboxEvent) event);
+        } else if (event instanceof GovUkPayEvent) {
+            return mapGovUkPayEventToPaymentState((GovUkPayEvent) event);
+        } else {
+            throw new IllegalArgumentException(format("Unexpected Event of type %s", event.getClass()));
+        }
+    }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
@@ -34,8 +34,8 @@ import static org.mockito.BDDMockito.given;
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_CANCELLED_BY_USER;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
-import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE;
-import static uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessEventToMandateStateMapper.GOCARDLESS_ACTIONS_THAT_CHANGE_STATE;
+import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE;
+import static uk.gov.pay.directdebit.mandate.services.gocardless.GoCardlessEventToMandateStateMapper.GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture.aGoCardlessEventFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GovUkPayEventFixture.aGovUkPayEventFixture;
@@ -87,7 +87,7 @@ public class GoCardlessMandateStateCalculatorTest {
     public void goCardlessEventActionMapsToState(String action, String expectedState) {
         GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture().withAction(action).toEntity();
         given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(goCardlessMandateId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE))
                 .willReturn(Optional.of(goCardlessEvent));
 
         Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mandate);
@@ -107,7 +107,7 @@ public class GoCardlessMandateStateCalculatorTest {
     public void govUkPayEventTypeMapsToState(String eventType, String expectedState) {
         GovUkPayEventType govUkPayEventType = GovUkPayEventType.valueOf(eventType);
         GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture().withEventType(govUkPayEventType).toEntity();
-        given(mockGovUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+        given(mockGovUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE))
                 .willReturn(Optional.of(govUkPayEvent));
 
         Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mandate);
@@ -122,7 +122,7 @@ public class GoCardlessMandateStateCalculatorTest {
                 .withDetailsDescription("This is a description")
                 .toEntity();
         given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(goCardlessMandateId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE))
                 .willReturn(Optional.of(goCardlessEvent));
 
         Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mandate);
@@ -138,14 +138,14 @@ public class GoCardlessMandateStateCalculatorTest {
                 .withCreatedAt(ZonedDateTime.of(2019, 7, 22, 9, 0, 0, 0, UTC))
                 .toEntity();
         given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(goCardlessMandateId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE))
                 .willReturn(Optional.of(goCardlessEvent));
 
         GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture()
                 .withEventType(MANDATE_CANCELLED_BY_USER)
                 .withEventDate(ZonedDateTime.of(2019, 7, 22, 10, 0, 0, 0, UTC))
                 .toEntity();
-        given(mockGovUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+        given(mockGovUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE))
                 .willReturn(Optional.of(govUkPayEvent));
 
         Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mandate);
@@ -160,14 +160,14 @@ public class GoCardlessMandateStateCalculatorTest {
                 .withCreatedAt(ZonedDateTime.of(2019, 7, 22, 10, 0, 0, 0, UTC))
                 .toEntity();
         given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(goCardlessMandateId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE))
                 .willReturn(Optional.of(goCardlessEvent));
 
         GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture()
                 .withEventType(MANDATE_CANCELLED_BY_USER)
                 .withEventDate(ZonedDateTime.of(2019, 7, 22, 9, 0, 0, 0, UTC))
                 .toEntity();
-        given(mockGovUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+        given(mockGovUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE))
                 .willReturn(Optional.of(govUkPayEvent));
 
         Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mandate);
@@ -178,14 +178,14 @@ public class GoCardlessMandateStateCalculatorTest {
     @Test
     public void noApplicableEventsMapsToNothing() {
         given(mockGoCardlessEventDao.findLatestApplicableEventForMandate(goCardlessMandateId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE))
                 .willReturn(Optional.empty());
 
         Optional<DirectDebitStateWithDetails<MandateState>> result = goCardlessMandateStateCalculator.calculate(mandate);
 
         assertThat(result, is(Optional.empty()));
     }
-    
+
     @Test
     public void gatewayAccountMissingOrganisationIdThrowsException() {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
@@ -196,7 +196,7 @@ public class GoCardlessMandateStateCalculatorTest {
                 .withPaymentProviderId(goCardlessMandateId)
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .toEntity();
-        
+
         thrown.expect(GatewayAccountMissingOrganisationIdException.class);
 
         goCardlessMandateStateCalculator.calculate(mandate);

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/sandbox/SandboxMandateStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/sandbox/SandboxMandateStateCalculatorTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
-import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE;
+import static uk.gov.pay.directdebit.mandate.services.GovUkPayEventToMandateStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GovUkPayEventFixture.aGovUkPayEventFixture;
 
@@ -65,7 +65,7 @@ public class SandboxMandateStateCalculatorTest {
     public void govUkPayEventTypeMapsToState(String eventType, String expectedState) {
         GovUkPayEventType govUkPayEventType = GovUkPayEventType.valueOf(eventType);
         GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture().withEventType(govUkPayEventType).toEntity();
-        given(mockGovUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+        given(mockGovUkPayEventDao.findLatestApplicableEventForMandate(mandate.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_MANDATE_STATE))
                 .willReturn(Optional.of(govUkPayEvent));
 
         Optional<DirectDebitStateWithDetails<MandateState>> result = sandboxMandateStateCalculator.calculate(mandate);

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculatorTest.java
@@ -40,8 +40,8 @@ import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGa
 import static uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture.aGoCardlessEventFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GovUkPayEventFixture.aGovUkPayEventFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
-import static uk.gov.pay.directdebit.payments.services.gocardless.GoCardlessPaymentStateCalculator.GOCARDLESS_ACTIONS_THAT_CHANGE_STATE;
-import static uk.gov.pay.directdebit.payments.services.gocardless.GoCardlessPaymentStateCalculator.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE;
+import static uk.gov.pay.directdebit.payments.services.GovUkPayEventToPaymentStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE;
+import static uk.gov.pay.directdebit.payments.services.gocardless.GoCardlessEventToPaymentStateMapper.GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE;
 
 @RunWith(JUnitParamsRunner.class)
 public class GoCardlessPaymentStateCalculatorTest {
@@ -89,7 +89,7 @@ public class GoCardlessPaymentStateCalculatorTest {
     public void goCardlessEventActionMapsToState(String action, String expectedState) {
         GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture().withAction(action).toEntity();
         given(mockGoCardlessEventDao.findLatestApplicableEventForPayment(goCardlessPaymentId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE))
                 .willReturn(Optional.of(goCardlessEvent));
 
         Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);
@@ -104,7 +104,7 @@ public class GoCardlessPaymentStateCalculatorTest {
     public void govUkPayEventTypeMapsToState(String eventType, String expectedState) {
         GovUkPayEventType govUkPayEventType = GovUkPayEventType.valueOf(eventType);
         GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture().withEventType(govUkPayEventType).toEntity();
-        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE))
                 .willReturn(Optional.of(govUkPayEvent));
 
         Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);
@@ -120,7 +120,7 @@ public class GoCardlessPaymentStateCalculatorTest {
                 .toEntity();
 
         given(mockGoCardlessEventDao.findLatestApplicableEventForPayment(goCardlessPaymentId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE))
                 .willReturn(Optional.of(goCardlessEvent));
 
         Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);
@@ -136,14 +136,14 @@ public class GoCardlessPaymentStateCalculatorTest {
                 .withCreatedAt(ZonedDateTime.of(2019, 7, 22, 9, 0, 0, 0, UTC))
                 .toEntity();
         given(mockGoCardlessEventDao.findLatestApplicableEventForPayment(goCardlessPaymentId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE))
                 .willReturn(Optional.of(goCardlessEvent));
 
         GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture()
                 .withEventType(PAYMENT_SUBMITTED)
                 .withEventDate(ZonedDateTime.of(2019, 7, 22, 10, 0, 0, 0, UTC))
                 .toEntity();
-        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE))
                 .willReturn(Optional.of(govUkPayEvent));
 
         Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);
@@ -158,14 +158,14 @@ public class GoCardlessPaymentStateCalculatorTest {
                 .withCreatedAt(ZonedDateTime.of(2019, 7, 22, 10, 0, 0, 0, UTC))
                 .toEntity();
         given(mockGoCardlessEventDao.findLatestApplicableEventForPayment(goCardlessPaymentId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE))
                 .willReturn(Optional.of(goCardlessEvent));
 
         GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture()
                 .withEventType(PAYMENT_SUBMITTED)
                 .withEventDate(ZonedDateTime.of(2019, 7, 22, 9, 0, 0, 0, UTC))
                 .toEntity();
-        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_STATE))
+        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE))
                 .willReturn(Optional.of(govUkPayEvent));
 
         Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);
@@ -176,7 +176,7 @@ public class GoCardlessPaymentStateCalculatorTest {
     @Test
     public void noApplicableEventsMapsToNothing() {
         given(mockGoCardlessEventDao.findLatestApplicableEventForPayment(goCardlessPaymentId, goCardlessOrganisationId,
-                GOCARDLESS_ACTIONS_THAT_CHANGE_STATE))
+                GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE))
                 .willReturn(Optional.empty());
 
         Optional<DirectDebitStateWithDetails<PaymentState>> result = goCardlessPaymentStateCalculator.calculate(payment);

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/sandbox/SandboxPaymentStateCalculatorTest.java
@@ -1,48 +1,64 @@
 package uk.gov.pay.directdebit.payments.services.sandbox;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.pay.directdebit.common.model.DirectDebitStateWithDetails;
+import uk.gov.pay.directdebit.events.dao.GovUkPayEventDao;
 import uk.gov.pay.directdebit.events.dao.SandboxEventDao;
+import uk.gov.pay.directdebit.events.model.GovUkPayEvent;
+import uk.gov.pay.directdebit.events.model.GovUkPayEventType;
 import uk.gov.pay.directdebit.events.model.SandboxEvent;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
 import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
-import uk.gov.pay.directdebit.webhook.sandbox.resources.WebhookSandboxResource.SandboxEventAction;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.PAYMENT_SUBMITTED;
+import static uk.gov.pay.directdebit.events.model.SandboxEvent.SandboxEventBuilder.aSandboxEvent;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.SANDBOX;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
+import static uk.gov.pay.directdebit.payments.fixtures.GovUkPayEventFixture.aGovUkPayEventFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFixture;
-import static uk.gov.pay.directdebit.payments.services.sandbox.SandboxPaymentStateCalculator.SANDBOX_ACTIONS_THAT_CHANGE_STATE;
+import static uk.gov.pay.directdebit.payments.services.GovUkPayEventToPaymentStateMapper.GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE;
+import static uk.gov.pay.directdebit.payments.services.sandbox.SandboxEventToPaymentStateMapper.SANDBOX_ACTIONS_THAT_CHANGE_PAYMENT_STATE;
+import static uk.gov.pay.directdebit.webhook.sandbox.resources.WebhookSandboxResource.SandboxEventAction.PAID_OUT;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(JUnitParamsRunner.class)
 public class SandboxPaymentStateCalculatorTest {
 
     private static final SandboxPaymentId SANDBOX_PAYMENT_ID = SandboxPaymentId.valueOf("Sandbox payment ID");
 
-    @Mock
-    private SandboxEvent mockSandboxEvent;
-
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    
     @Mock
     private SandboxEventDao mockSandboxEventDao;
 
+    @Mock
+    private GovUkPayEventDao mockGovUkPayEventDao;
+
     @InjectMocks
     private SandboxPaymentStateCalculator sandboxPaymentStateCalculator;
-    
+
     private Payment payment;
-    
+
     @Before
     public void setUp() {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
@@ -50,37 +66,90 @@ public class SandboxPaymentStateCalculatorTest {
 
         MandateFixture mandateFixture = aMandateFixture()
                 .withGatewayAccountFixture(gatewayAccountFixture);
-        
+
         payment = aPaymentFixture()
                 .withMandateFixture(mandateFixture)
                 .withPaymentProviderId(SANDBOX_PAYMENT_ID)
                 .toEntity();
-
-        given(mockSandboxEventDao.findLatestApplicableEventForPayment(SANDBOX_PAYMENT_ID, SANDBOX_ACTIONS_THAT_CHANGE_STATE))
-                .willReturn(Optional.of(mockSandboxEvent));
     }
 
     @Test
-    public void paidOutActionMapsToSuccessState() {
-        given(mockSandboxEvent.getEventAction()).willReturn(SandboxEventAction.PAID_OUT.toString());
-        
+    @Parameters({
+            "PAID_OUT, PAID_OUT"
+    })
+    public void sandboxEventActionMapsToState(String action, String expectedState) {
+        SandboxEvent sandboxEvent = aSandboxEvent().withEventAction(action).build();
+
+        given(mockSandboxEventDao.findLatestApplicableEventForPayment(SANDBOX_PAYMENT_ID, SANDBOX_ACTIONS_THAT_CHANGE_PAYMENT_STATE))
+                .willReturn(Optional.of(sandboxEvent));
+
+        Optional<DirectDebitStateWithDetails<PaymentState>> result = sandboxPaymentStateCalculator.calculate(payment);
+
+        assertThat(result.get().getState(), is(PaymentState.valueOf(expectedState)));
+    }
+
+    @Test
+    @Parameters({
+            "PAYMENT_SUBMITTED, SUBMITTED_TO_PROVIDER"
+    })
+    public void govUkPayEventTypeMapsToState(String eventType, String expectedState) {
+        GovUkPayEventType govUkPayEventType = GovUkPayEventType.valueOf(eventType);
+        GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture().withEventType(govUkPayEventType).toEntity();
+        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE))
+                .willReturn(Optional.of(govUkPayEvent));
+
+        Optional<DirectDebitStateWithDetails<PaymentState>> result = sandboxPaymentStateCalculator.calculate(payment);
+
+        assertThat(result.get().getState(), is(PaymentState.valueOf(expectedState)));
+    }
+
+    @Test
+    public void resolvesStateFromGovUkPayEventWhenIsLaterThanLatestSandboxEvent() {
+        SandboxEvent sandboxEvent = aSandboxEvent()
+                .withEventAction(PAID_OUT.toString())
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 22, 9, 0, 0, 0, UTC))
+                .build();
+
+        given(mockSandboxEventDao.findLatestApplicableEventForPayment(SANDBOX_PAYMENT_ID, SANDBOX_ACTIONS_THAT_CHANGE_PAYMENT_STATE))
+                .willReturn(Optional.of(sandboxEvent));
+
+        GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture()
+                .withEventType(PAYMENT_SUBMITTED)
+                .withEventDate(ZonedDateTime.of(2019, 7, 22, 10, 0, 0, 0, UTC))
+                .toEntity();
+        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE))
+                .willReturn(Optional.of(govUkPayEvent));
+
+        Optional<DirectDebitStateWithDetails<PaymentState>> result = sandboxPaymentStateCalculator.calculate(payment);
+
+        assertThat(result.get().getState(), is(PaymentState.SUBMITTED_TO_PROVIDER));
+    }
+
+    @Test
+    public void resolvesStateFromSandboxEventWhenIsLaterThanLatestGovUkPayEvent() {
+        SandboxEvent sandboxEvent = aSandboxEvent()
+                .withEventAction(PAID_OUT.toString())
+                .withCreatedAt(ZonedDateTime.of(2019, 7, 22, 10, 0, 0, 0, UTC))
+                .build();
+
+        given(mockSandboxEventDao.findLatestApplicableEventForPayment(SANDBOX_PAYMENT_ID, SANDBOX_ACTIONS_THAT_CHANGE_PAYMENT_STATE))
+                .willReturn(Optional.of(sandboxEvent));
+
+        GovUkPayEvent govUkPayEvent = aGovUkPayEventFixture()
+                .withEventType(PAYMENT_SUBMITTED)
+                .withEventDate(ZonedDateTime.of(2019, 7, 22, 9, 0, 0, 0, UTC))
+                .toEntity();
+        given(mockGovUkPayEventDao.findLatestApplicableEventForPayment(payment.getId(), GOV_UK_PAY_EVENT_TYPES_THAT_CHANGE_PAYMENT_STATE))
+                .willReturn(Optional.of(govUkPayEvent));
+
         Optional<DirectDebitStateWithDetails<PaymentState>> result = sandboxPaymentStateCalculator.calculate(payment);
 
         assertThat(result.get().getState(), is(PaymentState.PAID_OUT));
     }
 
     @Test
-    public void unrecognisedActionMapsToNothing() {
-        given(mockSandboxEvent.getEventAction()).willReturn("EATEN_BY_WOLVES");
-
-        Optional<DirectDebitStateWithDetails<PaymentState>> result = sandboxPaymentStateCalculator.calculate(payment);
-
-        assertThat(result, is(Optional.empty()));
-    }
-
-    @Test
     public void noApplicableEventsMapsToNothing() {
-        given(mockSandboxEventDao.findLatestApplicableEventForPayment(SANDBOX_PAYMENT_ID, SANDBOX_ACTIONS_THAT_CHANGE_STATE)).willReturn(Optional.empty());
+        given(mockSandboxEventDao.findLatestApplicableEventForPayment(SANDBOX_PAYMENT_ID, SANDBOX_ACTIONS_THAT_CHANGE_PAYMENT_STATE)).willReturn(Optional.empty());
 
         Optional<DirectDebitStateWithDetails<PaymentState>> result = sandboxPaymentStateCalculator.calculate(payment);
 


### PR DESCRIPTION
When calculating the state of a Sandbox payment, find the most recent Sandbox and GovUkPayEvent then use whichever has a later timestamp to calculate the state.

Add ...EventToPaymentStateMapper classes to share the GovUkPayEvent mapping between the GoCardless and Sandbox calculators. Add classes for GoCardless and Sandbox for consistency, as this was done for the mandate state calculation.