### PR TITLE
PP-6085 Add env-map buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
   - name: directdebit-connector
     buildpacks:
+      - https://github.com/alphagov/env-map-buildpack.git#v2
       - java_buildpack
     path: target/pay-direct-debit-connector-0.1-SNAPSHOT-allinone.jar
     health-check-type: http
@@ -9,24 +10,20 @@ applications:
     health-check-invocation-timeout: 5
     memory: ((memory))
     disk_quota: ((disk_quota))
+    services:
+      - app-catalog
+      - directdebit-connector-db
     env:
+      ENV_MAP_BP_USE_APP_PROFILE_DIR: true
       ADMIN_PORT: '10201'
       DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
       ENVIRONMENT: ((space))
-      FRONTEND_URL: ((directdebit_frontend_url))
-      ADMINUSERS_URL: ((adminusers_url))
       JAVA_OPTS: -Xms512m -Xmx1G
       JBP_CONFIG_JAVA_MAIN: '{ arguments: "server /home/vcap/app/config/config.yaml" }'
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
       JPA_LOG_LEVEL: 'INFO'
       JPA_SQL_LOG_LEVEL: 'INFO'
 
-      # Provide via dd-connector-db service
-      DB_HOST: postgres-((space)).apps.internal
-      DB_NAME: ((db_name))
-      DB_PASSWORD: ((db_password))
-      DB_USER: ((db_user))
-      DB_SSL_OPTION: ((db_ssl_option))
 
       GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ACCESS_TOKEN: ((gds_directdebit_connector_gocardless_acccess_token))
       GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_URL: ((gds_directdebit_connector_gocardless_url))
@@ -34,7 +31,6 @@ applications:
       GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ENVIRONMENT: ((gds_directdebit_connector_gocardless_environment))
       AUTH_READ_TIMEOUT_SECONDS: '1'
 
-      # Provide via GOCARDLESS service
       GOCARDLESS_TEST_CLIENT_ID: ((gocardless_test_client_id))
       GOCARDLESS_TEST_CLIENT_SECRET: ((gocardless_test_client_secret))
       GOCARDLESS_LIVE_CLIENT_ID: ((gocardless_live_client_secret))
@@ -43,11 +39,18 @@ applications:
       GOCARDLESS_LIVE_OAUTH_BASE_URL: ((gocardless_live_oauth_base_url))
 
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
-
-      # Provide via Sentry service
       SENTRY_DSN: noop://localhost
 
       RUN_APP: 'true'
       RUN_MIGRATION: ((run_migration))
-    routes:
-      - route: ((directdebit_connector_route))
+
+      # Provided via app-catalog see env-map.yml
+      FRONTEND_URL: ""
+      ADMINUSERS_URL: ""
+
+      # Provide via dd-connector-db service see env-map.yml
+      DB_HOST: ""
+      DB_NAME: ""
+      DB_PASSWORD: ""
+      DB_USER: ""
+      DB_SSL_OPTION: ""

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -1,0 +1,8 @@
+env_vars:
+  ADMINUSERS_URL:  '.[][] | select(.name == "app-catalog")              | .credentials.adminusers_url          '
+  FRONTEND_URL:    '.[][] | select(.name == "app-catalog")              | .credentials.card_frontend_url       '
+  DB_HOST:         '.[][] | select(.name == "directdebit-connector-db") | .credentials.host                    '
+  DB_NAME:         '.[][] | select(.name == "directdebit-connector-db") | .credentials.name                    '
+  DB_PASSWORD:     '.[][] | select(.name == "directdebit-connector-db") | .credentials.password                '
+  DB_USER:         '.[][] | select(.name == "directdebit-connector-db") | .credentials.username                '
+  DB_SSL_OPTION:   '.[][] | select(.name == "directdebit-connector-db") | .credentials.ssl_option // "ssl=true"'


### PR DESCRIPTION
Use the env-map buildpack to extract the db credentials from the bound
directdebit-connector-db cf service and other app urls from the bound
app-catalog service. The file `env-map.yml` provides the mapping between
the app vars and the credentials which will be found within the env var
`VCAP_SERVICES`

## How to test
Similar to the others, push the app
```
gds5062 > cf push --vars-file /Users/danworth/projects/gds/pay-omnibus/paas/env_variables/staging.yml
```
and check the vars are set
```
cf ssh directdebit-connector
/tmp/lifecycle/shell
env | grep DB
```