### PR TITLE
PP-5735: Update json logging configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <hamcrest.version>2.1</hamcrest.version>
         <rest-assured.version>4.1.2</rest-assured.version>
         <mockito.version>3.1.0</mockito.version>
-        <pay-java-commons.version>1.0.20191010084537</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20191016090650</pay-java-commons.version>
         <surefire.version>2.22.2</surefire.version>
     </properties>
 

--- a/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
+++ b/src/main/java/uk/gov/pay/directdebit/DirectDebitConnectorApp.java
@@ -16,7 +16,6 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.commons.utils.logging.LoggingFilter;
-import uk.gov.pay.commons.utils.logging.LogstashConsoleAppenderFactory;
 import uk.gov.pay.commons.utils.metrics.DatabaseMetricsService;
 import uk.gov.pay.directdebit.app.bootstrap.DependentResourcesWaitCommand;
 import uk.gov.pay.directdebit.app.config.DirectDebitConfig;
@@ -49,6 +48,7 @@ import uk.gov.pay.directdebit.tokens.resources.SecurityTokensResource;
 import uk.gov.pay.directdebit.webhook.gocardless.exception.InvalidWebhookExceptionMapper;
 import uk.gov.pay.directdebit.webhook.gocardless.resources.WebhookGoCardlessResource;
 import uk.gov.pay.directdebit.webhook.sandbox.resources.WebhookSandboxResource;
+import uk.gov.pay.logging.LogstashConsoleAppenderFactory;
 
 import java.net.ProxySelector;
 import java.util.concurrent.TimeUnit;

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -11,11 +11,9 @@ logging:
   appenders:
     - type: logstash-console
       threshold: ALL
-      timeZone: UTC
       target: stdout
-      layout:
-        type: json
-        timestampFormat: "yyyy-MM-dd HH:mm:ss.SSS"
+      customFields:
+        label: "directdebit-connector"
     - type: sentry
       threshold: ERROR
       dsn: ${SENTRY_DSN}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -7,13 +7,13 @@ server:
       port: 0
 
 logging:
-  level: WARN
+  level: INFO
   appenders:
-    - type: console
+    - type: logstash-console
       threshold: ALL
-      timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+      customFields:
+        label: "directdebit-connector"
 
 links:
   frontendUrl: http://Frontend


### PR DESCRIPTION
We can remove the timestamp format as the LogstashConsoleAppenderFactory in
pay-java-commons logs the ISO-8601 formatted timestamp by default.

Example log produced by this configuration:
```
{
  "@timestamp": "2019-10-16T11:07:13.070+01:00",
  "@version": "1",
  "message": "Registering jersey handler with root path prefix: /",
  "logger_name": "io.dropwizard.server.DefaultServerFactory",
  "thread_name": "main",
  "level": "INFO",
  "level_value": 20000,
  "label": "directdebit-connector"
}
```

From local testing I've also verified MDC values are logged and structured
argument values in log lines are logged as a key value pair in the json log.
For example,
    ```
    log.info("This is a log line", StructuredArguments.kv("gateway_account_id","abc"))
    ```
 will produce

```
    {
      "@timestamp": "2019-10-16T11:07:13.070+01:00",
      "@version": "1",
      "message": "This is a log line",
      "gateway_account_id": "abc"
      "logger_name": "io.dropwizard.server.DefaultServerFactory",
      "thread_name": "main",
      "level": "INFO",
      "level_value": 20000,
      "label": "directdebit-connector"
    }
```

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
