### PR TITLE
PP-5483 Unwrap Optional in Notify Emails

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/services/UserNotificationService.java
@@ -60,7 +60,7 @@ public class UserNotificationService {
             return;
         }
 
-        var personalisation = Map.of(MANDATE_REFERENCE_KEY, mandate.getMandateBankStatementReference().toString(),
+        var personalisation = Map.of(MANDATE_REFERENCE_KEY, mandate.getMandateBankStatementReference().get().toString(),
                 BANK_ACCOUNT_LAST_DIGITS_KEY, mandate.getPayer().orElseThrow(
                         () -> new PayerNotFoundException(mandate.getExternalId())).getAccountNumberLastTwoDigits(),
                 STATEMENT_NAME_KEY, sunName.get().toString(),
@@ -94,7 +94,7 @@ public class UserNotificationService {
 
         var personalisation = Map.of(AMOUNT_KEY, formatToPounds(payment.getAmount()),
                 COLLECTION_DATE_KEY, DATE_TIME_FORMATTER.format(chargeDate),
-                MANDATE_REFERENCE_KEY, mandate.getMandateBankStatementReference().toString(),
+                MANDATE_REFERENCE_KEY, mandate.getMandateBankStatementReference().get().toString(),
                 BANK_ACCOUNT_LAST_DIGITS_KEY, mandate.getPayer().orElseThrow(
                         () -> new PayerNotFoundException(mandate.getExternalId())).getAccountNumberLastTwoDigits(),
                 STATEMENT_NAME_KEY, sunName.get().toString(),

--- a/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/notifications/services/UserNotificationServiceTest.java
@@ -76,7 +76,7 @@ public class UserNotificationServiceTest {
         SunName sunName = SunName.of("test sun Name");
         when(mockSunService.getSunNameFor(mandate)).thenReturn(Optional.of(sunName));
         HashMap<String, String> emailPersonalisation = new HashMap<>();
-        emailPersonalisation.put("mandate reference", mandate.getMandateBankStatementReference().toString());
+        emailPersonalisation.put("mandate reference", mandate.getMandateBankStatementReference().get().toString());
         emailPersonalisation.put("bank account last 2 digits", mandate.getPayer().get().getAccountNumberLastTwoDigits());
         emailPersonalisation.put("statement name", sunName.toString());
         emailPersonalisation.put("dd guarantee link", "https://frontend.url.test/direct-debit-guarantee");
@@ -114,7 +114,7 @@ public class UserNotificationServiceTest {
         when(mockSunService.getSunNameFor(mandate)).thenReturn(Optional.of(sunName));
         HashMap<String, String> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put("amount", "123.45");
-        emailPersonalisation.put("mandate reference", mandate.getMandateBankStatementReference().toString());
+        emailPersonalisation.put("mandate reference", mandate.getMandateBankStatementReference().get().toString());
         emailPersonalisation.put("collection date", payment.getChargeDate().get()
                 .format(DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.UK)));
         emailPersonalisation.put("bank account last 2 digits", payerFixture.getAccountNumberLastTwoDigits());


### PR DESCRIPTION
- Currently emails sent from notify contain optional objects which are
not unwrapped, when Optional.toString() is called on them this then
displays confusing output to the user, eg Optional[YourSunOutputHere],
to fix this the Optional is now fully unwrapped with Optional.get()
beforehand.
