### PR TITLE
Remove support for custom CA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The [GOV.UK Pay](https://www.payments.service.gov.uk/) Direct Debit Connector
 | NAME                    | DESCRIPTION                                                                    |
 | ----------------------- | ------------------------------------------------------------------------------ |
 | `ADMIN_PORT`            | The port number to listen for Dropwizard admin requests on. Defaults to `8081`. |
-| `CERTS_PATH`            | If set, add all certificates in this directory to the default Java truststore. |
 | `RUN_APP`               | Set to `true` to run the application. Defaults to `true`. |
 | `PORT`                  | The port number to listen for requests on. Defaults to `8080`. |
 | `JAVA_OPTS`             | Commandline arguments to pass to the java runtime. Optional. |

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -6,16 +6,6 @@ RUN_MIGRATION=${RUN_MIGRATION:-false}
 RUN_APP=${RUN_APP:-true}
 JAVA_OPTS=${JAVA_OPTS:-}
 
-if [ -n "${CERTS_PATH:-}" ]; then
-  i=0
-  truststore_pass=changeit
-  for cert in "$CERTS_PATH"/*; do
-    [ -f "$cert" ] || continue
-    echo "Adding $cert to default truststore"
-    keytool -importcert -noprompt -cacerts -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
-  done
-fi
-
 java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then

--- a/env.sh
+++ b/env.sh
@@ -7,6 +7,4 @@ then
   set +a  
 fi
 
-export CERTS_PATH=$WORKSPACE/pay-scripts/services/ssl/certs
-
 eval "$@"


### PR DESCRIPTION
We only needed to augment the default Java truststore for local testing with
selfsigned certificates, but this is no longer required.

Remove support for adding custom CA certificates.