### PR TITLE
Use runAppE2E to run end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
         }
       }
     }
-    stage('Direct-Debit End-to-End') {
+    stage('End-to-End tests') {
       when {
         anyOf {
           branch 'master'
@@ -75,7 +75,7 @@ pipeline {
         }
       }
       steps {
-        runDirectDebitE2E("directdebit-connector")
+        runAppE2E("directdebit-connector", "directdebit")
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
Let's deprecate the run{test}E2E groovy routines and use runAppE2E everywhere