### PR TITLE
PP-5725 Add default Sentry DSN

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -18,7 +18,7 @@ logging:
         timestampFormat: "yyyy-MM-dd HH:mm:ss.SSS"
     - type: sentry
       threshold: ERROR
-      dsn: ${SENTRY_DSN}
+      dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
       environment: ${ENVIRONMENT}
 
 links:


### PR DESCRIPTION
The application will not start if the SENTRY_DSN is not a well formatted
DSN. This adds a default to avoid problems and to make it simplier to
run locally.

## WHAT YOU DID
Tested different scenarios for when the `SENTRY_DSN` is set, not set or set to invalid formats. See https://payments-platform.atlassian.net/secure/RapidBoard.jspa?rapidView=59&modal=detail&selectedIssue=PP-5725. The conclusion was to add a default value.