### PR TITLE
PP-5478 Change types of DB columns that hold GoCardless description

### DIFF
--- a/src/main/resources/migrations/00062_alter_tables_gocardless_events_mandates_payments_alter_columns_details_description_state_details_description.sql
+++ b/src/main/resources/migrations/00062_alter_tables_gocardless_events_mandates_payments_alter_columns_details_description_state_details_description.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table_gocardless_events_alter_column_details_description
+ALTER TABLE gocardless_events ALTER COLUMN details_description SET DATA TYPE TEXT;
+--rollback ALTER TABLE gocardless_events ALTER COLUMN details_description SET DATA TYPE VARCHAR(255);
+
+--changeset uk.gov.pay:alter_table_mandates_alter_column_state_details_description
+ALTER TABLE mandates ALTER COLUMN state_details_description SET DATA TYPE TEXT;
+--rollback ALTER TABLE mandates ALTER COLUMN state_details_description SET DATA TYPE VARCHAR(255);
+
+--changeset uk.gov.pay:alter_table_payments_alter_column_state_details_description
+ALTER TABLE payments ALTER COLUMN state_details_description SET DATA TYPE TEXT;
+--rollback ALTER TABLE payments ALTER COLUMN state_details_description SET DATA TYPE VARCHAR(255);


### PR DESCRIPTION
Change the types of database columns that store `details.description` from GoCardless events from `VARCHAR(255)` to `TEXT` because GoCardless like to be verbose sometimes.

Affected columns are:

• `details_description` in `gocardless_events`
• `state_details_description` in `mandates`
• `state_details_description` in `payments`