### PR TITLE
PP-5455 Map mandate expired GoCardless event to expired state

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessEventToMandateStateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessEventToMandateStateMapper.java
@@ -10,18 +10,17 @@ import java.util.Set;
 
 import static uk.gov.pay.directdebit.mandate.model.MandateState.ACTIVE;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.CANCELLED;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.CREATED;
+import static uk.gov.pay.directdebit.mandate.model.MandateState.EXPIRED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.FAILED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED_TO_BANK;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED_TO_PROVIDER;
-import static uk.gov.pay.directdebit.mandate.model.MandateState.USER_SETUP_CANCELLED;
 
 class GoCardlessEventToMandateStateMapper {
     private static final Map<String, MandateState> GOCARDLESS_ACTION_TO_MANDATE_STATE = Map.of(
             "submitted", SUBMITTED_TO_BANK,
             "active", ACTIVE,
-            "cancelled", CANCELLED,
             "failed", FAILED,
+            "cancelled", CANCELLED,
+            "expired", EXPIRED,
             "reinstated", ACTIVE
     );
 

--- a/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessMandateStateCalculatorTest.java
@@ -80,8 +80,9 @@ public class GoCardlessMandateStateCalculatorTest {
     @Parameters({
             "submitted, SUBMITTED_TO_BANK",
             "active, ACTIVE",
-            "cancelled, CANCELLED",
             "failed, FAILED",
+            "cancelled, CANCELLED",
+            "expired, EXPIRED",
             "reinstated, ACTIVE"
     })
     public void goCardlessEventActionMapsToState(String action, String expectedState) {

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceMandateActionsIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourceMandateActionsIT.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,7 +72,6 @@ public class WebhookGoCardlessResourceMandateActionsIT {
     }
 
     @Test
-    @Ignore
     public void submittedChangesStateToSubmittedToBank() {
         postWebhook("gocardless-webhook-mandate-submitted.json");
 
@@ -95,7 +93,6 @@ public class WebhookGoCardlessResourceMandateActionsIT {
     }
 
     @Test
-    @Ignore
     public void reinstatedChangesStateToActive() {
         postWebhook("gocardless-webhook-mandate-reinstated.json");
 
@@ -134,7 +131,6 @@ public class WebhookGoCardlessResourceMandateActionsIT {
     }
 
     @Test
-    @Ignore
     public void expiredChangesStateToExpired() {
         postWebhook("gocardless-webhook-mandate-expired.json");
 

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourcePaymentActionsIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/resources/WebhookGoCardlessResourcePaymentActionsIT.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,7 +77,6 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
     }
 
     @Test
-    @Ignore
     public void customerApprovalDeniedChangesStateToCustomerApprovalDenied() {
         postWebhook("gocardless-webhook-payment-customer-approval-denied.json");
 
@@ -89,7 +87,6 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
     }
 
     @Test
-    @Ignore
     public void submittedChangesStateToSubmittedToBank() {
         postWebhook("gocardless-webhook-payment-submitted.json");
 
@@ -100,7 +97,6 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
     }
 
     @Test
-    @Ignore
     public void confirmedChangesStateToCollectedByProvider() {
         postWebhook("gocardless-webhook-payment-confirmed.json");
 
@@ -112,7 +108,6 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
     }
 
     @Test
-    @Ignore
     public void cancelledChangesStateToCancelled() {
         postWebhook("gocardless-webhook-payment-cancelled.json");
 
@@ -137,7 +132,6 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
     }
 
     @Test
-    @Ignore
     public void chargedBackChangesStateToIndemnityClaim() {
         postWebhook("gocardless-webhook-payment-charged-back.json");
 
@@ -149,7 +143,6 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
     }
 
     @Test
-    @Ignore
     public void chargebackCancelledChangesStateToPaidOut() {
         postWebhook("gocardless-webhook-payment-chargeback-cancelled.json");
 
@@ -160,7 +153,6 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
     }
 
     @Test
-    @Ignore
     public void lateFailureSettledChangesStateToFailed() {
         postWebhook("gocardless-webhook-payment-late-failure-settled.json");
 
@@ -181,7 +173,6 @@ public class WebhookGoCardlessResourcePaymentActionsIT {
     }
 
     @Test
-    @Ignore
     public void chargebackSettledChangesStateToIndemnityClaim() {
         postWebhook("gocardless-webhook-payment-chargeback-settled.json");
 


### PR DESCRIPTION
When calculating the state of a mandate from received GoCardless events, map the expired action to the expired state.

Enable some GoCardless webhook event integration tests that now pass because of this and related changes.