### PR TITLE
PP-5670: Specify the consumer when running contract test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <hamcrest.version>2.1</hamcrest.version>
         <rest-assured.version>4.1.2</rest-assured.version>
         <mockito.version>3.1.0</mockito.version>
-        <pay-java-commons.version>1.0.20191001125636</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20191002153026</pay-java-commons.version>
         <surefire.version>2.22.2</surefire.version>
     </properties>
 

--- a/src/test/java/uk/gov/pay/directdebit/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/ContractTestSuite.java
@@ -1,13 +1,21 @@
 package uk.gov.pay.directdebit.pact;
 
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.TestSuite;
 import org.junit.runner.RunWith;
+import org.junit.runners.AllTests;
 import org.junit.runners.Suite;
+import uk.gov.pay.commons.testing.pact.provider.CreateTestSuite;
 
-@RunWith(Suite.class)
+import java.util.Map;
 
-@Suite.SuiteClasses({
-        PublicApiContractTest.class, SelfServiceApiContractTest.class
-})
+@RunWith(AllTests.class)
 public class ContractTestSuite {
 
+    public static TestSuite suite() {
+        Map<String, JUnit4TestAdapter> map = Map.of(
+                "publicapi", new JUnit4TestAdapter(PublicApiContractTest.class),
+                "selfservice", new JUnit4TestAdapter(SelfServiceContractTest.class));
+        return CreateTestSuite.create(map);
+    }
 }

--- a/src/test/java/uk/gov/pay/directdebit/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/SelfServiceContractTest.java
@@ -20,7 +20,7 @@ import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 @PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
-public class SelfServiceApiContractTest {
+public class SelfServiceContractTest {
 
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();


### PR DESCRIPTION
Currently when a consumer build is kicked off, the provider contract test will
run in its entirety. For example, in a selfservice build, the dd-connector provider
contract tests will run as well. However, what is run is:

publicapi->dd-connector
selfservice->dd-connector

We really only want to run selfservice->dd-connector in this case.

This commit will allow a dynamic creation of the test suite to run based on a
CONSUMER system property. This will mean shorter run times when a provider
contract test is run as part of a specific consumer build.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
