### PR TITLE
Use the correct naming scheme for integration tests

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoIT.java
@@ -29,7 +29,7 @@ import static uk.gov.pay.directdebit.payments.fixtures.GoCardlessEventFixture.aG
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
-public class GoCardlessEventDaoITest {
+public class GoCardlessEventDaoIT {
 
     @DropwizardTestContext
     private TestContext testContext;

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/GovUkPayEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/GovUkPayEventDaoIT.java
@@ -33,7 +33,7 @@ import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFi
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = DirectDebitConnectorApp.class, config = "config/test-it-config.yaml")
-public class GovUkPayEventDaoITest {
+public class GovUkPayEventDaoIT {
 
     @DropwizardTestContext
     private TestContext testContext;


### PR DESCRIPTION
This will avoid slow tests being run during 'mvn test'