### PR TITLE
PP-5893: Manually clear keys

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/directdebit/filters/LoggingMDCResponseFilter.java
@@ -6,10 +6,19 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import java.io.IOException;
+import java.util.List;
+
+import static uk.gov.pay.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
+import static uk.gov.pay.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
+import static uk.gov.pay.logging.LoggingKeys.MANDATE_EXTERNAL_ID;
+import static uk.gov.pay.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+import static uk.gov.pay.logging.LoggingKeys.PROVIDER;
+import static uk.gov.pay.logging.LoggingKeys.SECURE_TOKEN;
 
 public class LoggingMDCResponseFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
-        MDC.clear();
+        List.of(GATEWAY_ACCOUNT_ID, PROVIDER, GATEWAY_ACCOUNT_TYPE, MANDATE_EXTERNAL_ID, PAYMENT_EXTERNAL_ID, SECURE_TOKEN)
+                .forEach(MDC::remove);
     }
 }


### PR DESCRIPTION
We shouldn't use MDC.clear as LoggingMDCResponseFilter happens before the
LoggingFilter
(https://github.com/alphagov/pay-java-commons/blob/master/logging/src/main/java/uk/gov/pay/logging/LoggingFilter.java)
is called. This would remove the x_request_id needed in the LoggingFilter.

