### PR TITLE
PP-5433 Update payment state after inserting a GovUkPayEvent

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/payments/services/CollectServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/CollectServiceTest.java
@@ -41,9 +41,9 @@ public class CollectServiceTest {
     private GatewayAccount gatewayAccount = GatewayAccountFixture.aGatewayAccountFixture().withExternalId(GATEWAY_ACCOUNT_EXTERNAL_ID).toEntity();
 
     private Mandate mandate = MandateFixture.aMandateFixture().withExternalId(MANDATE_EXTERNAL_ID).withState(MandateState.PENDING).toEntity();
-    
+
     private CollectPaymentRequest collectPaymentRequest = new CollectPaymentRequest(MANDATE_EXTERNAL_ID, AMOUNT, DESCRIPTION, REFERENCE);
-    
+
     private CollectService collectService;
 
     @Before
@@ -58,7 +58,7 @@ public class CollectServiceTest {
         given(mockPaymentService.submitPaymentToProvider(mockCreatedPayment)).willReturn(mockPendingPayment);
 
         Payment payment = collectService.collect(gatewayAccount, collectPaymentRequest);
-        
+
         assertThat(payment, is(mockPendingPayment));
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GovUkPayEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GovUkPayEventServiceTest.java
@@ -45,9 +45,12 @@ public class GovUkPayEventServiceTest {
 
     @Mock
     private GovUkPayEventStateGraph mockGovUkPayEventStateGraph;
-    
+
     @Mock
     private MandateStateUpdater mockMandateStateUpdater;
+
+    @Mock
+    private PaymentStateUpdater mockPaymentStateUpdater;
 
     @InjectMocks
     private GovUkPayEventService govUkPayEventService;
@@ -153,9 +156,10 @@ public class GovUkPayEventServiceTest {
         when(mockGovUkPayEventDao.findLatestEventForPayment(paymentId)).thenReturn(Optional.empty());
         when(mockGovUkPayEventStateGraph.isValidStartValue(eventType)).thenReturn(true);
 
-        govUkPayEventService.storeEventForPayment(payment, eventType);
+        govUkPayEventService.storeEventAndUpdateStateForPayment(payment, eventType);
 
         verify(mockGovUkPayEventDao).insert(eventCaptor.capture());
+        verify(mockPaymentStateUpdater).updateStateIfNecessary(payment);
 
         GovUkPayEvent insertedEvent = eventCaptor.getValue();
         assertThat(insertedEvent.getEventType(), is(eventType));
@@ -180,6 +184,6 @@ public class GovUkPayEventServiceTest {
         expectedException.expect(InvalidGovUkPayEventInsertionException.class);
         expectedException.expectMessage("GOV.UK Pay event PAYMENT_SUBMITTED is invalid following event PAYMENT_SUBMITTED");
 
-        govUkPayEventService.storeEventForPayment(payment, newEventType);
+        govUkPayEventService.storeEventAndUpdateStateForPayment(payment, newEventType);
     }
 }


### PR DESCRIPTION
Recalculate the Payment state and update it if necessary after inserting a GovUkPayEvent. Currently there is only an event for submitted to provider.