### PR TITLE
PP-5777 Add environment field to logs

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -12,6 +12,7 @@ server:
           type: govuk-pay-access-json
           additionalFields:
             container: "directdebit-connector"
+            environment: ${ENVIRONMENT}
 
 logging:
   level: INFO
@@ -21,6 +22,7 @@ logging:
       target: stdout
       customFields:
         container: "directdebit-connector"
+        environment: ${ENVIRONMENT}
     - type: sentry
       threshold: ERROR
       dsn: ${SENTRY_DSN:-https://example.com@dummy/1}


### PR DESCRIPTION
Add an 'environment' field to the logs, so that it is possible to filter
by environment using a Splunk text search. Splunk does currently extract
the environment from the source if it is explicitly searched on using
e.g. the term 'environment="production-2"', but some of our reports use
a text search so will not pick up on all log lines.

The text search continues to work for many logs where the environment is
included in some way in the log message, but not for others where it
isn't so it makes sense to get rid of this ambiguity.

In the apps producing the logs, we get the environment from an
environment variable which is already configured for use by Sentry.