### PR TITLE
BAU Codacy Clean Ups

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/common/clients/GoCardlessClientFacadeTest.java
@@ -59,10 +59,10 @@ public class GoCardlessClientFacadeTest {
     private com.gocardless.resources.Payment mockPayment;
 
     @Mock
-    private com.gocardless.resources.Creditor mockCreditor;
+    private Creditor mockCreditor;
 
     @Mock
-    private com.gocardless.resources.Creditor.SchemeIdentifier mockSchemeIdentifier;
+    private Creditor.SchemeIdentifier mockSchemeIdentifier;
 
     private GoCardlessClientFacade goCardlessClientFacade;
 

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
@@ -105,7 +105,7 @@ public class GatewayAccountDaoIT {
         String description2 = "can't type and is not drunk maybe";
         String analyticsId2 = "DD_234098_BBBLABLA";
         testGatewayAccount.insert(testContext.getJdbi());
-        GatewayAccountFixture.aGatewayAccountFixture()
+        aGatewayAccountFixture()
                 .withExternalId(externalId2)
                 .withDescription(description2)
                 .withPaymentProvider(paymentProvider2)
@@ -155,16 +155,14 @@ public class GatewayAccountDaoIT {
         PaymentProviderAccessToken accessToken             = PaymentProviderAccessToken.of("gimmeaccess");
         GoCardlessOrganisationId organisation = GoCardlessOrganisationId.valueOf("organisation");
 
-        GatewayAccountFixture
-          .aGatewayAccountFixture()
+        aGatewayAccountFixture()
           .withExternalId(externalId)
           .withDescription(description)
           .withPaymentProvider(paymentProvider)
           .withAnalyticsId(analyticsId)
           .insert(testContext.getJdbi());
 
-        GatewayAccountFixture
-          .aGatewayAccountFixture()
+        aGatewayAccountFixture()
           .withExternalId(externalId2)
           .withDescription(description2)
           .withPaymentProvider(paymentProvider2)

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java
@@ -129,7 +129,7 @@ public class GatewayAccountResourceIT {
 
     @Test
     public void shouldReturnAGatewayAccountWithMinimalFields() {
-        GatewayAccountFixture testGatewayAccount2 = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture testGatewayAccount2 = aGatewayAccountFixture()
                 .withExternalId("externalId")
                 .withPaymentProvider(PaymentProvider.GOCARDLESS)
                 .withType(GatewayAccount.Type.LIVE)
@@ -162,7 +162,7 @@ public class GatewayAccountResourceIT {
         String analyticsId2 = "DD_234098_BBBLABLA";
         String externalId2 = "DD_234098_BBBLABLA";
 
-        GatewayAccountFixture testGatewayAccount2 = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture testGatewayAccount2 = aGatewayAccountFixture()
                 .withExternalId(externalId2)
                 .withDescription(description2)
                 .withPaymentProvider(paymentProvider2)
@@ -223,7 +223,7 @@ public class GatewayAccountResourceIT {
         String analyticsId3 = "DD_234099_BBBLABLA";
         String externalId3 = "DD_234099_BBBLABLA";
 
-        GatewayAccountFixture testGatewayAccount3 = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture testGatewayAccount3 = aGatewayAccountFixture()
                 .withExternalId(externalId3)
                 .withDescription(description3)
                 .withPaymentProvider(paymentProvider3)
@@ -234,7 +234,7 @@ public class GatewayAccountResourceIT {
           .forEach(path -> givenSetup()
             .queryParam(
                 "externalAccountIds",
-                String.format("%s,%s", EXTERNAL_ID, externalId3)
+                format("%s,%s", EXTERNAL_ID, externalId3)
                 )
             .get(path)
             .then()
@@ -382,7 +382,7 @@ public class GatewayAccountResourceIT {
         String description4 = "can't type and is not hungover maybe";
         String analyticsId4 = "DD_234099_BBBLABLA";
 
-        GatewayAccountFixture testGatewayAccount4 = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture testGatewayAccount4 = aGatewayAccountFixture()
                 .withExternalId(externalId4)
                 .withDescription(description4)
                 .withPaymentProvider(paymentProvider3)

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java
@@ -182,8 +182,7 @@ public class GatewayAccountServiceTest {
     @Test
     public void shouldUpdateAGatewayAccount() {
         String externalAccountId = "an-external-id";
-        GatewayAccount gatewayAccount = GatewayAccountFixture
-                .aGatewayAccountFixture()
+        GatewayAccount gatewayAccount = aGatewayAccountFixture()
                 .withExternalId(externalAccountId)
                 .toEntity();
         when(gatewayAccountDao.findByExternalId(externalAccountId)).thenReturn(Optional.of(gatewayAccount));

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -529,11 +529,11 @@ public class MandateDaoIT {
         MandateFixture.aMandateFixture()
                 .withState(SUBMITTED_TO_PROVIDER)
                 .withGatewayAccountFixture(gatewayAccountFixture)
-                .withCreatedDate(ZonedDateTime.now().minusMinutes(91L))
+                .withCreatedDate(now().minusMinutes(91L))
                 .insert(testContext.getJdbi());
         
         Set<MandateState> states = Set.of(CREATED, AWAITING_DIRECT_DEBIT_DETAILS);
-        List<Mandate> transactions = mandateDao.findAllMandatesBySetOfStatesAndMaxCreationTime(states, ZonedDateTime.now().minusMinutes(90L));
+        List<Mandate> transactions = mandateDao.findAllMandatesBySetOfStatesAndMaxCreationTime(states, now().minusMinutes(90L));
         assertThat(transactions.size(), is(0));
     }
 
@@ -542,11 +542,11 @@ public class MandateDaoIT {
         MandateFixture.aMandateFixture()
                 .withState(CREATED)
                 .withGatewayAccountFixture(gatewayAccountFixture)
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(now())
                 .insert(testContext.getJdbi());
 
         Set<MandateState> states = Set.of(CREATED, AWAITING_DIRECT_DEBIT_DETAILS);
-        List<Mandate> transactions = mandateDao.findAllMandatesBySetOfStatesAndMaxCreationTime(states, ZonedDateTime.now().minusMinutes(90L));
+        List<Mandate> transactions = mandateDao.findAllMandatesBySetOfStatesAndMaxCreationTime(states, now().minusMinutes(90L));
         assertThat(transactions.size(), is(0));
     }
 
@@ -555,23 +555,23 @@ public class MandateDaoIT {
         MandateFixture.aMandateFixture()
                 .withState(AWAITING_DIRECT_DEBIT_DETAILS)
                 .withGatewayAccountFixture(gatewayAccountFixture)
-                .withCreatedDate(ZonedDateTime.now().minusMinutes(200L))
+                .withCreatedDate(now().minusMinutes(200L))
                 .insert(testContext.getJdbi());
 
         MandateFixture.aMandateFixture()
                 .withState(CREATED)
                 .withGatewayAccountFixture(gatewayAccountFixture)
-                .withCreatedDate(ZonedDateTime.now().minusMinutes(100L))
+                .withCreatedDate(now().minusMinutes(100L))
                 .insert(testContext.getJdbi());
 
         MandateFixture.aMandateFixture()
                 .withState(SUBMITTED_TO_PROVIDER)
                 .withGatewayAccountFixture(gatewayAccountFixture)
-                .withCreatedDate(ZonedDateTime.now().minusMinutes(91L))
+                .withCreatedDate(now().minusMinutes(91L))
                 .insert(testContext.getJdbi());
 
         Set<MandateState> states = Set.of(CREATED, AWAITING_DIRECT_DEBIT_DETAILS, SUBMITTED_TO_PROVIDER);
-        List<Mandate> transactions = mandateDao.findAllMandatesBySetOfStatesAndMaxCreationTime(states, ZonedDateTime.now().minusMinutes(90L));
+        List<Mandate> transactions = mandateDao.findAllMandatesBySetOfStatesAndMaxCreationTime(states, now().minusMinutes(90L));
         assertThat(transactions.size(), is(3));
     }
 }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDaoIT.java
@@ -52,7 +52,7 @@ public class MandateSearchDaoIT {
             .withCreatedDate(now().minusHours(6));
     
     private static ZonedDateTime now() {
-        return java.time.ZonedDateTime.now(ZoneOffset.UTC);
+        return ZonedDateTime.now(ZoneOffset.UTC);
     }
     
     @Before

--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -7,9 +7,9 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableMap;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.converters.Nullable;
-import junitparams.JUnitParamsRunner;
 import org.apache.http.HttpStatus;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
@@ -17,10 +17,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.junit.DropwizardAppWithPostgresRule;
+import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
-import uk.gov.pay.directdebit.mandate.model.MandateState;
 import uk.gov.pay.directdebit.mandate.model.subtype.MandateExternalId;
 import uk.gov.pay.directdebit.payers.fixtures.GoCardlessCustomerFixture;
 import uk.gov.pay.directdebit.payers.fixtures.PayerFixture;
@@ -31,6 +30,7 @@ import uk.gov.pay.directdebit.payments.model.PaymentState;
 import javax.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -288,7 +288,7 @@ public class MandateResourceIT {
                 .body("state.status", is("created"))
                 .body("state.details", is(nullValue()))
                 .body("service_reference", is("test-service-reference"))
-                .body("payment_provider", is(gatewayAccountFixture.getPaymentProvider().toString().toLowerCase()))
+                .body("payment_provider", is(gatewayAccountFixture.getPaymentProvider().toString().toLowerCase(Locale.ENGLISH)))
                 .body("provider_id", is(nullValue()))
                 .body("mandate_reference", is(nullValue()))
                 .body("description", optionalMatcher(description))
@@ -485,7 +485,7 @@ public class MandateResourceIT {
                 .withPaymentProvider(GOCARDLESS).insert(testContext.getJdbi());
 
         MandateFixture mandateFixture = aMandateFixture()
-                .withState(MandateState.AWAITING_DIRECT_DEBIT_DETAILS)
+                .withState(AWAITING_DIRECT_DEBIT_DETAILS)
                 .withGatewayAccountFixture(gatewayAccountFixture)
                 .withPayerFixture(payerFixture)
                 .insert(testContext.getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentDaoIT.java
@@ -311,7 +311,7 @@ public class PaymentDaoIT {
     
     @Test
     public void shouldFindAllPaymentsByPaymentStateAndProvider() {
-        GatewayAccountFixture goCardlessGatewayAccount = aGatewayAccountFixture().withPaymentProvider(PaymentProvider.GOCARDLESS).insert(testContext.getJdbi());
+        GatewayAccountFixture goCardlessGatewayAccount = aGatewayAccountFixture().withPaymentProvider(GOCARDLESS).insert(testContext.getJdbi());
         GatewayAccountFixture sandboxGatewayAccount = aGatewayAccountFixture().withPaymentProvider(SANDBOX).insert(testContext.getJdbi());
 
         MandateFixture sandboxMandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(sandboxGatewayAccount).insert(testContext.getJdbi());
@@ -417,12 +417,12 @@ public class PaymentDaoIT {
 
     @Test
     public void shouldUpdateStateByProviderIdAndOrganisationAndReturnNumberOfAffectedRows() {
-        GatewayAccountFixture goCardlessGatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture goCardlessGatewayAccountFixture = aGatewayAccountFixture()
                 .withPaymentProvider(GOCARDLESS)
                 .withOrganisation(GoCardlessOrganisationId.valueOf("Organisation ID we want"))
                 .insert(testContext.getJdbi());
 
-        GatewayAccountFixture goCardlessGatewayAccountFixtureWithWrongOrganisation = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture goCardlessGatewayAccountFixtureWithWrongOrganisation = aGatewayAccountFixture()
                 .withPaymentProvider(GOCARDLESS)
                 .withOrganisation(GoCardlessOrganisationId.valueOf("Different organisation"))
                 .insert(testContext.getJdbi());
@@ -435,18 +435,18 @@ public class PaymentDaoIT {
                 .withGatewayAccountFixture(goCardlessGatewayAccountFixtureWithWrongOrganisation)
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixture)
                 .withExternalId("Payment we want")
                 .withPaymentProviderId(GoCardlessPaymentId.valueOf("Payment ID we want"))
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixture)
                 .withPaymentProviderId(GoCardlessPaymentId.valueOf("Different payment ID"))
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixtureWithWrongOrganisation)
                 .withPaymentProviderId(GoCardlessPaymentId.valueOf("Payment ID we want"))
                 .insert(testContext.getJdbi());
@@ -464,12 +464,12 @@ public class PaymentDaoIT {
 
     @Test
     public void shouldUpdateStateByProviderIdAndOrganisationWithNoDetailsAndDescriptionAndReturnNumberOfAffectedRows() {
-        GatewayAccountFixture goCardlessGatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture goCardlessGatewayAccountFixture = aGatewayAccountFixture()
                 .withPaymentProvider(GOCARDLESS)
                 .withOrganisation(GoCardlessOrganisationId.valueOf("Organisation ID we want"))
                 .insert(testContext.getJdbi());
 
-        GatewayAccountFixture goCardlessGatewayAccountFixtureWithWrongOrganisation = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture goCardlessGatewayAccountFixtureWithWrongOrganisation = aGatewayAccountFixture()
                 .withPaymentProvider(GOCARDLESS)
                 .withOrganisation(GoCardlessOrganisationId.valueOf("Different organisation"))
                 .insert(testContext.getJdbi());
@@ -482,7 +482,7 @@ public class PaymentDaoIT {
                 .withGatewayAccountFixture(goCardlessGatewayAccountFixtureWithWrongOrganisation)
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixture)
                 .withExternalId("Payment we want")
                 .withStateDetails("state details before update")
@@ -490,12 +490,12 @@ public class PaymentDaoIT {
                 .withPaymentProviderId(GoCardlessPaymentId.valueOf("Payment ID we want"))
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixture)
                 .withPaymentProviderId(GoCardlessPaymentId.valueOf("Different payment ID"))
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixtureWithWrongOrganisation)
                 .withPaymentProviderId(GoCardlessPaymentId.valueOf("Payment ID we want"))
                 .insert(testContext.getJdbi());
@@ -513,12 +513,12 @@ public class PaymentDaoIT {
     
     @Test
     public void shouldUpdateStateByProviderIdAndNoOrganisationAndReturnNumberOfAffectedRows() {
-        GatewayAccountFixture gatewayAccountFixtureWithNoOrganisation = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture gatewayAccountFixtureWithNoOrganisation = aGatewayAccountFixture()
                 .withPaymentProvider(SANDBOX)
                 .withOrganisation(null)
                 .insert(testContext.getJdbi());
 
-        GatewayAccountFixture gatewayAccountFixtureWithWrongOrganisation = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture gatewayAccountFixtureWithWrongOrganisation = aGatewayAccountFixture()
                 .withPaymentProvider(SANDBOX)
                 .withOrganisation(GoCardlessOrganisationId.valueOf("Different organisation"))
                 .insert(testContext.getJdbi());
@@ -531,18 +531,18 @@ public class PaymentDaoIT {
                 .withGatewayAccountFixture(gatewayAccountFixtureWithWrongOrganisation)
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixtureWithNoOrganisation)
                 .withExternalId("Payment we want")
                 .withPaymentProviderId(SandboxPaymentId.valueOf("Payment ID we want"))
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixtureWithNoOrganisation)
                 .withPaymentProviderId(SandboxPaymentId.valueOf("Different payment ID"))
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixtureWithWrongOrganisation)
                 .withPaymentProviderId(SandboxPaymentId.valueOf("Payment ID we want"))
                 .insert(testContext.getJdbi());
@@ -563,12 +563,12 @@ public class PaymentDaoIT {
 
     @Test
     public void shouldUpdateStateByProviderIdAndNoOrganisationWithNoDetailsAndDescriptionAndReturnNumberOfAffectedRows() {
-        GatewayAccountFixture gatewayAccountFixtureWithNoOrganisation = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture gatewayAccountFixtureWithNoOrganisation = aGatewayAccountFixture()
                 .withPaymentProvider(SANDBOX)
                 .withOrganisation(null)
                 .insert(testContext.getJdbi());
 
-        GatewayAccountFixture gatewayAccountFixtureWithWrongOrganisation = GatewayAccountFixture.aGatewayAccountFixture()
+        GatewayAccountFixture gatewayAccountFixtureWithWrongOrganisation = aGatewayAccountFixture()
                 .withPaymentProvider(SANDBOX)
                 .withOrganisation(GoCardlessOrganisationId.valueOf("Different organisation"))
                 .insert(testContext.getJdbi());
@@ -581,18 +581,18 @@ public class PaymentDaoIT {
                 .withGatewayAccountFixture(gatewayAccountFixtureWithWrongOrganisation)
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixtureWithNoOrganisation)
                 .withExternalId("Payment we want")
                 .withPaymentProviderId(SandboxPaymentId.valueOf("Payment ID we want"))
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixtureWithNoOrganisation)
                 .withPaymentProviderId(SandboxPaymentId.valueOf("Different payment ID"))
                 .insert(testContext.getJdbi());
 
-        PaymentFixture.aPaymentFixture()
+        aPaymentFixture()
                 .withMandateFixture(mandateFixtureWithWrongOrganisation)
                 .withPaymentProviderId(SandboxPaymentId.valueOf("Payment ID we want"))
                 .withStateDetails("state details before update")

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -143,7 +144,7 @@ public class PaymentResourceIT {
                 .body(JSON_MANDATE_ID_KEY, is(mandateFixture.getExternalId().toString()))
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
                 .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
-                .body(JSON_PAYMENT_PROVIDER_KEY, is(SANDBOX.toString().toLowerCase()))
+                .body(JSON_PAYMENT_PROVIDER_KEY, is(SANDBOX.toString().toLowerCase(Locale.ENGLISH)))
                 .contentType(JSON);
 
         String externalTransactionId = response.extract().path(JSON_PAYMENT_ID_KEY).toString();
@@ -188,7 +189,7 @@ public class PaymentResourceIT {
     @Test
     public void shouldCollectAPayment_forGoCardless() throws Exception {
         GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()
-                .withPaymentProvider(PaymentProvider.GOCARDLESS).insert(testContext.getJdbi());
+                .withPaymentProvider(GOCARDLESS).insert(testContext.getJdbi());
         PayerFixture payerFixture = aPayerFixture();
         GoCardlessMandateId goCardlessMandate = GoCardlessMandateId.valueOf("aGoCardlessMandateId");
         Mandate mandate = aMandateFixture()
@@ -248,7 +249,7 @@ public class PaymentResourceIT {
                 .body(JSON_MANDATE_ID_KEY, is(mandate.getExternalId().toString()))
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
                 .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
-                .body(JSON_PAYMENT_PROVIDER_KEY, is(GOCARDLESS.toString().toLowerCase()))
+                .body(JSON_PAYMENT_PROVIDER_KEY, is(GOCARDLESS.toString().toLowerCase(Locale.ENGLISH)))
                 .contentType(JSON);
         
         String externalTransactionId = response.extract().path(JSON_PAYMENT_ID_KEY).toString();
@@ -273,7 +274,7 @@ public class PaymentResourceIT {
                 .body(JSON_MANDATE_ID_KEY, is(mandate.getExternalId().toString()))
                 .body(JSON_STATE_STATUS_KEY, is("pending"))
                 .body(JSON_PROVIDER_ID_KEY, is(notNullValue()))
-                .body(JSON_PAYMENT_PROVIDER_KEY, is(GOCARDLESS.toString().toLowerCase()))
+                .body(JSON_PAYMENT_PROVIDER_KEY, is(GOCARDLESS.toString().toLowerCase(Locale.ENGLISH)))
                 .contentType(JSON);
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentSearchResourceIT.java
@@ -145,7 +145,9 @@ public class PaymentSearchResourceIT {
     @Test
     public void shouldReturnPageOfPaginatedResults() {
         for (int i = 0; i < 15; i++) {
-            MandateFixture mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(testGatewayAccount).insert(testContext.getJdbi());
+            MandateFixture mandateFixture = aMandateFixture()
+                    .withGatewayAccountFixture(testGatewayAccount)
+                    .insert(testContext.getJdbi());
 
             aPaymentFixture()
                     .withId((long) i)

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/GovUkPayEventServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/GovUkPayEventServiceTest.java
@@ -173,7 +173,7 @@ public class GovUkPayEventServiceTest {
     @Test
     public void insertPaymentEvent_shouldThrowForInvalidEventTransition() {
         var previousEvent = aGovUkPayEventFixture()
-                .withResourceType(GovUkPayEvent.ResourceType.PAYMENT)
+                .withResourceType(PAYMENT)
                 .withPaymentId(paymentId)
                 .withEventType(PAYMENT_SUBMITTED)
                 .toEntity();

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/PaymentServiceTest.java
@@ -139,7 +139,7 @@ public class PaymentServiceTest {
         when(mockedGovUkPayEventService.storeEventAndUpdateStateForPayment(paymentWithProviderIdAndChargeDate, PAYMENT_SUBMITTED))
                 .thenAnswer(invocationOnMock -> {
                     Payment paymentToUpdate = invocationOnMock.getArgument(0, Payment.class);
-                    return Payment.PaymentBuilder.fromPayment(paymentToUpdate).withState(SUBMITTED_TO_PROVIDER).build();
+                    return fromPayment(paymentToUpdate).withState(SUBMITTED_TO_PROVIDER).build();
                 });
 
         Payment returnedPayment = service.submitPaymentToProvider(payment, SANDBOX_MANDATE_ID);

--- a/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/services/gocardless/GoCardlessPaymentStateCalculatorTest.java
@@ -70,7 +70,7 @@ public class GoCardlessPaymentStateCalculatorTest {
     @Before
     public void setUp() {
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()
-                .withPaymentProvider(PaymentProvider.GOCARDLESS)
+                .withPaymentProvider(GOCARDLESS)
                 .withOrganisation(goCardlessOrganisationId);
 
         MandateFixture mandateFixture = aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture);

--- a/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/api/GoCardlessWebhookParserTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/webhook/gocardless/api/GoCardlessWebhookParserTest.java
@@ -18,6 +18,7 @@ import javax.json.JsonObjectBuilder;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -171,7 +172,7 @@ public class GoCardlessWebhookParserTest {
                 .add("metadata",
                         Json.createObjectBuilder()
                         .build())
-                .add("resource_type", resourceType.toString().toLowerCase())
+                .add("resource_type", resourceType.toString().toLowerCase(Locale.ENGLISH))
                 .add("links", buildLinks(organisationIdentifier, resourceType, resourceId))
                 .build().toString(); 
     }


### PR DESCRIPTION
- Specify a locale when using String.toLowerCase() or toUpperCase().
- Remove "Unnecessary use of fully qualified name" when there is an existing
static import.

## WHAT YOU DID
I ran PMD linter which uses the `rules.xml` and fixed some things.