### PR TITLE
PP-5455 Add REFUNDS and SUBSCRIPTIONS to GoCardlessResourceType

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessResourceType.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessResourceType.java
@@ -1,11 +1,8 @@
 package uk.gov.pay.directdebit.events.model;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public enum GoCardlessResourceType {
-    PAYMENTS, MANDATES, PAYOUTS, UNHANDLED;
-    private static final Logger LOGGER = LoggerFactory.getLogger(GoCardlessResourceType.class);
+
+    PAYMENTS, MANDATES, PAYOUTS, REFUNDS, SUBSCRIPTIONS;
 
     public static GoCardlessResourceType fromString(String type) {
         for (GoCardlessResourceType typeEnum : GoCardlessResourceType.values()) {
@@ -13,7 +10,7 @@ public enum GoCardlessResourceType {
                 return typeEnum;
             }
         }
-        LOGGER.warn("Unhandled resource type received in a GoCardless Webhook: {}", type);
-        return UNHANDLED;
+        throw new IllegalArgumentException("Unhandled GoCardless resource_type " + type);
     }
+
 }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
@@ -33,7 +33,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.MANDATES;
 import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.PAYMENTS;
-import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.UNHANDLED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.REFUNDS;
+import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.SUBSCRIPTIONS;
 import static uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture.aGoCardlessEventFixture;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -74,8 +75,17 @@ public class WebhookGoCardlessServiceTest {
     }
 
     @Test
-    public void shouldStoreEventsWithAnUnhandledResource() {
-        GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture().withResourceType(UNHANDLED).withAction("created").toEntity();
+    public void shouldStoreButNotHandleEventsWithRefundsResource() {
+        GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture().withResourceType(REFUNDS).withAction("created").toEntity();
+
+        List<GoCardlessEvent> events = Collections.singletonList(goCardlessEvent);
+        webhookGoCardlessService.handleEvents(events);
+        verify(mockedGoCardlessEventService).storeEvent(goCardlessEvent);
+    }
+
+    @Test
+    public void shouldStoreButNotHandleEventsWithSubscriptionsResource() {
+        GoCardlessEvent goCardlessEvent = aGoCardlessEventFixture().withResourceType(SUBSCRIPTIONS).withAction("created").toEntity();
 
         List<GoCardlessEvent> events = Collections.singletonList(goCardlessEvent);
         webhookGoCardlessService.handleEvents(events);


### PR DESCRIPTION
Add `REFUNDS` and `SUBSCRIPTIONS` to `GoCardlessResourceType` enum. When we receive a webhook event from GoCardless with a `"resource_type"` of `"refunds"` or `"subscriptions"`, we will convert it to a value from the enum before persisting to the database. Without `REFUNDS` and `SUBSCRIPTIONS` in the enum, we were persisting the default `UNHANDLED` (which has now been removed).