### PR TITLE
PP-6146: Bind paas app to secret service

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,6 +12,7 @@ applications:
     disk_quota: ((disk_quota))
     services:
       - app-catalog
+      - directdebit-connector-secret-service
       - directdebit-connector-db
     env:
       ENV_MAP_BP_USE_APP_PROFILE_DIR: true


### PR DESCRIPTION
## WHAT YOU DID
Adds a missing service binding to manifest.yml ensuring the dd-connector app is bound to the "secrets" user-provided service.