### PR TITLE
PP-5475 Remove finished property from state objects

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/api/ExternalMandateState.java
@@ -7,31 +7,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExternalMandateState {
-
-    EXTERNAL_CREATED("created", false),
-    EXTERNAL_STARTED("started", false),
-    EXTERNAL_PENDING("pending", false),
-    EXTERNAL_ACTIVE("active", true),
-    EXTERNAL_INACTIVE("inactive", true),
-    EXTERNAL_CANCELLED("cancelled", true),
-    EXTERNAL_FAILED("failed", true),
-    EXTERNAL_ABANDONED("abandoned", true),
-    EXTERNAL_ERROR("error", true);
+    EXTERNAL_CREATED("created"),
+    EXTERNAL_STARTED("started"),
+    EXTERNAL_PENDING("pending"),
+    EXTERNAL_ACTIVE("active"),
+    EXTERNAL_INACTIVE("inactive"),
+    EXTERNAL_CANCELLED("cancelled"),
+    EXTERNAL_FAILED("failed"),
+    EXTERNAL_ABANDONED("abandoned"),
+    EXTERNAL_ERROR("error");
 
     private final String value;
-    private final boolean finished;
 
-    ExternalMandateState(String value, boolean finished) {
+    ExternalMandateState(String value) {
         this.value = value;
-        this.finished = finished;
     }
 
     @JsonProperty("status")
     public String getState() {
         return value;
-    }
-
-    public boolean isFinished() {
-        return finished;
     }
 }

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentState.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentState.java
@@ -7,59 +7,30 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExternalPaymentState {
-    EXTERNAL_CREATED("created", false),
-    EXTERNAL_PENDING("pending", false),
-    EXTERNAL_SUCCESS("success", true),
-    EXTERNAL_FAILED("failed", true),
-    EXTERNAL_CANCELLED("cancelled", true),
-    EXTERNAL_PAID_OUT("paidout", true),
-    EXTERNAL_INDEMNITY_CLAIM("indemnityclaim", true),
-    EXTERNAL_ERROR("error", true);
+    EXTERNAL_CREATED("created"),
+    EXTERNAL_PENDING("pending"),
+    EXTERNAL_SUCCESS("success"),
+    EXTERNAL_FAILED("failed"),
+    EXTERNAL_CANCELLED("cancelled"),
+    EXTERNAL_PAID_OUT("paidout"),
+    EXTERNAL_INDEMNITY_CLAIM("indemnityclaim"),
+    EXTERNAL_ERROR("error");
 
     @JsonProperty("status")
     private final String status;
-    
-    private final boolean finished;
-    private final String code;
-    private final String message;
 
-    ExternalPaymentState(String status, boolean finished) {
+    ExternalPaymentState(String status) {
         this.status = status;
-        this.finished = finished;
-        this.code = null;
-        this.message = null;
     }
 
-    ExternalPaymentState(String status, boolean finished, String code, String message) {
-        this.status = status;
-        this.finished = finished;
-        this.code = code;
-        this.message = message;
-    }
-    
     public String getStatus() {
         return status;
-    }
-    public boolean isFinished() {
-        return finished;
-    }
-
-    
-    public String getCode() {
-        return code;
-    }
-
-    public String getMessage() {
-        return message;
     }
 
     @Override
     public String toString() {
         return "ExternalPaymentState{" +
                 "status='" + status + '\'' +
-                ", finished=" + finished +
-                ", code='" + code + '\'' +
-                ", message='" + message + '\'' +
                 '}';
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -129,7 +129,7 @@ public class MandateResourceIT {
         String hrefNextUrlPost = "http://Frontend/secure";
 
         response.body("links", containsLink("next_url", "GET", hrefNextUrl))
-                .body("links", containsLink("next_url_post", "POST", hrefNextUrlPost, 
+                .body("links", containsLink("next_url_post", "POST", hrefNextUrlPost,
                         "application/x-www-form-urlencoded", Map.of("chargeTokenId", token)));
 
         simulateFollowingNextUrlFromMandateCreation(externalMandateId);
@@ -141,7 +141,7 @@ public class MandateResourceIT {
                 .body("links", doesNotContainLink("next_url"))
                 .body("links", doesNotContainLink("next_url_post"));
     }
-    
+
     @Test
     public void payerEmailAndNameShouldBePopulatedOnInputOfUserDetails() throws Exception {
 
@@ -163,10 +163,10 @@ public class MandateResourceIT {
                 .body("payer.email", is(payerFixture.getEmail()))
                 .body("payer.name", is(payerFixture.getName()));
     }
-    
+
     @Test
     public void providerIdAndBankStatementReferenceShouldBePopulatedOnConfirmingAMandate() throws Exception {
-        
+
         String mandateExternalId = createMandate();
 
         simulateFollowingNextUrlFromMandateCreation(mandateExternalId);
@@ -175,7 +175,7 @@ public class MandateResourceIT {
 
         String providerId = "MD123";
         String reference = "REF-123";
-        
+
         simulateConfirmFromFrontend(mandateExternalId, providerId, reference);
 
         givenSetup()
@@ -285,7 +285,6 @@ public class MandateResourceIT {
                 .body("created_date", is(notNullValue()))
                 .body("state.status", is("created"))
                 .body("state.details", is(nullValue()))
-                .body("state.finished", is(false))
                 .body("service_reference", is("test-service-reference"))
                 .body("payment_provider", is(gatewayAccountFixture.getPaymentProvider().toString().toLowerCase()))
                 .body("provider_id", is(nullValue()))
@@ -304,8 +303,8 @@ public class MandateResourceIT {
         response.body("links", hasSize(3))
                 .body("links", containsLink("self", "GET", documentLocation))
                 .body("links", containsLink("next_url", "GET", hrefNextUrl))
-                .body("links", containsLink("next_url_post", "POST", hrefNextUrlPost, "application/x-www-form-urlencoded", 
-                    Map.of("chargeTokenId", token)
+                .body("links", containsLink("next_url_post", "POST", hrefNextUrlPost, "application/x-www-form-urlencoded",
+                        Map.of("chargeTokenId", token)
                 ));
     }
 
@@ -408,7 +407,6 @@ public class MandateResourceIT {
                 .body("mandate_id", is(mandateFixture.getExternalId().toString()))
                 .body("return_url", is(mandateFixture.getReturnUrl()))
                 .body("state.status", is(mandateFixture.getState().toExternal().getState()))
-                .body("state.finished", is(mandateFixture.getState().toExternal().isFinished()))
                 .body("state.details", is(mandateFixture.getStateDetails()))
                 .body("service_reference", is(mandateFixture.getServiceReference()))
                 .body("mandate_reference", is(notNullValue()))
@@ -460,7 +458,7 @@ public class MandateResourceIT {
                 .withState(AWAITING_DIRECT_DEBIT_DETAILS)
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .insert(testContext.getJdbi());
-        
+
         aGovUkPayEventFixture()
                 .withMandateId(testMandate.getId())
                 .withEventType(MANDATE_TOKEN_EXCHANGED)
@@ -483,7 +481,7 @@ public class MandateResourceIT {
     public void confirm_shouldCreateACustomerBankAccountMandate() {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
                 .withPaymentProvider(GOCARDLESS).insert(testContext.getJdbi());
-        
+
         MandateFixture mandateFixture = aMandateFixture()
                 .withState(MandateState.AWAITING_DIRECT_DEBIT_DETAILS)
                 .withGatewayAccountFixture(gatewayAccountFixture)

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -72,7 +72,6 @@ public class PaymentResourceIT {
     private static final String JSON_MANDATE_ID_KEY = "mandate_id";
     private static final String JSON_PAYMENT_PROVIDER_KEY = "payment_provider";
     private static final String JSON_STATE_STATUS_KEY = "state.status";
-    private static final String JSON_STATE_FINISHED_KEY = "state.finished";
     private static final String JSON_STATE_DETAILS_KEY = "state.details";
     private static final long AMOUNT = 6234L;
     private GatewayAccountFixture testGatewayAccount;
@@ -151,7 +150,6 @@ public class PaymentResourceIT {
                 .body(JSON_DESCRIPTION_KEY, is(expectedDescription))
                 .body(JSON_MANDATE_ID_KEY, is(mandateFixture.getExternalId().toString()))
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
-                .body(JSON_STATE_FINISHED_KEY, is(false))
                 .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
                 .body(JSON_PAYMENT_PROVIDER_KEY, is(SANDBOX.toString().toLowerCase()))
                 .contentType(JSON);
@@ -257,7 +255,6 @@ public class PaymentResourceIT {
                 .body(JSON_DESCRIPTION_KEY, is(expectedDescription))
                 .body(JSON_MANDATE_ID_KEY, is(mandate.getExternalId().toString()))
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
-                .body(JSON_STATE_FINISHED_KEY, is(false))
                 .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
                 .body(JSON_PAYMENT_PROVIDER_KEY, is(GOCARDLESS.toString().toLowerCase()))
                 .contentType(JSON);
@@ -283,7 +280,6 @@ public class PaymentResourceIT {
                 .body(JSON_DESCRIPTION_KEY, is(expectedDescription))
                 .body(JSON_MANDATE_ID_KEY, is(mandate.getExternalId().toString()))
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
-                .body(JSON_STATE_FINISHED_KEY, is(false))
                 .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
                 .body(JSON_PAYMENT_PROVIDER_KEY, is(GOCARDLESS.toString().toLowerCase()))
                 .contentType(JSON);
@@ -313,7 +309,6 @@ public class PaymentResourceIT {
                 .body(JSON_REFERENCE_KEY, is(paymentFixture.getReference()))
                 .body(JSON_DESCRIPTION_KEY, is(paymentFixture.getDescription()))
                 .body(JSON_STATE_STATUS_KEY, is(paymentFixture.getState().toExternal().getStatus()))
-                .body(JSON_STATE_FINISHED_KEY, is(false))
                 .body(JSON_STATE_DETAILS_KEY, is(paymentFixture.getStateDetails()));
     }
     

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResourceIT.java
@@ -383,7 +383,6 @@ public class PaymentSearchResourceIT { //TODO merge with PaymentResource
                 .contentType(JSON)
                 .body("count", is(3))
                 .body("results", hasSize(3))
-                .body("results[0].state.finished", is(true))
                 .body("results[0].state.status", is("cancelled"))
                 .body("results[0].state.details", is("state_details"));
     }


### PR DESCRIPTION
The "finished" property isn't very useful for direct debits as there aren't really final states, as mandates can be re-activated after they become inactive, and payments can be indemnity claimed. So remove this from the external state objects as it's no longer consumed by Public API.