### PR TITLE
PP-5511 Add JSON Formatting To DDConnector Logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
             <artifactId>validation</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
+        <dependency>
+            <groupId>uk.gov.pay</groupId>
+            <artifactId>logging</artifactId>
+            <version>${pay-java-commons.version}</version>
+        </dependency>
         <!-- testing -->
         <dependency>
             <groupId>pl.pragmatists</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <hamcrest.version>2.1</hamcrest.version>
         <rest-assured.version>4.0.0</rest-assured.version>
         <mockito.version>3.0.0</mockito.version>
-        <pay-java-commons.version>1.0.20190812091514</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190815122130</pay-java-commons.version>
         <surefire.version>2.22.2</surefire.version>
     </properties>
 

--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -16,6 +16,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.commons.utils.logging.LoggingFilter;
+import uk.gov.pay.commons.utils.logging.LogstashConsoleAppenderFactory;
 import uk.gov.pay.commons.utils.metrics.DatabaseMetricsService;
 import uk.gov.pay.directdebit.app.bootstrap.DependentResourcesWaitCommand;
 import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
@@ -82,6 +83,7 @@ public class DirectDebitConnectorApp extends Application<DirectDebitConfig> {
         });
         bootstrap.addBundle(new JdbiExceptionsBundle());
         bootstrap.addCommand(new DependentResourcesWaitCommand());
+        bootstrap.getObjectMapper().getSubtypeResolver().registerSubtypes(LogstashConsoleAppenderFactory.class);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/services/PaymentService.java
@@ -13,11 +13,13 @@ import uk.gov.pay.directdebit.payments.model.Payment;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderFactory;
 import uk.gov.pay.directdebit.payments.model.PaymentProviderPaymentIdAndChargeDate;
 import uk.gov.pay.directdebit.payments.model.PaymentState;
+import uk.gov.pay.logging.LoggingKeys;
 
 import javax.inject.Inject;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.PAYMENT_CREATED;
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.PAYMENT_ERROR_SUBMITTING_TO_PROVIDER;
 import static uk.gov.pay.directdebit.events.model.GovUkPayEventType.PAYMENT_SUBMITTED;
@@ -44,7 +46,7 @@ public class PaymentService {
     }
 
     Payment createPayment(long amount, String description, String reference, Mandate mandate) {
-        LOGGER.info("Creating payment for mandate {}", mandate.getExternalId());
+        LOGGER.info("Creating payment for mandate {}", kv(LoggingKeys.EXTERNAL_ID, mandate.getExternalId()));
         Payment payment = aPayment()
                 .withExternalId(RandomIdGenerator.newId())
                 .withAmount(amount)

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -8,12 +8,17 @@ server:
 
 logging:
   level: INFO
+  layout:
+      type: json
+
   appenders:
-    - type: console
+    - type: logstash-console
       threshold: ALL
       timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+      layout:
+        type: json
+        timestampFormat: "yyyy-MM-dd HH:mm:ss.SSS"
 
 links:
   frontendUrl: ${FRONTEND_URL:-}


### PR DESCRIPTION
- Make DD Connector use JSON logging as the format for outputting log
lines.
- Edits the yaml file to facilitate this by adding ```type: logstash-console```
