### PR TITLE
PP-5459 Increase minimum amount for payments to 100 pence

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/CollectPaymentRequestValidator.java
@@ -13,7 +13,7 @@ public class CollectPaymentRequestValidator extends ApiValidation {
     private final static String REFERENCE_KEY = "reference";
     private final static String MANDATE_ID_KEY = "mandate_id";
 
-    private final static int MIN_AMOUNT_IN_PENCE = 1;
+    private final static int MIN_AMOUNT_IN_PENCE = 100;
     private final static int MAX_AMOUNT_IN_PENCE = 5000_00;
 
     private final static Map<String, Function<String, Boolean>> validators =


### PR DESCRIPTION
Gocardless have a minimum of 100 pence for payments. This increases the minimum
amount used for validation and brings it inline with PublicApi and GoCardless.