### PR TITLE
PP-5486 Use SystemRoutePlanner

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/notifications/clients/ClientFactory.java
+++ b/src/main/java/uk/gov/pay/directdebit/notifications/clients/ClientFactory.java
@@ -2,6 +2,7 @@ package uk.gov.pay.directdebit.notifications.clients;
 
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.setup.Environment;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import uk.gov.pay.commons.utils.logging.LoggingFilter;
 import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
 
@@ -23,6 +24,7 @@ public class ClientFactory {
 
         Client client = new JerseyClientBuilder(environment)
                 .using(conf.getClientConfiguration())
+                .using(new SystemDefaultRoutePlanner(null))
                 .build(name);
         client.register(LoggingFilter.class);
 


### PR DESCRIPTION
- Use the SystemRoutePlanner to inject the Environment Variables for
NonProxyHosts into the Jersey Client.
