### PR TITLE
PP-5455 Log errors for GoCardless events we don't handle

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessEvent.java
@@ -17,6 +17,9 @@ public class GoCardlessEvent implements Event {
     public static final String ACTION_MANDATE_EXPIRED = "expired";
     public static final String ACTION_MANDATE_REINSTATED = "reinstated";
     public static final String ACTION_MANDATE_REPLACED = "replaced";
+    public static final String ACTION_MANDATE_CUSTOMER_APPROVAL_GRANTED = "customer_approval_granted";
+    public static final String ACTION_MANDATE_CUSTOMER_APPROVAL_SKIPPED = "customer_approval_skipped";
+    public static final String ACTION_MANDATE_RESUBMISSION_REQUESTED = "resubmission_requested";
 
     public static final String ACTION_PAYMENT_SUBMITTED = "submitted";
     public static final String ACTION_PAYMENT_FAILED = "failed";

--- a/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessEvent.java
@@ -9,6 +9,12 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class GoCardlessEvent implements Event {
+    
+    public static final String ACTION_MANDATE_FAILED = "failed";
+    public static final String ACTION_MANDATE_CANCELLED = "cancelled";
+    public static final String ACTION_MANDATE_REPLACED = "replaced";
+    public static final String ACTION_PAYMENT_FAILED = "failed";
+    public static final String ACTION_PAYMENT_RESUBMISSION_REQUESTED = "resubmission_requested";
 
     private final Long id;
     private final String resourceId;

--- a/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessEvent.java
@@ -9,11 +9,25 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class GoCardlessEvent implements Event {
-    
+
+    public static final String ACTION_MANDATE_SUBMITTED = "submitted";
+    public static final String ACTION_MANDATE_ACTIVE = "active";
     public static final String ACTION_MANDATE_FAILED = "failed";
     public static final String ACTION_MANDATE_CANCELLED = "cancelled";
+    public static final String ACTION_MANDATE_EXPIRED = "expired";
+    public static final String ACTION_MANDATE_REINSTATED = "reinstated";
     public static final String ACTION_MANDATE_REPLACED = "replaced";
+
+    public static final String ACTION_PAYMENT_SUBMITTED = "submitted";
     public static final String ACTION_PAYMENT_FAILED = "failed";
+    public static final String ACTION_PAYMENT_PAID_OUT = "paid_out";
+    public static final String ACTION_PAYMENT_CUSTOMER_APPROVAL_DENIED = "customer_approval_denied";
+    public static final String ACTION_PAYMENT_CONFIRMED = "confirmed";
+    public static final String ACTION_PAYMENT_CANCELLED = "cancelled";
+    public static final String ACTION_PAYMENT_CHARGED_BACK = "charged_back";
+    public static final String ACTION_PAYMENT_CHARGEBACK_SETTLED = "chargeback_settled";
+    public static final String ACTION_PAYMENT_CHARGEBACK_CANCELLED = "chargeback_cancelled";
+    public static final String ACTION_PAYMENT_LATE_FAILURE_SETTLED = "late_failure_settled";
     public static final String ACTION_PAYMENT_RESUBMISSION_REQUESTED = "resubmission_requested";
 
     private final Long id;

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessEventToMandateStateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessEventToMandateStateMapper.java
@@ -8,6 +8,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_CANCELLED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_EXPIRED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_FAILED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_REINSTATED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_SUBMITTED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.ACTIVE;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.CANCELLED;
 import static uk.gov.pay.directdebit.mandate.model.MandateState.EXPIRED;
@@ -16,12 +22,12 @@ import static uk.gov.pay.directdebit.mandate.model.MandateState.SUBMITTED_TO_BAN
 
 class GoCardlessEventToMandateStateMapper {
     private static final Map<String, MandateState> GOCARDLESS_ACTION_TO_MANDATE_STATE = Map.of(
-            "submitted", SUBMITTED_TO_BANK,
-            "active", ACTIVE,
-            "failed", FAILED,
-            "cancelled", CANCELLED,
-            "expired", EXPIRED,
-            "reinstated", ACTIVE
+            ACTION_MANDATE_SUBMITTED, SUBMITTED_TO_BANK,
+            ACTION_MANDATE_ACTIVE, ACTIVE,
+            ACTION_MANDATE_FAILED, FAILED,
+            ACTION_MANDATE_CANCELLED, CANCELLED,
+            ACTION_MANDATE_EXPIRED, EXPIRED,
+            ACTION_MANDATE_REINSTATED, ACTIVE
     );
 
     static final Set<String> GOCARDLESS_ACTIONS_THAT_CHANGE_MANDATE_STATE = GOCARDLESS_ACTION_TO_MANDATE_STATE.keySet();

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessEventToPaymentStateMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessEventToPaymentStateMapper.java
@@ -8,6 +8,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_CANCELLED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_CHARGEBACK_CANCELLED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_CHARGEBACK_SETTLED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_CHARGED_BACK;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_CONFIRMED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_CUSTOMER_APPROVAL_DENIED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_FAILED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_LATE_FAILURE_SETTLED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_PAID_OUT;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_SUBMITTED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.CANCELLED;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.COLLECTED_BY_PROVIDER;
 import static uk.gov.pay.directdebit.payments.model.PaymentState.CUSTOMER_APPROVAL_DENIED;
@@ -18,16 +28,16 @@ import static uk.gov.pay.directdebit.payments.model.PaymentState.SUBMITTED_TO_BA
 
 public class GoCardlessEventToPaymentStateMapper {
     private static final Map<String, PaymentState> GOCARDLESS_ACTION_TO_PAYMENT_STATE = Map.of(
-            "submitted", SUBMITTED_TO_BANK,
-            "failed", FAILED,
-            "paid_out", PAID_OUT,
-            "customer_approval_denied", CUSTOMER_APPROVAL_DENIED,
-            "confirmed", COLLECTED_BY_PROVIDER,
-            "cancelled", CANCELLED,
-            "charged_back", INDEMNITY_CLAIM,
-            "chargeback_cancelled", PAID_OUT,
-            "late_failure_settled", FAILED,
-            "chargeback_settled", INDEMNITY_CLAIM
+            ACTION_PAYMENT_SUBMITTED, SUBMITTED_TO_BANK,
+            ACTION_PAYMENT_FAILED, FAILED,
+            ACTION_PAYMENT_PAID_OUT, PAID_OUT,
+            ACTION_PAYMENT_CUSTOMER_APPROVAL_DENIED, CUSTOMER_APPROVAL_DENIED,
+            ACTION_PAYMENT_CONFIRMED, COLLECTED_BY_PROVIDER,
+            ACTION_PAYMENT_CANCELLED, CANCELLED,
+            ACTION_PAYMENT_CHARGED_BACK, INDEMNITY_CLAIM,
+            ACTION_PAYMENT_CHARGEBACK_CANCELLED, PAID_OUT,
+            ACTION_PAYMENT_LATE_FAILURE_SETTLED, FAILED,
+            ACTION_PAYMENT_CHARGEBACK_SETTLED, INDEMNITY_CLAIM
     );
 
     static final Set<String> GOCARDLESS_ACTIONS_THAT_CHANGE_PAYMENT_STATE = GOCARDLESS_ACTION_TO_PAYMENT_STATE.keySet();

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
@@ -16,6 +16,7 @@ import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.services.PaymentQueryService;
 import uk.gov.pay.directdebit.payments.services.PaymentStateUpdater;
 import uk.gov.pay.directdebit.webhook.gocardless.services.handlers.SendEmailsForGoCardlessEventsHandler;
+import uk.gov.pay.directdebit.webhook.gocardless.services.handlers.UnhandledGoCardlessEventsLogger;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -57,7 +58,7 @@ public class WebhookGoCardlessService {
         events.forEach(goCardlessService::storeEvent);
         updateStatesForEvents(events);
         sendEmailsForGoCardlessEventsHandler.sendEmails(events);
-        //TODO goCardlessEventErrorLogger.logErrorsForEvents(events)
+        UnhandledGoCardlessEventsLogger.logUnhandledEvents(events);
     }
 
     private void updateStatesForEvents(List<GoCardlessEvent> events) {

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessService.java
@@ -38,27 +38,30 @@ public class WebhookGoCardlessService {
     private final MandateQueryService mandateQueryService;
     private final PaymentQueryService paymentQueryService;
     private final SendEmailsForGoCardlessEventsHandler sendEmailsForGoCardlessEventsHandler;
+    private final UnhandledGoCardlessEventsLogger unhandledGoCardlessEventsLogger;
 
     @Inject
     WebhookGoCardlessService(GoCardlessEventService goCardlessService,
                              MandateStateUpdater mandateStateUpdater,
                              PaymentStateUpdater paymentStateUpdater,
                              MandateQueryService mandateQueryService,
-                             PaymentQueryService paymentQueryService, 
-                             SendEmailsForGoCardlessEventsHandler sendEmailsForGoCardlessEventsHandler) {
+                             PaymentQueryService paymentQueryService,
+                             SendEmailsForGoCardlessEventsHandler sendEmailsForGoCardlessEventsHandler,
+                             UnhandledGoCardlessEventsLogger unhandledGoCardlessEventsLogger) {
         this.goCardlessService = goCardlessService;
         this.sendEmailsForGoCardlessEventsHandler = sendEmailsForGoCardlessEventsHandler;
         this.mandateStateUpdater = mandateStateUpdater;
         this.paymentStateUpdater = paymentStateUpdater;
         this.mandateQueryService = mandateQueryService;
         this.paymentQueryService = paymentQueryService;
+        this.unhandledGoCardlessEventsLogger = unhandledGoCardlessEventsLogger;
     }
 
     public void processEvents(List<GoCardlessEvent> events) {
         events.forEach(goCardlessService::storeEvent);
         updateStatesForEvents(events);
         sendEmailsForGoCardlessEventsHandler.sendEmails(events);
-        UnhandledGoCardlessEventsLogger.logUnhandledEvents(events);
+        unhandledGoCardlessEventsLogger.logUnhandledEvents(events);
     }
 
     private void updateStatesForEvents(List<GoCardlessEvent> events) {

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLogger.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLogger.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.directdebit.webhook.gocardless.services.handlers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_REPLACED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_RESUBMISSION_REQUESTED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.MANDATES;
+import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.PAYMENTS;
+
+public class UnhandledGoCardlessEventsLogger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnhandledGoCardlessEventsLogger.class);
+
+    private static Predicate<GoCardlessEvent> byValidEventsForMandateResourceTypes =
+            event -> MANDATES.equals(event.getResourceType());
+
+    private static Predicate<GoCardlessEvent> byValidEventsForPaymentsResourceTypes =
+            event -> PAYMENTS.equals(event.getResourceType());
+    
+    public static void logUnhandledEvents(List<GoCardlessEvent> events) {
+        events.stream().filter(byValidEventsForMandateResourceTypes).forEach(UnhandledGoCardlessEventsLogger::logErrorForUnexpectedMandateEvents);
+        events.stream().filter(byValidEventsForPaymentsResourceTypes).forEach(UnhandledGoCardlessEventsLogger::logErrorForUnexpectedPaymentEvents);
+    }
+    
+    private static void logErrorForUnexpectedMandateEvents(GoCardlessEvent event) {
+        if (event.getAction().equals(ACTION_MANDATE_REPLACED)) {
+            event.getLinksMandate().ifPresentOrElse(
+                    goCardlessMandateId -> LOGGER.error("Received a GoCardless event with action {} for mandate {}, " +
+                            "which we do not expect to receive and do not handle", event.getAction(), goCardlessMandateId),
+                    () -> LOGGER.error("Received a GoCardless event with action {} for an unspecified mandate, which we " +
+                            "do not expect to receive and do not handle", event.getAction()));
+        }
+    }
+
+    private static void logErrorForUnexpectedPaymentEvents(GoCardlessEvent event) {
+        if (event.getAction().equals(ACTION_PAYMENT_RESUBMISSION_REQUESTED)) {
+            event.getLinksPayment().ifPresentOrElse(
+                    goCardlessPaymentId -> LOGGER.error("Received a GoCardless event with action {} for payment {}, which " +
+                            "we do not expect to receive and do not handle", event.getAction(), goCardlessPaymentId),
+                    () -> LOGGER.error("Received a GoCardless event with action {} for an unspecified payment, which we do " +
+                            "not expect to receive and do not handle", event.getAction()));
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLogger.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLogger.java
@@ -5,9 +5,13 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_CUSTOMER_APPROVAL_GRANTED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_CUSTOMER_APPROVAL_SKIPPED;
 import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_REPLACED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_RESUBMISSION_REQUESTED;
 import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_RESUBMISSION_REQUESTED;
 import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.MANDATES;
 import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.PAYMENTS;
@@ -22,13 +26,23 @@ public class UnhandledGoCardlessEventsLogger {
     private static Predicate<GoCardlessEvent> byValidEventsForPaymentsResourceTypes =
             event -> PAYMENTS.equals(event.getResourceType());
     
-    public static void logUnhandledEvents(List<GoCardlessEvent> events) {
-        events.stream().filter(byValidEventsForMandateResourceTypes).forEach(UnhandledGoCardlessEventsLogger::logErrorForUnexpectedMandateEvents);
-        events.stream().filter(byValidEventsForPaymentsResourceTypes).forEach(UnhandledGoCardlessEventsLogger::logErrorForUnexpectedPaymentEvents);
+    private static Set<String> UNHANDLED_MANDATE_ACTIONS = Set.of(
+            ACTION_MANDATE_REPLACED,
+            ACTION_MANDATE_CUSTOMER_APPROVAL_GRANTED,
+            ACTION_MANDATE_CUSTOMER_APPROVAL_SKIPPED,
+            ACTION_MANDATE_RESUBMISSION_REQUESTED);
+    
+    private static Set<String> UNHANDLED_PAYMENT_ACTIONS = Set.of(
+            ACTION_PAYMENT_RESUBMISSION_REQUESTED
+    );
+    
+    public void logUnhandledEvents(List<GoCardlessEvent> events) {
+        events.stream().filter(byValidEventsForMandateResourceTypes).forEach(this::logErrorForUnexpectedMandateEvents);
+        events.stream().filter(byValidEventsForPaymentsResourceTypes).forEach(this::logErrorForUnexpectedPaymentEvents);
     }
     
-    private static void logErrorForUnexpectedMandateEvents(GoCardlessEvent event) {
-        if (event.getAction().equals(ACTION_MANDATE_REPLACED)) {
+    private void logErrorForUnexpectedMandateEvents(GoCardlessEvent event) {
+        if (UNHANDLED_MANDATE_ACTIONS.contains(event.getAction())) {
             event.getLinksMandate().ifPresentOrElse(
                     goCardlessMandateId -> LOGGER.error("Received a GoCardless event with action {} for mandate {}, " +
                             "which we do not expect to receive and do not handle", event.getAction(), goCardlessMandateId),
@@ -37,8 +51,8 @@ public class UnhandledGoCardlessEventsLogger {
         }
     }
 
-    private static void logErrorForUnexpectedPaymentEvents(GoCardlessEvent event) {
-        if (event.getAction().equals(ACTION_PAYMENT_RESUBMISSION_REQUESTED)) {
+    private void logErrorForUnexpectedPaymentEvents(GoCardlessEvent event) {
+        if (UNHANDLED_PAYMENT_ACTIONS.contains(event.getAction())) {
             event.getLinksPayment().ifPresentOrElse(
                     goCardlessPaymentId -> LOGGER.error("Received a GoCardless event with action {} for payment {}, which " +
                             "we do not expect to receive and do not handle", event.getAction(), goCardlessPaymentId),

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/WebhookGoCardlessServiceTest.java
@@ -20,6 +20,7 @@ import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.services.PaymentQueryService;
 import uk.gov.pay.directdebit.payments.services.PaymentStateUpdater;
 import uk.gov.pay.directdebit.webhook.gocardless.services.handlers.SendEmailsForGoCardlessEventsHandler;
+import uk.gov.pay.directdebit.webhook.gocardless.services.handlers.UnhandledGoCardlessEventsLogger;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,6 +55,9 @@ public class WebhookGoCardlessServiceTest {
     
     @Mock
     private PaymentQueryService mockedPaymentQueryService;
+    
+    @Mock
+    private UnhandledGoCardlessEventsLogger mockedUnhandledGoCardlessEventsLogger;
 
     @InjectMocks
     private WebhookGoCardlessService webhookGoCardlessService;

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLoggerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLoggerTest.java
@@ -1,0 +1,110 @@
+package uk.gov.pay.directdebit.webhook.gocardless.services.handlers;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
+import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentId;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_ACTIVE;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_REPLACED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_MANDATE_RESUBMISSION_REQUESTED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_FAILED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessEvent.ACTION_PAYMENT_RESUBMISSION_REQUESTED;
+import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.MANDATES;
+import static uk.gov.pay.directdebit.events.model.GoCardlessResourceType.PAYMENTS;
+import static uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture.aGoCardlessEventFixture;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnhandledGoCardlessEventsLoggerTest {
+    
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+    
+    @InjectMocks
+    private UnhandledGoCardlessEventsLogger unhandledGoCardlessEventsLogger;
+
+    @Captor
+    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+    
+    @Before
+    public void setUp() {
+        Logger root = (Logger) LoggerFactory.getLogger(UnhandledGoCardlessEventsLogger.class);
+        root.addAppender(mockAppender);
+    }
+
+    @Test
+    public void shouldLogForUnhandledMandateActions() {
+        GoCardlessEvent unhandledMandateEvent1 = aGoCardlessEventFixture()
+                .withResourceType(MANDATES)
+                .withAction(ACTION_MANDATE_REPLACED)
+                .withLinksMandate(GoCardlessMandateId.valueOf("test-mandate-id1"))
+                .toEntity();
+
+        GoCardlessEvent unhandledMandateEvent2 = aGoCardlessEventFixture()
+                .withResourceType(MANDATES)
+                .withAction(ACTION_MANDATE_RESUBMISSION_REQUESTED)
+                .withLinksMandate(GoCardlessMandateId.valueOf("test-mandate-id2"))
+                .toEntity();
+
+        GoCardlessEvent handledMandateEvent = aGoCardlessEventFixture()
+                .withResourceType(MANDATES)
+                .withAction(ACTION_MANDATE_ACTIVE)
+                .withLinksMandate(GoCardlessMandateId.valueOf("test-mandate-id3"))
+                .toEntity();
+
+        GoCardlessEvent unhandledPaymentEvent = aGoCardlessEventFixture()
+                .withResourceType(PAYMENTS)
+                .withAction(ACTION_PAYMENT_RESUBMISSION_REQUESTED)
+                .withLinksPayment(GoCardlessPaymentId.valueOf("test-payment-id1"))
+                .toEntity();
+        
+        GoCardlessEvent handledPaymentEvent = aGoCardlessEventFixture()
+                .withResourceType(PAYMENTS)
+                .withAction(ACTION_PAYMENT_FAILED)
+                .withLinksPayment(GoCardlessPaymentId.valueOf("test-payment-id2"))
+                .toEntity();
+
+        unhandledGoCardlessEventsLogger.logUnhandledEvents(List.of(
+                unhandledMandateEvent1,
+                unhandledMandateEvent2,
+                handledMandateEvent,
+                unhandledPaymentEvent,
+                handledPaymentEvent));
+        
+        verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
+
+        List<String> loggedMessages = getLoggedMessages();
+
+        assertThat(loggedMessages, containsInAnyOrder(
+                "Received a GoCardless event with action replaced for mandate test-mandate-id1, which we do not expect to receive and do not handle",
+                "Received a GoCardless event with action resubmission_requested for mandate test-mandate-id2, which we do not expect to receive and do not handle",
+                "Received a GoCardless event with action resubmission_requested for payment test-payment-id1, which we do not expect to receive and do not handle"));
+    }
+    
+    private List<String> getLoggedMessages() {
+        return loggingEventArgumentCaptor
+                    .getAllValues()
+                    .stream()
+                    .map(LoggingEvent::getFormattedMessage)
+                    .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Log errors for GoCardless event actions that we've identified as needing operations performed if we receive them, but which we do not expect to receive in standard usage so do not handle.