### PR TITLE
Improve logging on failed emails

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/notifications/clients/AdminUsersClient.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/clients/AdminUsersClient.java
@@ -30,6 +30,10 @@ public class AdminUsersClient {
 
     public void sendEmail(EmailTemplate template, Mandate mandate, Map<String, String> personalisation) {
         String gatewayAccountExternalId = mandate.getGatewayAccount().getExternalId();
+        LOGGER.info("Calling adminusers to send {} email for mandate id {} for gateway account id {}",
+                template.toString(),
+                mandate.getExternalId(),
+                gatewayAccountExternalId);
         String email = mandate.getPayer().orElseThrow(() -> new PayerNotFoundException(mandate.getExternalId())).getEmail();
         var emailPayloadRequest = new EmailPayloadRequest(email, gatewayAccountExternalId, template, personalisation);
         try {

--- a/src/main/java/uk/gov/pay/directdebit/notifications/clients/AdminUsersClient.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/clients/AdminUsersClient.java
@@ -5,6 +5,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
 import org.slf4j.Logger;
 import uk.gov.pay.directdebit.app.config.AdminUsersConfig;
 import org.slf4j.LoggerFactory;
@@ -13,10 +14,12 @@ import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.notifications.api.EmailPayloadRequest;
 import uk.gov.pay.directdebit.notifications.model.EmailPayload.EmailTemplate;
 
+import static java.lang.String.format;
+
 public class AdminUsersClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AdminUsersClient.class);
-    
+
     private final Client client;
     private final AdminUsersConfig config;
 
@@ -27,20 +30,23 @@ public class AdminUsersClient {
 
     public void sendEmail(EmailTemplate template, Mandate mandate, Map<String, String> personalisation) {
         String gatewayAccountExternalId = mandate.getGatewayAccount().getExternalId();
-        LOGGER.info("Calling adminusers to send {} email for mandate id {} for gateway account id {}",
-                template.toString(),
-                mandate.getExternalId(),
-                gatewayAccountExternalId);
         String email = mandate.getPayer().orElseThrow(() -> new PayerNotFoundException(mandate.getExternalId())).getEmail();
         var emailPayloadRequest = new EmailPayloadRequest(email, gatewayAccountExternalId, template, personalisation);
         try {
-             Response response = client.target(config.getAdminUsersUrl())
+            Response response = client.target(config.getAdminUsersUrl())
                     .path("/v1/emails/send")
                     .request()
                     .post(Entity.entity(emailPayloadRequest, MediaType.APPLICATION_JSON_TYPE));
-            response.readEntity(String.class);
-        } catch (Exception exc) {
-            LOGGER.error("Making call to adminusers failed with exception {}", exc.getMessage());
+            if (response.getStatus() != 200) {
+                throw new RuntimeException(format("Sending email failed with status %s and response %s", response.getStatus(), response.readEntity(String.class)));
+            }
+        } catch (Exception exception) {
+            LOGGER.error("Failed to send {} email for mandate id {} for gateway account id {}",
+                    template.toString(),
+                    mandate.getExternalId(),
+                    gatewayAccountExternalId,
+                    exception);
+            throw exception;
         }
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoIT.java
@@ -29,7 +29,7 @@ import static uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture.aG
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
-public class GoCardlessEventDaoITest {
+public class GoCardlessEventDaoIT {
 
     @DropwizardTestContext
     private TestContext testContext;

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/GovUkPayEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/GovUkPayEventDaoIT.java
@@ -33,7 +33,7 @@ import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFi
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
-public class GovUkPayEventDaoITest {
+public class GovUkPayEventDaoIT {
 
     @DropwizardTestContext
     private TestContext testContext;


### PR DESCRIPTION
## WHAT YOU DID
When sending emails via adminusers, ensure we log any failures with enough information to diagnose the problem.

Log nothing on success.

Also, rename tests which spin up postgres so that they run during the integration test phase of maven, not the unit test phase.

## How to test

Does this look robust enough? Could it reveal any sensitive information into the logs?

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
