### PR TITLE
PP-6031 Correct manifest var for dd-frontend

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,7 +13,7 @@ applications:
       ADMIN_PORT: '10201'
       DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
       ENVIRONMENT: ((space))
-      FRONTEND_URL: ((frontend_url))
+      FRONTEND_URL: ((directdebit_frontend_url))
       ADMINUSERS_URL: ((adminusers_url))
       JAVA_OPTS: -Xms512m -Xmx1G
       JBP_CONFIG_JAVA_MAIN: '{ arguments: "server /home/vcap/app/config/config.yaml" }'


### PR DESCRIPTION
We are using card_frontend_url and directdebit_frontend_url to
distinguish between the frontends.

## WHAT YOU DID
Checked on test-12 that this var is for dd-frontend...