### PR TITLE
PP-5451 Move payment updating to PaymentService

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
@@ -110,6 +110,22 @@ public class Payment {
                 chargeDate);
     }
 
+    @Override
+    public String toString() {
+        return "Payment{" +
+                "id=" + id +
+                ", externalId='" + externalId + '\'' +
+                ", amount=" + amount +
+                ", state=" + state +
+                ", stateDetails='" + stateDetails + '\'' +
+                ", stateDetailsDescription='" + stateDetailsDescription + '\'' +
+                ", reference='" + reference + '\'' +
+                ", providerId=" + providerId +
+                ", createdDate=" + createdDate +
+                ", mandate=" + mandate +
+                ", chargeDate=" + chargeDate +
+                '}';
+    }
 
     public static final class PaymentBuilder {
         private Long id;

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/SandboxService.java
@@ -10,14 +10,12 @@ import uk.gov.pay.directdebit.mandate.model.PaymentProviderMandateIdAndBankRefer
 import uk.gov.pay.directdebit.mandate.model.SandboxMandateId;
 import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
-import uk.gov.pay.directdebit.payments.dao.PaymentDao;
 import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProvider;
 import uk.gov.pay.directdebit.payments.model.DirectDebitPaymentProviderCommandService;
 import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentIdAndChargeDate;
 import uk.gov.pay.directdebit.payments.model.SandboxPaymentId;
 
-import javax.inject.Inject;
 import java.time.LocalDate;
 import java.util.Optional;
 
@@ -25,13 +23,6 @@ public class SandboxService implements DirectDebitPaymentProvider, DirectDebitPa
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SandboxService.class);
     private static final int DAYS_TO_COLLECTION = 4;
-
-    private final PaymentDao paymentDao;
-
-    @Inject
-    public SandboxService(PaymentDao paymentDao) {
-        this.paymentDao = paymentDao;
-    }
 
     @Override
     public PaymentProviderMandateIdAndBankReference confirmMandate(Mandate mandate, BankAccountDetails bankAccountDetails) {
@@ -44,17 +35,9 @@ public class SandboxService implements DirectDebitPaymentProvider, DirectDebitPa
     @Override
     public PaymentProviderPaymentIdAndChargeDate collect(Mandate mandate, Payment payment) {
         LOGGER.info("Collecting payment for sandbox, mandate with id: {}, payment with id: {}", mandate.getExternalId(), payment.getExternalId());
-        var providerIdAndChargeDate = new PaymentProviderPaymentIdAndChargeDate(
+        return new PaymentProviderPaymentIdAndChargeDate(
                 SandboxPaymentId.valueOf(payment.getExternalId()),
                 LocalDate.now().plusDays(DAYS_TO_COLLECTION));
-
-        Payment updatePayment = Payment.PaymentBuilder.fromPayment(payment)
-                .withProviderId(providerIdAndChargeDate.getPaymentProviderPaymentId())
-                .withChargeDate(providerIdAndChargeDate.getChargeDate())
-                .build();
-
-        paymentDao.updateProviderIdAndChargeDate(updatePayment);
-        return providerIdAndChargeDate;
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/SandboxServiceTest.java
@@ -4,8 +4,6 @@ import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.directdebit.common.model.subtype.SunName;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
@@ -15,7 +13,6 @@ import uk.gov.pay.directdebit.payers.api.BankAccountValidationResponse;
 import uk.gov.pay.directdebit.payers.model.AccountNumber;
 import uk.gov.pay.directdebit.payers.model.BankAccountDetails;
 import uk.gov.pay.directdebit.payers.model.SortCode;
-import uk.gov.pay.directdebit.payments.dao.PaymentDao;
 import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 import uk.gov.pay.directdebit.payments.fixtures.PaymentFixture;
 import uk.gov.pay.directdebit.payments.model.Payment;
@@ -28,25 +25,20 @@ import java.util.Optional;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static uk.gov.pay.directdebit.mandate.fixtures.MandateFixture.aMandateFixture;
 import static uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture.aGatewayAccountFixture;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SandboxServiceTest {
-    
+
     private SandboxService service;
 
     private GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture();
     private MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture);
 
-    @Mock
-    protected PaymentDao paymentDao;
-
     @Before
     public void setUp() {
-        service = new SandboxService(paymentDao);
+        service = new SandboxService();
     }
 
     @Test
@@ -72,8 +64,6 @@ public class SandboxServiceTest {
 
         assertThat(providerPaymentIdAndChargeDate.getChargeDate(), is(LocalDateMatchers
                 .within(1, ChronoUnit.DAYS, LocalDate.now().plusDays(4))));
-        
-        verify(paymentDao).updateProviderIdAndChargeDate(any(Payment.class));
     }
 
     @Test


### PR DESCRIPTION
Currently after submitting a payment, we call the DAO to update it both from GoCardlessService and SandboxService. This is different from what we do for a mandate, when the updating is done by the MandateService.

Move this behaviour to PaymentService to make this consistent and remove some duplication.