### PR TITLE
When processing a NotFoundException, log at WARN rather than ERROR

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/exception/NotFoundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/NotFoundExceptionMapper.java
@@ -2,7 +2,6 @@ package uk.gov.pay.directdebit.common.exception;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.directdebit.common.model.ErrorResponse;
 
 import javax.ws.rs.core.Response;
@@ -16,7 +15,7 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
 
     @Override
     public Response toResponse(NotFoundException exception) {
-        LOGGER.error(exception.getMessage());
+        LOGGER.warn(exception.getMessage());
         ErrorResponse errorResponse = new ErrorResponse(exception.getErrorIdentifier(), exception.getMessage());
         return Response.status(404).entity(errorResponse).type(APPLICATION_JSON).build();
     }


### PR DESCRIPTION
Many `NotFoundException`s are caused by input that’s outside of our control, so log at WARN (which doesn’t create a support ticket) rather than ERROR (which does).

When we have time, we might want to make any `NotFoundException`s that are not caused by external input log errors again, as this is more indicative of a problem we can do something about.