### PR TITLE
Tweak logging for errors validating bank details with GoCardless

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/common/exception/ExceptionSummariser.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/ExceptionSummariser.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.directdebit.common.exception;
+
+import java.util.ArrayDeque;
+
+public class ExceptionSummariser {
+
+    public static String summarise(Throwable e) {
+        var sb = new StringBuilder();
+        var throwables = new ArrayDeque<Throwable>();
+        throwables.add(e);
+        while (!throwables.isEmpty()) {
+            var throwable = throwables.removeFirst();
+            sb.append(throwable.getClass().getSimpleName());
+            if (throwable.getMessage() != null) {
+                sb.append(": ").append(throwable.getMessage());
+            }
+            if (throwable.getCause() != null) {
+                sb.append(". Caused by ");
+                throwables.add(throwable.getCause());
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/InternalServerErrorException.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/InternalServerErrorException.java
@@ -5,4 +5,8 @@ public class InternalServerErrorException extends RuntimeException {
     public InternalServerErrorException(String message) {
         super(message);
     }
+
+    public InternalServerErrorException(String message, Exception cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/uk/gov/pay/directdebit/common/exception/InternalServerErrorExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/exception/InternalServerErrorExceptionMapper.java
@@ -16,7 +16,15 @@ public class InternalServerErrorExceptionMapper implements ExceptionMapper<Inter
 
     @Override
     public Response toResponse(InternalServerErrorException exception) {
-        LOGGER.error(exception.getMessage());
+        StringBuilder sb = new StringBuilder();
+        sb.append("Internal server error");
+        if (exception.getMessage() != null) {
+            sb.append(": ").append(exception.getMessage());
+        }
+        if (exception.getCause() != null) {
+            sb.append(ExceptionSummariser.summarise(exception.getCause()));
+        }
+        LOGGER.error(sb.toString());
         ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
         return Response.status(500).entity(errorResponse).type(APPLICATION_JSON).build();
     }

--- a/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessService.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/services/gocardless/GoCardlessService.java
@@ -90,8 +90,7 @@ public class GoCardlessService implements DirectDebitPaymentProviderCommandServi
         } catch (ValidationFailedException exc) {
             return new BankAccountValidationResponse(false);
         } catch (GoCardlessException exc) {
-            LOGGER.error("Exception while validating bank account details in GoCardless, message: {}", exc.getMessage());
-            throw new InternalServerErrorException("Exception while validating bank account details in GoCardless");
+            throw new InternalServerErrorException("Exception while validating bank account details in GoCardless", exc);
         }
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/common/exception/ExceptionSummariserTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/exception/ExceptionSummariserTest.java
@@ -1,0 +1,76 @@
+package uk.gov.pay.directdebit.common.exception;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ExceptionSummariserTest {
+
+    @Test
+    public void exceptionWithNoMessage() {
+        Exception exception = new RuntimeException();
+
+        String summary = ExceptionSummariser.summarise(exception);
+
+        assertThat(summary, is("RuntimeException"));
+    }
+
+    @Test
+    public void exceptionWithMessage() {
+        Exception exception = new RuntimeException("Something went wrong");
+        
+        String summary = ExceptionSummariser.summarise(exception);
+        
+        assertThat(summary, is("RuntimeException: Something went wrong"));
+    }
+
+    @Test
+    public void exceptionWithNoMessageWrappingCauseWithNoMessage() {
+        Exception exception = new RuntimeException(new IllegalArgumentException());
+
+        String summary = ExceptionSummariser.summarise(exception);
+
+        assertThat(summary, is("RuntimeException: java.lang.IllegalArgumentException. Caused by IllegalArgumentException"));
+    }
+
+    @Test
+    public void exceptionWithMessageWrappingCauseWithNoMessage() {
+        Exception exception = new RuntimeException("Something went wrong", new IllegalArgumentException());
+
+        String summary = ExceptionSummariser.summarise(exception);
+
+        assertThat(summary, is("RuntimeException: Something went wrong. Caused by IllegalArgumentException"));
+    }
+
+    @Test
+    public void exceptionWithNoMessageWrappingCauseWithMessage() {
+        Exception exception = new RuntimeException(new IllegalArgumentException("Something was illegal"));
+
+        String summary = ExceptionSummariser.summarise(exception);
+
+        assertThat(summary, is("RuntimeException: java.lang.IllegalArgumentException: Something was illegal. " +
+                "Caused by IllegalArgumentException: Something was illegal"));
+    }
+
+    @Test
+    public void exceptionWithMessageWrappingCauseWithMessage() {
+        Exception exception = new RuntimeException("Something went wrong", new IllegalArgumentException("Something was illegal"));
+
+        String summary = ExceptionSummariser.summarise(exception);
+
+        assertThat(summary, is("RuntimeException: Something went wrong. Caused by IllegalArgumentException: Something was illegal"));
+    }
+
+    @Test
+    public void manyNestedExceptions() {
+        Exception exception = new RuntimeException("Something went wrong",
+                new IllegalArgumentException("Something was illegal", new NullPointerException("Something was illegal")));
+
+        String summary = ExceptionSummariser.summarise(exception);
+
+        assertThat(summary, is("RuntimeException: Something went wrong. Caused by IllegalArgumentException: Something was illegal. " +
+                "Caused by NullPointerException: Something was illegal"));
+    }
+
+}


### PR DESCRIPTION
When there’s a `GoCardlessException` while validating bank account details, don’t log two lines, one with the `GoCardlessException` message immediately, and one without the message when the resultant `InternalServerErrorException`. Instead do all the logging when mapping the `InternalServerErrorException` and enhance this so it always includes the names of and messages from the wrapped exceptions.

We can replace this with something even better when we have structured logging in place.