### PR TITLE
PP-5517 Return payment provider id in search payments response

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
@@ -94,6 +94,14 @@ public class PaymentResponse {
         return reference;
     }
 
+    public MandateExternalId getMandateId() {
+        return mandateId;
+    }
+
+    public PaymentProviderPaymentId getProviderId() {
+        return providerId;
+    }
+
     public static PaymentResponse from(Payment payment) {
         PaymentResponseBuilder paymentResponseBuilder = aPaymentResponse()
                 .withPaymentExternalId(payment.getExternalId())

--- a/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDao.java
@@ -20,10 +20,10 @@ public class PaymentViewDao {
             "p.state AS state, " +
             "p.state_details AS state_details, " +
             "p.state_details_description AS state_details_description, " +
+            "p.payment_provider_id as provider_id, " +
             "pa.name AS name, " +
             "pa.email AS email, " +
             "ga.payment_provider as payment_provider, " +
-            "m.payment_provider_id as provider_id, " +
             "m.external_id as mandate_external_id " +
             "FROM payments p " +
             "INNER JOIN mandates m ON p.mandate_id = m.id " +


### PR DESCRIPTION
Previously, we were selecting the mandate payment_provider_id in the DAO. Fix the query to instead select the payment payment_provider_id. Add a test for the DAO to check the extracted response is what we expect.