### PR TITLE
PP-5455 Add integration test for GoCardless late_failure_settled

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceMandateActionsIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceMandateActionsIT.java
@@ -78,7 +78,7 @@ public class WebhookGoCardlessResourceMandateActionsIT {
         postWebhook("gocardless-webhook-mandate-submitted.json");
 
         Map<String, Object> mandate = testContext.getDatabaseTestHelper().getMandateById(mandateFixture.getId());
-        assertThat(mandate.get("state"), is("SUBMITTED_TO_BANK"));
+        assertThat(mandate.get("state"), is(MandateState.SUBMITTED_TO_BANK.toString()));
         assertThat(mandate.get("state_details"), is("mandate_submitted"));
         assertThat(mandate.get("state_details_description"), is("The mandate has been submitted to the banks."));
     }
@@ -135,11 +135,11 @@ public class WebhookGoCardlessResourceMandateActionsIT {
 
     @Test
     @Ignore
-    public void expiredChangesStateToFailed() {
+    public void expiredChangesStateToExpired() {
         postWebhook("gocardless-webhook-mandate-expired.json");
 
         Map<String, Object> mandate = testContext.getDatabaseTestHelper().getMandateById(mandateFixture.getId());
-        assertThat(mandate.get("state"), is(MandateState.USER_SETUP_EXPIRED.toString()));
+        assertThat(mandate.get("state"), is(MandateState.EXPIRED.toString()));
         assertThat(mandate.get("state_details"), is("mandate_expired"));
         assertThat(mandate.get("state_details_description"), is("The mandate is being marked as expired, because no payments have been collected " +
                 "against it for the dormancy period of your service user number. If you have access to the mandate reinstation API endpoint, you can use " +

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourcePaymentActionsIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourcePaymentActionsIT.java
@@ -83,7 +83,7 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
         postWebhook("gocardless-webhook-payment-customer-approval-denied.json");
 
         Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
-        assertThat(payment.get("state"), is("CUSTOMER_APPROVAL_DENIED"));
+        assertThat(payment.get("state"), is(PaymentState.CUSTOMER_APPROVAL_DENIED.toString()));
         assertThat(payment.get("state_details"), is("customer_approval_denied"));
         assertThat(payment.get("state_details_description"), is("The customer denied approval for this payment"));
     }
@@ -94,7 +94,7 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
         postWebhook("gocardless-webhook-payment-submitted.json");
 
         Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
-        assertThat(payment.get("state"), is("SUBMITTED_TO_BANK"));
+        assertThat(payment.get("state"), is(PaymentState.SUBMITTED_TO_BANK.toString()));
         assertThat(payment.get("state_details"), is("payment_submitted"));
         assertThat(payment.get("state_details_description"), is("Payment submitted to the banks. As a result, it can no longer be cancelled."));
     }
@@ -105,7 +105,7 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
         postWebhook("gocardless-webhook-payment-confirmed.json");
 
         Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
-        assertThat(payment.get("state"), is("COLLECTED_BY_PROVIDER"));
+        assertThat(payment.get("state"), is(PaymentState.COLLECTED_BY_PROVIDER.toString()));
         assertThat(payment.get("state_details"), is("payment_confirmed"));
         assertThat(payment.get("state_details_description"), is("Enough time has passed since the payment was submitted for the banks to return an " +
                 "error, so this payment is now confirmed."));
@@ -117,7 +117,7 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
         postWebhook("gocardless-webhook-payment-cancelled.json");
 
         Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
-        assertThat(payment.get("state"), is("USER_SETUP_CANCELLED"));
+        assertThat(payment.get("state"), is(PaymentState.CANCELLED.toString()));
         assertThat(payment.get("state_details"), is("mandate_cancelled"));
         assertThat(payment.get("state_details_description"), is("The mandate for this payment was cancelled at a bank branch."));
     }
@@ -142,7 +142,7 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
         postWebhook("gocardless-webhook-payment-charged-back.json");
 
         Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
-        assertThat(payment.get("state"), is("INDEMNITY_CLAIM"));
+        assertThat(payment.get("state"), is(PaymentState.INDEMNITY_CLAIM.toString()));
         assertThat(payment.get("state_details"), is("authorisation_disputed"));
         assertThat(payment.get("state_details_description"), is("The customer has disputed that the amount taken differs from the amount they were " +
                 "notified of."));
@@ -154,18 +154,28 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
         postWebhook("gocardless-webhook-payment-chargeback-cancelled.json");
 
         Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
-        assertThat(payment.get("state"), is("PAID_OUT"));
+        assertThat(payment.get("state"), is(PaymentState.PAID_OUT.toString()));
         assertThat(payment.get("state_details"), is("payment_confirmed"));
         assertThat(payment.get("state_details_description"), is("The chargeback for this payment was reversed"));
     }
 
     @Test
     @Ignore
+    public void lateFailureSettledChangesStateToFailed() {
+        postWebhook("gocardless-webhook-payment-late-failure-settled.json");
+
+        Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
+        assertThat(payment.get("state"), is(PaymentState.FAILED.toString()));
+        assertThat(payment.get("state_details"), is("late_failure_settled"));
+        assertThat(payment.get("state_details_description"), is("This late failed payment has been settled against a payout."));
+    }
+
+    @Test
     public void paidOutChangesStateToPaidOut() {
         postWebhook("gocardless-webhook-payment-paid-out.json");
 
         Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
-        assertThat(payment.get("state"), is("PAID_OUT"));
+        assertThat(payment.get("state"), is(PaymentState.PAID_OUT.toString()));
         assertThat(payment.get("state_details"), is("payment_paid_out"));
         assertThat(payment.get("state_details_description"), is("The payment has been paid out by GoCardless."));
     }
@@ -176,7 +186,7 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
         postWebhook("gocardless-webhook-payment-chargeback-settled.json");
 
         Map<String, Object> payment = testContext.getDatabaseTestHelper().getPaymentById(paymentFixture.getId());
-        assertThat(payment.get("state"), is("INDEMNITY_CLAIM"));
+        assertThat(payment.get("state"), is(PaymentState.INDEMNITY_CLAIM.toString()));
         assertThat(payment.get("state_details"), is("chargeback_settled"));
         assertThat(payment.get("state_details_description"), is("This charged back payment has been settled against a payout."));
     }

--- a/src/test/resources/gocardless-webhook-payment-late-failure-settled.json
+++ b/src/test/resources/gocardless-webhook-payment-late-failure-settled.json
@@ -1,0 +1,20 @@
+{
+  "events": [
+    {
+      "id": "EVTESTE4SCQR3S",
+      "created_at": "2019-07-29T08:57:57.943Z",
+      "resource_type": "payments",
+      "action": "late_failure_settled",
+      "links": {
+        "payment": "PM000JWCBM6ABD",
+        "organisation": "OR00003V8M32F0"
+      },
+      "details": {
+        "origin": "gocardless",
+        "cause": "late_failure_settled",
+        "description": "This late failed payment has been settled against a payout."
+      },
+      "metadata": {}
+    }
+  ]
+}


### PR DESCRIPTION
Add integration test to check that we set the state of a payment to `FAILED` if we receive a webhook from GoCardless with an event with a payment `late_failure_settled` action. Ignored for now until we actually implement this behaviour.

Also enable the test that we set the state of a payment to `PAID_OUT` if we receive a webhook from GoCardless with an event with a payment `paid_out` action because it works now and make some small correctness tweaks to the remaining tests.