### PR TITLE
BAU Codacy Clean Up

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
+++ b/src/main/java/uk/gov/pay/directdebit/app/config/DirectDebitModule.java
@@ -32,6 +32,7 @@ public class DirectDebitModule extends AbstractModule {
     private final Jdbi jdbi;
 
     public DirectDebitModule(final DirectDebitConfig configuration, final Environment environment, final Jdbi jdbi) {
+        super();
         this.configuration = configuration;
         this.environment = environment;
         this.jdbi = jdbi;

--- a/src/main/java/uk/gov/pay/directdebit/common/model/SearchResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/SearchResponse.java
@@ -51,10 +51,16 @@ public class SearchResponse<T> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         SearchResponse<?> that = (SearchResponse<?>) o;
-        return count == that.count &&
+        return count.equals(that.count) &&
                 Objects.equals(gatewayExternalId, that.gatewayExternalId) &&
                 Objects.equals(total, that.total) &&
                 Objects.equals(page, that.page) &&

--- a/src/main/java/uk/gov/pay/directdebit/common/model/subtype/SunName.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/model/subtype/SunName.java
@@ -24,8 +24,13 @@ public class SunName {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         SunName that = (SunName) o;
 

--- a/src/main/java/uk/gov/pay/directdebit/common/proxy/CustomInetSocketAddressProxySelector.java
+++ b/src/main/java/uk/gov/pay/directdebit/common/proxy/CustomInetSocketAddressProxySelector.java
@@ -41,6 +41,7 @@ public class CustomInetSocketAddressProxySelector extends ProxySelector {
     public CustomInetSocketAddressProxySelector(ProxySelector defaultProxySelector,
                                                 String proxyHostname,
                                                 int proxyPort) {
+        super();
         this.defaultProxySelector = defaultProxySelector;
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/model/GoCardlessEvent.java
@@ -177,8 +177,14 @@ public class GoCardlessEvent implements Event {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         GoCardlessEvent that = (GoCardlessEvent) o;
         return id.equals(that.id) &&
                 goCardlessEventId.equals(that.goCardlessEventId) &&

--- a/src/main/java/uk/gov/pay/directdebit/events/model/GovUkPayEvent.java
+++ b/src/main/java/uk/gov/pay/directdebit/events/model/GovUkPayEvent.java
@@ -75,8 +75,14 @@ public class GovUkPayEvent implements Event {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         GovUkPayEvent that = (GovUkPayEvent) o;
         return Objects.equals(id, that.id) &&
                 Objects.equals(mandateId, that.mandateId) &&

--- a/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/model/Mandate.java
@@ -92,8 +92,14 @@ public class Mandate {
     }
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         Mandate mandate = (Mandate) o;
         return Objects.equals(id, mandate.id) &&
                 Objects.equals(externalId, mandate.externalId) &&

--- a/src/main/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/mandate/params/MandateSearchParams.java
@@ -37,9 +37,11 @@ public class MandateSearchParams extends SearchParams {
     private String email;
 
     public MandateSearchParams() {
+        super();
     }
 
     private MandateSearchParams(MandateSearchParamsBuilder builder) {
+        super();
         this.serviceReference = builder.serviceReference;
         this.externalMandateState = builder.externalMandateState;
         this.mandateBankStatementReference = builder.mandateBankStatementReference;

--- a/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/api/CreatePayerResponse.java
@@ -29,8 +29,13 @@ public class CreatePayerResponse {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         CreatePayerResponse that = (CreatePayerResponse) o;
 

--- a/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/payers/model/BankAccountDetails.java
@@ -28,12 +28,20 @@ public class BankAccountDetails {
     
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         BankAccountDetails that = (BankAccountDetails) o;
 
-        if (!accountNumber.equals(that.accountNumber)) return false;
+        if (!accountNumber.equals(that.accountNumber)) {
+            return false;
+        }
+
         return sortCode.equals(that.sortCode);
     }
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentStateWithDetails.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/ExternalPaymentStateWithDetails.java
@@ -35,8 +35,14 @@ public class ExternalPaymentStateWithDetails {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         ExternalPaymentStateWithDetails that = (ExternalPaymentStateWithDetails) o;
         return paymentState == that.paymentState &&
                 Objects.equals(details, that.details);

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentResponse.java
@@ -134,8 +134,14 @@ public class PaymentResponse {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         PaymentResponse that = (PaymentResponse) o;
         return Objects.equals(paymentExternalId, that.paymentExternalId) &&
                 Objects.equals(amount, that.amount) &&

--- a/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/api/PaymentViewResultResponse.java
@@ -113,8 +113,13 @@ public class PaymentViewResultResponse {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         PaymentViewResultResponse that = (PaymentViewResultResponse) o;
 

--- a/src/main/java/uk/gov/pay/directdebit/payments/links/Link.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/links/Link.java
@@ -46,8 +46,14 @@ public class Link {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         Link link = (Link) o;
         return Objects.equals(href, link.href) &&
                 Objects.equals(method, link.method);

--- a/src/main/java/uk/gov/pay/directdebit/payments/links/PaginationLink.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/links/PaginationLink.java
@@ -34,8 +34,14 @@ public class PaginationLink {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         PaginationLink link = (PaginationLink) o;
         return Objects.equals(href, link.href);
     }

--- a/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/model/Payment.java
@@ -87,8 +87,14 @@ public class Payment {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
         Payment payment = (Payment) o;
         return Objects.equals(id, payment.id) &&
                 externalId.equals(payment.externalId) &&

--- a/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
+++ b/src/main/java/uk/gov/pay/directdebit/payments/params/PaymentViewSearchParams.java
@@ -34,9 +34,11 @@ public class PaymentViewSearchParams extends SearchParams {
     private String state;
 
     public PaymentViewSearchParams() {
+        super();
     }
 
     private PaymentViewSearchParams(PaymentViewSearchParamsBuilder builder) {
+        super();
         this.page = builder.page;
         this.displaySize = builder.displaySize;
         this.fromDate = builder.fromDateString;

--- a/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/directdebit/tokens/api/TokenResponse.java
@@ -86,7 +86,9 @@ public class TokenResponse {
         }
         if (mandateReference != null ? !mandateReference.equals(that.mandateReference) : that.mandateReference != null) {
             return false;
-        } else return true;
+        } else {
+            return true;
+        }
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/GoCardlessEventDaoIT.java
@@ -37,7 +37,7 @@ public class GoCardlessEventDaoIT {
     private GoCardlessEventDao goCardlessEventDao;
 
     @Before
-    public void setup() {
+    public void setUp() {
         goCardlessEventDao = testContext.getJdbi().onDemand(GoCardlessEventDao.class);
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/events/dao/SandboxEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/events/dao/SandboxEventDaoIT.java
@@ -38,7 +38,7 @@ public class SandboxEventDaoIT {
     private TestContext testContext;
 
     @Before
-    public void setup() {
+    public void setUp() {
         sandboxEventDao = testContext.getJdbi().onDemand(SandboxEventDao.class);
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
@@ -43,7 +43,7 @@ public class GatewayAccountDaoIT {
     private GatewayAccountFixture testGatewayAccount;
 
     @Before
-    public void setup() {
+    public void setUp() {
         gatewayAccountDao = testContext.getJdbi().onDemand(GatewayAccountDao.class);
         this.testGatewayAccount = aGatewayAccountFixture()
                 .withExternalId(EXTERNAL_ID)

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateDaoIT.java
@@ -54,7 +54,7 @@ public class MandateDaoIT {
     private GatewayAccountFixture gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture();
 
     @Before
-    public void setup() {
+    public void setUp() {
         gatewayAccountFixture.insert(testContext.getJdbi());
         mandateDao = testContext.getJdbi().onDemand(MandateDao.class);
     }

--- a/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/dao/MandateSearchDaoIT.java
@@ -56,7 +56,7 @@ public class MandateSearchDaoIT {
     }
     
     @Before
-    public void setup() {
+    public void setUp() {
         mandateSearchDao = new MandateSearchDao(testContext.getJdbi());
 
         gatewayAccountFixture.insert(testContext.getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/partnerapp/dao/GoCardlessAppConnectAccountTokenDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/partnerapp/dao/GoCardlessAppConnectAccountTokenDaoIT.java
@@ -30,7 +30,7 @@ public class GoCardlessAppConnectAccountTokenDaoIT {
     private GatewayAccountFixture gatewayAccountFixture;
 
     @Before
-    public void setup() {
+    public void setUp() {
         tokenDao = testContext.getJdbi().onDemand(GoCardlessAppConnectAccountTokenDao.class);
         gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture()
                 .insert(testContext.getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/payers/dao/GoCardlessCustomerDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/dao/GoCardlessCustomerDaoIT.java
@@ -37,7 +37,7 @@ public class GoCardlessCustomerDaoIT {
     private GatewayAccountFixture gatewayAccountFixture;
 
     @Before
-    public void setup() {
+    public void setUp() {
         gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
         mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());
         paymentFixture = PaymentFixture.aPaymentFixture()

--- a/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payers/dao/PayerDaoIT.java
@@ -45,7 +45,7 @@ public class PayerDaoIT {
     private MandateFixture testMandate;
 
     @Before
-    public void setup() {
+    public void setUp() {
         payerDao = testContext.getJdbi().onDemand(PayerDao.class);
         testGatewayAccount = GatewayAccountFixture.aGatewayAccountFixture()
                 .insert(testContext.getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentDaoIT.java
@@ -56,7 +56,7 @@ public class PaymentDaoIT {
     private MandateFixture testMandate;
 
     @Before
-    public void setup() {
+    public void setUp() {
         paymentDao = testContext.getJdbi().onDemand(PaymentDao.class);
         testGatewayAccount = aGatewayAccountFixture().insert(testContext.getJdbi());
         testMandate = MandateFixture.aMandateFixture().withGatewayAccountFixture(testGatewayAccount).withStateDetails("state details").insert(testContext.getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/dao/PaymentViewDaoIT.java
@@ -46,7 +46,7 @@ public class PaymentViewDaoIT {
     private Payment mandate2Payment1;
 
     @Before
-    public void setup() {
+    public void setUp() {
         paymentViewDao = new PaymentViewDao(testContext.getJdbi());
 
         GatewayAccountFixture gatewayAccountFixture = aGatewayAccountFixture()

--- a/src/test/java/uk/gov/pay/directdebit/tokens/dao/TokenDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/tokens/dao/TokenDaoIT.java
@@ -39,7 +39,7 @@ public class TokenDaoIT {
     private TestContext testContext;
 
     @Before
-    public void setup() {
+    public void setUp() {
         tokenDao = testContext.getJdbi().onDemand(TokenDao.class);
         gatewayAccountFixture = GatewayAccountFixture.aGatewayAccountFixture().insert(testContext.getJdbi());
         mandateFixture = MandateFixture.aMandateFixture().withGatewayAccountFixture(gatewayAccountFixture).insert(testContext.getJdbi());

--- a/src/test/java/uk/gov/pay/directdebit/util/NumberMatcher.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/NumberMatcher.java
@@ -11,6 +11,7 @@ public class NumberMatcher extends BaseMatcher<Number> {
     private String actualClass;
 
     private NumberMatcher(Number expectation) {
+        super();
         this.expectation = expectation;
     }
 

--- a/src/test/java/uk/gov/pay/directdebit/util/ResponseContainsLinkMatcher.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/ResponseContainsLinkMatcher.java
@@ -18,6 +18,7 @@ public class ResponseContainsLinkMatcher extends TypeSafeMatcher<List<Map<String
     private Map<String, Object> params;
 
     private ResponseContainsLinkMatcher(String rel, String method, String href) {
+        super();
         checkNotNull(rel);
         checkNotNull(method);
         checkNotNull(href);

--- a/src/test/java/uk/gov/pay/directdebit/util/ResponseDoesNotContainLinkMatcher.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/ResponseDoesNotContainLinkMatcher.java
@@ -13,6 +13,7 @@ public class ResponseDoesNotContainLinkMatcher extends TypeSafeMatcher<List<Map<
     private final String rel;
 
     private ResponseDoesNotContainLinkMatcher(String rel) {
+        super();
         checkNotNull(rel);
         this.rel = rel;
     }

--- a/src/test/java/uk/gov/pay/directdebit/util/ZonedDateTimeTimestampMatcher.java
+++ b/src/test/java/uk/gov/pay/directdebit/util/ZonedDateTimeTimestampMatcher.java
@@ -12,6 +12,7 @@ public class ZonedDateTimeTimestampMatcher extends TypeSafeMatcher<Timestamp> {
     private Timestamp from;
 
     private ZonedDateTimeTimestampMatcher(Timestamp from) {
+        super();
         this.from = from;
     }
 


### PR DESCRIPTION
- `if` statements should make use of `{}`.
- Correct misspelled Junit setUp() method names (was using lower-case
`u`).
- "It is a good practice to call super() in a constructor".

## WHAT YOU DID
I ran PMD linter and fixed a few things.