### PR TITLE
PP-5455 Log errors for unhandled GoCardless event resource types

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLogger.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLogger.java
@@ -3,6 +3,7 @@ package uk.gov.pay.directdebit.webhook.gocardless.services.handlers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.events.model.GoCardlessResourceType;
 
 import java.util.List;
 import java.util.Set;
@@ -38,9 +39,17 @@ public class UnhandledGoCardlessEventsLogger {
             event -> PAYMENTS.equals(event.getResourceType())
                     && UNHANDLED_PAYMENT_ACTIONS.contains(event.getAction());
 
+    private static Predicate<GoCardlessEvent> byUnhandledResourceTypes =
+            event -> Set.of(GoCardlessResourceType.REFUNDS, GoCardlessResourceType.SUBSCRIPTIONS)
+                    .contains(event.getResourceType());
+
     public void logUnhandledEvents(List<GoCardlessEvent> events) {
         events.stream().filter(byUnhandledMandateActions).forEach(this::logErrorForUnexpectedMandateEvent);
         events.stream().filter(byUndandledPaymentActions).forEach(this::logErrorForUnexpectedPaymentEvent);
+        events.stream().filter(byUnhandledResourceTypes).forEach(event ->
+                LOGGER.error("Received a GoCardless event with id {} for organisation {} with resource type {}, which " +
+                                "we do not expect to receive and do not handle.", event.getGoCardlessEventId(),
+                        event.getLinksOrganisation(), event.getResourceType()));
     }
 
     private void logErrorForUnexpectedMandateEvent(GoCardlessEvent event) {
@@ -48,7 +57,7 @@ public class UnhandledGoCardlessEventsLogger {
                 goCardlessMandateId -> LOGGER.error("Received a GoCardless event with id {} for organisation {} with " +
                                 "action {} for mandate {}, which we do not expect to receive and do not handle.",
                         event.getGoCardlessEventId(), event.getLinksOrganisation(), event.getAction(), goCardlessMandateId),
-                () -> LOGGER.error("Received a GoCardless eventwith id {} for organisation {} with action {} for an " +
+                () -> LOGGER.error("Received a GoCardless event with id {} for organisation {} with action {} for an " +
                                 "unspecified mandate, which we do not expect to receive and do not handle.",
                         event.getGoCardlessEventId(), event.getLinksOrganisation(), event.getAction()));
     }

--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLogger.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLogger.java
@@ -20,44 +20,46 @@ public class UnhandledGoCardlessEventsLogger {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UnhandledGoCardlessEventsLogger.class);
 
-    private static Predicate<GoCardlessEvent> byValidEventsForMandateResourceTypes =
-            event -> MANDATES.equals(event.getResourceType());
-
-    private static Predicate<GoCardlessEvent> byValidEventsForPaymentsResourceTypes =
-            event -> PAYMENTS.equals(event.getResourceType());
-    
     private static Set<String> UNHANDLED_MANDATE_ACTIONS = Set.of(
             ACTION_MANDATE_REPLACED,
             ACTION_MANDATE_CUSTOMER_APPROVAL_GRANTED,
             ACTION_MANDATE_CUSTOMER_APPROVAL_SKIPPED,
             ACTION_MANDATE_RESUBMISSION_REQUESTED);
-    
+
     private static Set<String> UNHANDLED_PAYMENT_ACTIONS = Set.of(
             ACTION_PAYMENT_RESUBMISSION_REQUESTED
     );
-    
+
+    private static Predicate<GoCardlessEvent> byUnhandledMandateActions =
+            event -> MANDATES.equals(event.getResourceType())
+                    && UNHANDLED_MANDATE_ACTIONS.contains(event.getAction());
+
+    private static Predicate<GoCardlessEvent> byUndandledPaymentActions =
+            event -> PAYMENTS.equals(event.getResourceType())
+                    && UNHANDLED_PAYMENT_ACTIONS.contains(event.getAction());
+
     public void logUnhandledEvents(List<GoCardlessEvent> events) {
-        events.stream().filter(byValidEventsForMandateResourceTypes).forEach(this::logErrorForUnexpectedMandateEvents);
-        events.stream().filter(byValidEventsForPaymentsResourceTypes).forEach(this::logErrorForUnexpectedPaymentEvents);
-    }
-    
-    private void logErrorForUnexpectedMandateEvents(GoCardlessEvent event) {
-        if (UNHANDLED_MANDATE_ACTIONS.contains(event.getAction())) {
-            event.getLinksMandate().ifPresentOrElse(
-                    goCardlessMandateId -> LOGGER.error("Received a GoCardless event with action {} for mandate {}, " +
-                            "which we do not expect to receive and do not handle", event.getAction(), goCardlessMandateId),
-                    () -> LOGGER.error("Received a GoCardless event with action {} for an unspecified mandate, which we " +
-                            "do not expect to receive and do not handle", event.getAction()));
-        }
+        events.stream().filter(byUnhandledMandateActions).forEach(this::logErrorForUnexpectedMandateEvent);
+        events.stream().filter(byUndandledPaymentActions).forEach(this::logErrorForUnexpectedPaymentEvent);
     }
 
-    private void logErrorForUnexpectedPaymentEvents(GoCardlessEvent event) {
-        if (UNHANDLED_PAYMENT_ACTIONS.contains(event.getAction())) {
-            event.getLinksPayment().ifPresentOrElse(
-                    goCardlessPaymentId -> LOGGER.error("Received a GoCardless event with action {} for payment {}, which " +
-                            "we do not expect to receive and do not handle", event.getAction(), goCardlessPaymentId),
-                    () -> LOGGER.error("Received a GoCardless event with action {} for an unspecified payment, which we do " +
-                            "not expect to receive and do not handle", event.getAction()));
-        }
+    private void logErrorForUnexpectedMandateEvent(GoCardlessEvent event) {
+        event.getLinksMandate().ifPresentOrElse(
+                goCardlessMandateId -> LOGGER.error("Received a GoCardless event with id {} for organisation {} with " +
+                                "action {} for mandate {}, which we do not expect to receive and do not handle.",
+                        event.getGoCardlessEventId(), event.getLinksOrganisation(), event.getAction(), goCardlessMandateId),
+                () -> LOGGER.error("Received a GoCardless eventwith id {} for organisation {} with action {} for an " +
+                                "unspecified mandate, which we do not expect to receive and do not handle.",
+                        event.getGoCardlessEventId(), event.getLinksOrganisation(), event.getAction()));
+    }
+
+    private void logErrorForUnexpectedPaymentEvent(GoCardlessEvent event) {
+        event.getLinksPayment().ifPresentOrElse(
+                goCardlessPaymentId -> LOGGER.error("Received a GoCardless event with id {} for organisation {} with " +
+                                "action {} for payment {}, which we do not expect to receive and do not handle.",
+                        event.getGoCardlessEventId(), event.getLinksOrganisation(), event.getAction(), goCardlessPaymentId),
+                () -> LOGGER.error("Received a GoCardless event with id {} for organisation {} with action {} for an " +
+                                "unspecified payment, which we do not expect to receive and do not handle.",
+                        event.getGoCardlessEventId(), event.getLinksOrganisation(), event.getAction()));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLoggerTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/services/handlers/UnhandledGoCardlessEventsLoggerTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.directdebit.events.model.GoCardlessEvent;
+import uk.gov.pay.directdebit.events.model.GoCardlessEventId;
+import uk.gov.pay.directdebit.gatewayaccounts.model.GoCardlessOrganisationId;
 import uk.gov.pay.directdebit.mandate.model.GoCardlessMandateId;
 import uk.gov.pay.directdebit.payments.model.GoCardlessPaymentId;
 
@@ -52,33 +54,43 @@ public class UnhandledGoCardlessEventsLoggerTest {
     }
 
     @Test
-    public void shouldLogForUnhandledMandateActions() {
+    public void shouldLogForUnhandledEventActions() {
         GoCardlessEvent unhandledMandateEvent1 = aGoCardlessEventFixture()
                 .withResourceType(MANDATES)
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("event1"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("ORG1"))
                 .withAction(ACTION_MANDATE_REPLACED)
                 .withLinksMandate(GoCardlessMandateId.valueOf("test-mandate-id1"))
                 .toEntity();
 
         GoCardlessEvent unhandledMandateEvent2 = aGoCardlessEventFixture()
                 .withResourceType(MANDATES)
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("event2"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("ORG1"))
                 .withAction(ACTION_MANDATE_RESUBMISSION_REQUESTED)
                 .withLinksMandate(GoCardlessMandateId.valueOf("test-mandate-id2"))
                 .toEntity();
 
         GoCardlessEvent handledMandateEvent = aGoCardlessEventFixture()
                 .withResourceType(MANDATES)
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("event3"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("ORG1"))
                 .withAction(ACTION_MANDATE_ACTIVE)
                 .withLinksMandate(GoCardlessMandateId.valueOf("test-mandate-id3"))
                 .toEntity();
 
         GoCardlessEvent unhandledPaymentEvent = aGoCardlessEventFixture()
                 .withResourceType(PAYMENTS)
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("event4"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("ORG1"))
                 .withAction(ACTION_PAYMENT_RESUBMISSION_REQUESTED)
                 .withLinksPayment(GoCardlessPaymentId.valueOf("test-payment-id1"))
                 .toEntity();
         
         GoCardlessEvent handledPaymentEvent = aGoCardlessEventFixture()
                 .withResourceType(PAYMENTS)
+                .withGoCardlessEventId(GoCardlessEventId.valueOf("event5"))
+                .withLinksOrganisation(GoCardlessOrganisationId.valueOf("ORG1"))
                 .withAction(ACTION_PAYMENT_FAILED)
                 .withLinksPayment(GoCardlessPaymentId.valueOf("test-payment-id2"))
                 .toEntity();
@@ -95,16 +107,16 @@ public class UnhandledGoCardlessEventsLoggerTest {
         List<String> loggedMessages = getLoggedMessages();
 
         assertThat(loggedMessages, containsInAnyOrder(
-                "Received a GoCardless event with action replaced for mandate test-mandate-id1, which we do not expect to receive and do not handle",
-                "Received a GoCardless event with action resubmission_requested for mandate test-mandate-id2, which we do not expect to receive and do not handle",
-                "Received a GoCardless event with action resubmission_requested for payment test-payment-id1, which we do not expect to receive and do not handle"));
+                "Received a GoCardless event with id event1 for organisation ORG1 with action replaced for mandate test-mandate-id1, which we do not expect to receive and do not handle.",
+                "Received a GoCardless event with id event2 for organisation ORG1 with action resubmission_requested for mandate test-mandate-id2, which we do not expect to receive and do not handle.",
+                "Received a GoCardless event with id event4 for organisation ORG1 with action resubmission_requested for payment test-payment-id1, which we do not expect to receive and do not handle."));
     }
-    
+
     private List<String> getLoggedMessages() {
         return loggingEventArgumentCaptor
                     .getAllValues()
                     .stream()
                     .map(LoggingEvent::getFormattedMessage)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toUnmodifiableList());
     }
 }


### PR DESCRIPTION
2 Commits:

### PP-5455 Improve logging for unexpected GoCardless event actions

- Add the event id and organisation id in the error message.
- Refactor code slightly.


### PP-5455 Log errors for GoCardless events with unhandled resource types

- Log errors for 'subscriptions' and 'refunds' event resource types as we do not expect to receive these types of events.