### PR TITLE
PP-5511 Add JSON Formatting To DDConnector Logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <hamcrest.version>2.1</hamcrest.version>
         <rest-assured.version>4.0.0</rest-assured.version>
         <mockito.version>3.0.0</mockito.version>
-        <pay-java-commons.version>1.0.20190812091514</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190815122130</pay-java-commons.version>
         <surefire.version>2.22.2</surefire.version>
     </properties>
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -8,12 +8,17 @@ server:
 
 logging:
   level: INFO
+  layout:
+      type: json
+
   appenders:
-    - type: console
+    - type: logstash-console
       threshold: ALL
       timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+      layout:
+        type: json
+        timestampFormat: "yyyy-MM-dd HH:mm:ss.SSS"
 
 links:
   frontendUrl: ${FRONTEND_URL:-}


### PR DESCRIPTION
- Make DD Connector use JSON logging as the format for outputting log
lines.
- Edits the yaml file to facilitate this by adding ```type: logstash-console```
