### PR TITLE
PP-5455 Delete data from many Direct Debit connector tables

### DIFF
--- a/src/main/resources/migrations/00065_truncate_tables_sandbox_events_gocardless_events_gocardless_customers_payers_payments_mandates.sql
+++ b/src/main/resources/migrations/00065_truncate_tables_sandbox_events_gocardless_events_gocardless_customers_payers_payments_mandates.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:delete_from_sandbox_events
+DELETE FROM sandbox_events;
+
+--changeset uk.gov.pay:delete_from_gocardless_events
+DELETE FROM gocardless_events;
+
+--changeset uk.gov.pay:delete_from_gocardless_customers
+DELETE FROM gocardless_customers;
+
+--changeset uk.gov.pay:delete_from__payers
+DELETE FROM payers;
+
+--changeset uk.gov.pay:delete_from__payments
+DELETE FROM payments;
+
+--changeset uk.gov.pay:delete_from__mandates
+DELETE FROM mandates;


### PR DESCRIPTION
Delete all rows from the following tables in the following order:

• `sandbox_events`
• `gocardless_events`
• `gocardless_customers`
• `payers`
• `payments`
• `mandates`

We’ve changed the data we store quite substantially with the result that some older data is no longer considered valid. It’s all test data, so we can safely remove it.