### PR TITLE
PP-5459 Delete data from many Direct Debit connector tables

### DIFF
--- a/src/main/resources/migrations/00066_truncate_tables_govukpay_events_sandbox_events_gocardless_events_gocardless_customers_payers_payments_mandates.sql
+++ b/src/main/resources/migrations/00066_truncate_tables_govukpay_events_sandbox_events_gocardless_events_gocardless_customers_payers_payments_mandates.sql
@@ -1,0 +1,25 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:delete_from_tokens
+DELETE FROM tokens;
+
+--changeset uk.gov.pay:delete_from_govukpay_events
+DELETE FROM govukpay_events;
+
+--changeset uk.gov.pay:delete_from_sandbox_events
+DELETE FROM sandbox_events;
+
+--changeset uk.gov.pay:delete_from_gocardless_events
+DELETE FROM gocardless_events;
+
+--changeset uk.gov.pay:delete_from_gocardless_customers
+DELETE FROM gocardless_customers;
+
+--changeset uk.gov.pay:delete_from__payers
+DELETE FROM payers;
+
+--changeset uk.gov.pay:delete_from__payments
+DELETE FROM payments;
+
+--changeset uk.gov.pay:delete_from__mandates
+DELETE FROM mandates;


### PR DESCRIPTION
Delete all rows from the following tables in the following order:

• `govukpay_events`
• `sandbox_events`
• `gocardless_events`
• `gocardless_customers`
• `payers`
• `payments`
• `mandates`

We’ve changed the data we store quite substantially with the result that some older data is no longer considered valid. It’s all test data, so we can safely remove it.