### PR TITLE
PP-5451 Remove internal_event_id from select statements

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDao.java
@@ -74,7 +74,6 @@ public interface GoCardlessEventDao {
     Long insert(@BindBean GoCardlessEvent goCardlessEvent);
 
     @SqlQuery("SELECT id, " +
-            "internal_event_id, " +
             "event_id, " +
             "action, " +
             "created_at, " +
@@ -107,7 +106,6 @@ public interface GoCardlessEventDao {
                                                                   @BindList("applicableActions") Set<String> applicableActions);
 
     @SqlQuery("SELECT id, " +
-            "internal_event_id, " +
             "event_id, " +
             "action, " +
             "created_at, " +

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoITest.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoITest.java
@@ -50,7 +50,6 @@ public class GoCardlessEventDaoITest {
         Map<String, Object> goCardlessEvent = testContext.getDatabaseTestHelper().getGoCardlessEventById(id);
 
         assertThat(goCardlessEvent.get("id"), is(id));
-        assertThat(goCardlessEvent.get("internal_event_id"), is(nullValue()));
         assertThat(goCardlessEvent.get("event_id"), is(goCardlessEventFixture.getGoCardlessEventId().toString()));
         assertThat(goCardlessEvent.get("action"), is(goCardlessEventFixture.getAction()));
         assertThat(goCardlessEvent.get("resource_type"), is(goCardlessEventFixture.getResourceType().toString()));


### PR DESCRIPTION
Remove selecting internal_event_id from gocardless_events table so that the column can be dropped.