### PR TITLE
PP-5475 Update mandate external states

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
@@ -7,15 +7,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExternalMandateState {
-    CREATED("created", false),
-    STARTED("started", false),
-    PENDING("pending", false),
-    SUBMITTED("submitted", false),
-    ACTIVE("active", true),
-    INACTIVE("inactive", true),
-    CANCELLED("cancelled", true),
-    FAILED("failed", true),
-    ABANDONED("abandoned", true);
+    EXTERNAL_CREATED("created", false),
+    EXTERNAL_STARTED("started", false),
+    EXTERNAL_PENDING("pending", false),
+    EXTERNAL_ACTIVE("active", true),
+    EXTERNAL_INACTIVE("inactive", true),
+    EXTERNAL_CANCELLED("cancelled", true),
+    EXTERNAL_FAILED("failed", true),
+    EXTERNAL_ABANDONED("abandoned", true);
 
     private final String value;
     private final boolean finished;

--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
@@ -13,7 +13,9 @@ public enum ExternalMandateState {
     SUBMITTED("submitted", false),
     ACTIVE("active", true),
     INACTIVE("inactive", true),
-    CANCELLED("cancelled", true);
+    CANCELLED("cancelled", true),
+    FAILED("failed", true),
+    ABANDONED("abandoned", true);
 
     private final String value;
     private final boolean finished;

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateState.java
@@ -3,21 +3,22 @@ package uk.gov.pay.directdebit.mandate.model;
 import uk.gov.pay.directdebit.mandate.api.ExternalMandateState;
 import uk.gov.pay.directdebit.payments.model.DirectDebitState;
 
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.ABANDONED;
 import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.INACTIVE;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.PENDING;
 import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.STARTED;
 
 public enum MandateState implements DirectDebitState {
     CREATED(ExternalMandateState.CREATED),
     AWAITING_DIRECT_DEBIT_DETAILS(STARTED),
-    USER_CANCEL_NOT_ELIGIBLE(ExternalMandateState.CANCELLED),
-    SUBMITTED_TO_PROVIDER(ExternalMandateState.PENDING),
-    SUBMITTED_TO_BANK(ExternalMandateState.PENDING),
+    SUBMITTED_TO_PROVIDER(PENDING),
+    SUBMITTED_TO_BANK(PENDING),
     ACTIVE(ExternalMandateState.ACTIVE),
-    FAILED(INACTIVE),
+    FAILED(ExternalMandateState.FAILED),
     EXPIRED(INACTIVE),
     CANCELLED(ExternalMandateState.CANCELLED),
-    USER_SETUP_CANCELLED(INACTIVE),
-    USER_SETUP_EXPIRED(INACTIVE);
+    USER_SETUP_CANCELLED(ABANDONED),
+    USER_SETUP_EXPIRED(ABANDONED);
 
     private ExternalMandateState externalState;
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/MandateState.java
@@ -3,22 +3,26 @@ package uk.gov.pay.directdebit.mandate.model;
 import uk.gov.pay.directdebit.mandate.api.ExternalMandateState;
 import uk.gov.pay.directdebit.payments.model.DirectDebitState;
 
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.ABANDONED;
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.INACTIVE;
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.PENDING;
-import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.STARTED;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_ABANDONED;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_ACTIVE;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_CANCELLED;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_CREATED;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_FAILED;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_INACTIVE;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_PENDING;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_STARTED;
 
 public enum MandateState implements DirectDebitState {
-    CREATED(ExternalMandateState.CREATED),
-    AWAITING_DIRECT_DEBIT_DETAILS(STARTED),
-    SUBMITTED_TO_PROVIDER(PENDING),
-    SUBMITTED_TO_BANK(PENDING),
-    ACTIVE(ExternalMandateState.ACTIVE),
-    FAILED(ExternalMandateState.FAILED),
-    EXPIRED(INACTIVE),
-    CANCELLED(ExternalMandateState.CANCELLED),
-    USER_SETUP_CANCELLED(ABANDONED),
-    USER_SETUP_EXPIRED(ABANDONED);
+    CREATED(EXTERNAL_CREATED),
+    AWAITING_DIRECT_DEBIT_DETAILS(EXTERNAL_STARTED),
+    SUBMITTED_TO_PROVIDER(EXTERNAL_PENDING),
+    SUBMITTED_TO_BANK(EXTERNAL_PENDING),
+    ACTIVE(EXTERNAL_ACTIVE),
+    FAILED(EXTERNAL_FAILED),
+    EXPIRED(EXTERNAL_INACTIVE),
+    CANCELLED(EXTERNAL_CANCELLED),
+    USER_SETUP_CANCELLED(EXTERNAL_ABANDONED),
+    USER_SETUP_EXPIRED(EXTERNAL_ABANDONED);
 
     private ExternalMandateState externalState;
 

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/MandateService.java
@@ -52,6 +52,7 @@ import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_TOKE
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_USER_SETUP_CANCELLED;
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.MANDATE_USER_SETUP_CANCELLED_NOT_ELIGIBLE;
 import static uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider.GOCARDLESS;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_CREATED;
 import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.aMandate;
 import static uk.gov.pay.directdebit.mandate.model.Mandate.MandateBuilder.fromMandate;
 
@@ -204,7 +205,7 @@ public class MandateService {
                 accountExternalId,
                 mandate.getExternalId().toString())));
 
-        if (mandate.getState().toExternal() == ExternalMandateState.CREATED) {
+        if (mandate.getState().toExternal() == EXTERNAL_CREATED) {
             Token token = tokenService.generateNewTokenFor(mandate);
             dataLinks.add(createLink("next_url",
                     GET,

--- a/src/test/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParamsTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.directdebit.mandate.api.ExternalMandateState.EXTERNAL_CREATED;
 import static uk.gov.pay.directdebit.mandate.params.MandateSearchParams.MandateSearchParamsBuilder.aMandateSearchParams;
 
 public class MandateSearchParamsTest {
@@ -22,7 +23,7 @@ public class MandateSearchParamsTest {
         String serviceReference = "aServiceReference";
         String toDate = LocalDate.now().toString();
         String fromDate = LocalDate.now().minusDays(3).toString();
-        String mandateState = ExternalMandateState.CREATED.getState();
+        String mandateState = EXTERNAL_CREATED.getState();
         MandateBankStatementReference mandateBankStatementReference = 
                 MandateBankStatementReference.valueOf("bankReference");
         

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/CollectServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/CollectServiceTest.java
@@ -76,10 +76,10 @@ public class CollectServiceTest {
     @Test(expected = MandateStateInvalidException.class)
     @Parameters({
             "CREATED", 
-            "AWAITING_DIRECT_DEBIT_DETAILS", 
-            "USER_CANCEL_NOT_ELIGIBLE", 
+            "AWAITING_DIRECT_DEBIT_DETAILS",
             "FAILED", 
             "EXPIRED", 
+            "CANCELLED",
             "USER_SETUP_CANCELLED", 
             "USER_SETUP_EXPIRED"})
     public void collectPaymentFailureForInvalidMandateStates(String mandateState) {


### PR DESCRIPTION
Update mandate external states to make it more obvious what they mean and the distinction between states that occurred during user setup and after the mandate has been submitted to the payment provider clearer.