### PR TITLE
PP-5451 Remove payment expiry

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/tasks/resources/ExpireResource.java
+++ b/src/main/java/uk/gov/pay/directdebit/tasks/resources/ExpireResource.java
@@ -28,9 +28,8 @@ public class ExpireResource {
     @Produces(APPLICATION_JSON)
     @Timed
     public Response expirePaymentsAndMandates() {
-        int numberOfExpiredPayments = expireService.expirePayments();
         int numberOfExpiredMandates = expireService.expireMandates();
-        ResourceResponse resourceResponse =  new ResourceResponse(numberOfExpiredPayments, numberOfExpiredMandates);
+        ResourceResponse resourceResponse =  new ResourceResponse(0, numberOfExpiredMandates);
         return Response.ok(resourceResponse).build();
     }
     
@@ -38,6 +37,7 @@ public class ExpireResource {
     private static class ResourceResponse {
         
         @JsonProperty
+        @Deprecated
         private final int numberOfExpiredPayments;
         
         @JsonProperty

--- a/src/main/java/uk/gov/pay/directdebit/tasks/services/ExpireService.java
+++ b/src/main/java/uk/gov/pay/directdebit/tasks/services/ExpireService.java
@@ -7,10 +7,6 @@ import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
 import uk.gov.pay.directdebit.mandate.services.MandateStateUpdateService;
-import uk.gov.pay.directdebit.payments.model.Payment;
-import uk.gov.pay.directdebit.payments.model.PaymentState;
-import uk.gov.pay.directdebit.payments.model.PaymentStatesGraph;
-import uk.gov.pay.directdebit.payments.services.PaymentService;
 
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
@@ -18,44 +14,21 @@ import java.util.List;
 import java.util.Set;
 
 public class ExpireService {
-
-    private PaymentService paymentService;
-    private PaymentStatesGraph paymentStatesGraph;
+    
     private MandateStatesGraph mandateStatesGraph;
     private static final Logger LOGGER = LoggerFactory.getLogger(ExpireService.class);
     private final long MIN_EXPIRY_AGE_MINUTES = 90L;
-    private final PaymentState PAYMENT_EXPIRY_CUTOFF_STATUS = PaymentState.SUBMITTED_TO_PROVIDER;
     private final MandateState MANDATE_EXPIRY_CUTOFF_STATUS = MandateState.SUBMITTED_TO_PROVIDER;
     private final MandateQueryService mandateQueryService;
     private final MandateStateUpdateService mandateStateUpdateService;
 
     @Inject
-    ExpireService(PaymentService paymentService,
-                  MandateStatesGraph mandateStatesGraph,
-                  PaymentStatesGraph paymentStatesGraph,
+    ExpireService(MandateStatesGraph mandateStatesGraph,
                   MandateQueryService mandateQueryService,
                   MandateStateUpdateService mandateStateUpdateService) {
-        this.paymentService = paymentService;
-        this.paymentStatesGraph = paymentStatesGraph;
         this.mandateQueryService = mandateQueryService;
         this.mandateStateUpdateService = mandateStateUpdateService;
         this.mandateStatesGraph = mandateStatesGraph;
-    }
-
-    public int expirePayments() {
-        LOGGER.info("Starting expire payments process.");
-        List<Payment> paymentsToExpire = getPaymentsForExpiration();
-        for (Payment payment : paymentsToExpire) {
-            paymentService.paymentExpired(payment);
-            LOGGER.info("Expired payment " + payment.getId());
-        }
-        return paymentsToExpire.size();
-    }
-
-    private List<Payment> getPaymentsForExpiration() {
-        Set<PaymentState> states = paymentStatesGraph.getPriorStates(PAYMENT_EXPIRY_CUTOFF_STATUS);
-        ZonedDateTime cutOffTime = ZonedDateTime.now().minusMinutes(MIN_EXPIRY_AGE_MINUTES);
-        return paymentService.findAllPaymentsBySetOfStatesAndCreationTime(states, cutOffTime);
     }
 
     public int expireMandates() {

--- a/src/test/java/uk/gov/pay/directdebit/tasks/resources/ExpireResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/tasks/resources/ExpireResourceIT.java
@@ -42,24 +42,6 @@ public class ExpireResourceIT {
     }
 
     @Test
-    public void shouldExpireATransactionInStateStartedOlderThanOneDay() {
-        MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(testGatewayAccount).insert(testContext.getJdbi());
-        PaymentFixture.aPaymentFixture()
-                .withState(PaymentState.CREATED)
-                .withCreatedDate(ZonedDateTime.of(2018,1,1,1,1,1,1,ZoneId.systemDefault()))
-                .withMandateFixture(mandateFixture)
-                .insert(testContext.getJdbi());
-        String requestPath = "/v1/api/tasks/expire-payments-and-mandates";
-        given().port(testContext.getPort())
-            .contentType(JSON)
-            .post(requestPath)
-            .then()
-            .statusCode(Response.Status.OK.getStatusCode())
-            .contentType(JSON)
-            .body("numberOfExpiredPayments", is(1));
-    }
-
-    @Test
     public void shouldExpireAMandateInState_CREATED_OlderThan_90Minutes() {
         Mandate mandate = MandateFixture.aMandateFixture()
                 .withState(MandateState.CREATED)

--- a/src/test/java/uk/gov/pay/directdebit/tasks/services/ExpireServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/tasks/services/ExpireServiceTest.java
@@ -12,14 +12,8 @@ import uk.gov.pay.directdebit.mandate.model.Mandate;
 import uk.gov.pay.directdebit.mandate.model.MandateStatesGraph;
 import uk.gov.pay.directdebit.mandate.services.MandateQueryService;
 import uk.gov.pay.directdebit.mandate.services.MandateStateUpdateService;
-import uk.gov.pay.directdebit.payments.fixtures.PaymentFixture;
-import uk.gov.pay.directdebit.payments.model.Payment;
-import uk.gov.pay.directdebit.payments.model.PaymentState;
-import uk.gov.pay.directdebit.payments.model.PaymentStatesGraph;
-import uk.gov.pay.directdebit.payments.services.PaymentService;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -36,31 +30,20 @@ public class ExpireServiceTest {
 
     @DropwizardTestContext
     private TestContext testContext;
-
-    private PaymentStatesGraph paymentStatesGraph = new PaymentStatesGraph();
+    
     private MandateStatesGraph mandateStatesGraph = new MandateStatesGraph();
-    @Mock
-    private PaymentService paymentService;
+
     @Mock
     private MandateQueryService mandateQueryService;
+    
     @Mock
     private MandateStateUpdateService mandateStateUpdateService;
+    
     private ExpireService expireService;
     
     @Before
     public void setup() {
-        expireService = new ExpireService(paymentService, mandateStatesGraph, paymentStatesGraph, mandateQueryService, mandateStateUpdateService);
-    }
-    
-    @Test
-    public void expirePayments_shouldCallTransactionServiceWithPriorStatesToPending() {
-        Payment payment = PaymentFixture.aPaymentFixture().withState(PaymentState.CREATED).toEntity();
-        when(paymentService
-                .findAllPaymentsBySetOfStatesAndCreationTime(eq(paymentStatesGraph.getPriorStates(PaymentState.SUBMITTED_TO_PROVIDER)), any()))
-                .thenReturn(Collections.singletonList(payment));
-        
-        int numberOfExpiredPayments = expireService.expirePayments();
-        assertEquals(1, numberOfExpiredPayments);
+        expireService = new ExpireService(mandateStatesGraph, mandateQueryService, mandateStateUpdateService);
     }
 
     @Test
@@ -71,13 +54,6 @@ public class ExpireServiceTest {
                 .thenReturn(Collections.singletonList(mandate));
         int numberOfExpiredMandates = expireService.expireMandates();
         assertEquals(1, numberOfExpiredMandates);
-    }
-
-    @Test
-    public void shouldGetCorrectPaymentsStatesPriorToPending() {
-        Set<PaymentState> paymentStates = paymentStatesGraph.getPriorStates(PaymentState.SUBMITTED_TO_PROVIDER);
-        Set<PaymentState> expectedPaymentStates = new HashSet<>(Collections.singletonList(PaymentState.CREATED));
-        assertEquals(expectedPaymentStates, paymentStates);
     }
 
     @Test


### PR DESCRIPTION
This is a hang-over from one-off payments. Remove code responsible for expiry but keep the expired payments count in the resource response as this may be consumed by the initiating task.