### PR TITLE
PP-5840 Bump Docker Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11@sha256:eaa182283f19d3f0ee0c6217d29e299bb4056d379244ce957e30dcdc9e278e1e
+FROM adoptopenjdk/openjdk11@sha256:8cdca24628b649ebf5bdddc836416f869f94204931a48719090ca13492adbb18
 
 RUN ["apk", "--no-cache", "upgrade"]
 


### PR DESCRIPTION
- Bumps the docker base image from jre11.0.3 -> jre11.0.5
