### PR TITLE
PP-5486 Add Extra NonProxyHosts Configuration

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -90,3 +90,7 @@ jerseyClient:
   retries: 0
   userAgent: directdebit-connector
   gzipEnabledForRequests: false
+  proxy:
+    host: ${HTTP_PROXY_HOST}
+    port: ${HTTP_PROXY_PORT}
+    nonProxyHosts: ${HTTP_NON_PROXY_HOSTS}


### PR DESCRIPTION
- Configuration to add environment variables for NonProxyHosts for the
apache client.
