### PR TITLE
PP-6001 Upgrade dropwizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>1.3.15</dropwizard.version>
+        <dropwizard.version>2.0.0</dropwizard.version>
         <mainClass>uk.gov.pay.directdebit.DirectDebitConnectorApp</mainClass>
 
         <wiremock.version>2.25.1</wiremock.version>
@@ -30,10 +30,15 @@
         <hamcrest.version>2.2</hamcrest.version>
         <rest-assured.version>4.1.2</rest-assured.version>
         <mockito.version>3.1.0</mockito.version>
-        <pay-java-commons.version>1.0.20191210155032</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20200107160358</pay-java-commons.version>
         <surefire.version>3.0.0-M4</surefire.version>
     </properties>
 
+    <parent>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-dependencies</artifactId>
+        <version>2.0.0</version>
+    </parent>
     <repositories>
         <repository>
             <snapshots>
@@ -107,7 +112,7 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
-            <version>1.3.9-2</version>
+            <version>2.0.0-4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountRequestTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/CreateGatewayAccountRequestTest.java
@@ -29,14 +29,14 @@ public class CreateGatewayAccountRequestTest {
     public void shouldGiveConstraintViolationForNullPaymentProvider() {
         Set<ConstraintViolation<CreateGatewayAccountRequest>> violations = validator.validateValue(CreateGatewayAccountRequest.class, "paymentProvider", null);
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("may not be null"));
+        assertThat(violations.iterator().next().getMessage(), is("must not be null"));
     }
 
     @Test
     public void shouldGiveConstraintViolationForNullType() {
         Set<ConstraintViolation<CreateGatewayAccountRequest>> violations = validator.validateValue(CreateGatewayAccountRequest.class, "type", null);
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("may not be null"));
+        assertThat(violations.iterator().next().getMessage(), is("must not be null"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/gatewayaccounts/dao/GatewayAccountDaoIT.java
@@ -45,6 +45,7 @@ public class GatewayAccountDaoIT {
     @Before
     public void setUp() {
         gatewayAccountDao = testContext.getJdbi().onDemand(GatewayAccountDao.class);
+        testContext.getDatabaseTestHelper().truncateAllData();
         this.testGatewayAccount = aGatewayAccountFixture()
                 .withExternalId(EXTERNAL_ID)
                 .withPaymentProvider(PAYMENT_PROVIDER)

--- a/src/test/java/uk/gov/pay/directdebit/junit/DropwizardJUnitRunner.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/DropwizardJUnitRunner.java
@@ -62,14 +62,14 @@ public final class DropwizardJUnitRunner extends JUnitParamsRunner {
             configOverride.add(config("database.user", getDbUsername()));
             configOverride.add(config("database.password", getDbPassword()));
         }
-        Optional<DropwizardTestSupport> createdApp = createIfNotRunning(dropwizardConfigAnnotation.app(), dropwizardConfigAnnotation.config(), configOverride.toArray(new ConfigOverride[0]));
-        if (dropwizardConfigAnnotation.withDockerPostgres() && createdApp.isPresent()) {
-            try {
+        try {
+            Optional<DropwizardTestSupport> createdApp = createIfNotRunning(dropwizardConfigAnnotation.app(), dropwizardConfigAnnotation.config(), configOverride.toArray(new ConfigOverride[0]));
+            if (dropwizardConfigAnnotation.withDockerPostgres() && createdApp.isPresent()) {
                 createdApp.get().getApplication().run("db", "migrate", resourceFilePath(dropwizardConfigAnnotation.config()));
                 createTemplate(getDbUri(), getDbUsername(), getDbPassword());
-            } catch (Exception e) {
-                throw new DropwizardJUnitRunnerException(e);
             }
+        } catch (Exception e) {
+            throw new DropwizardJUnitRunnerException(e);
         }
 
         return super.classBlock(notifier);

--- a/src/test/java/uk/gov/pay/directdebit/junit/DropwizardTestApplications.java
+++ b/src/test/java/uk/gov/pay/directdebit/junit/DropwizardTestApplications.java
@@ -35,7 +35,7 @@ final class DropwizardTestApplications {
         }));
     }
 
-    static Optional<DropwizardTestSupport> createIfNotRunning(Class<? extends Application> appClass, String configClasspathLocation, ConfigOverride... configOverrides) {
+    static Optional<DropwizardTestSupport> createIfNotRunning(Class<? extends Application> appClass, String configClasspathLocation, ConfigOverride... configOverrides) throws Exception {
         Pair<Class<? extends Application>, String> key = Pair.of(appClass, configClasspathLocation);
         if (!apps.containsKey(key)) {
             String resourceConfigFilePath = ResourceHelpers.resourceFilePath(configClasspathLocation);


### PR DESCRIPTION
## WHAT

- Upgrades dropwizard to v2.0.0
- Added `dropwizard-dependencies` as parent as v2.0.0 upgrade doesn't specify transitive dependency versions anymore https://www.dropwizard.io/en/release-2.0.x/manual/upgrade-notes/upgrade-notes-2_0_x.html

   We can also include BOM for transitive dependency versions but versions can't be overridden and we may end up with multiple revisions of same library. For example, `jackson-version` current used is `2.10.0` but dropwizard uses `2.10.1`

- Upgraded dropwizard-sentry library to latest version as container might fail to start with error `java.lang.NoSuchMethodError: 'com.google.common.collect.ImmutableList org.dhatim.dropwizard.sentry.logging.SentryAppenderFactory.getFilterFactories()

