### PR TITLE
PP-6445 Make pact broker host configurable

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/PublicApiContractTest.java
@@ -31,7 +31,7 @@ import static uk.gov.pay.directdebit.payments.fixtures.PaymentFixture.aPaymentFi
 
 @RunWith(PactRunner.class)
 @Provider("direct-debit-connector")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"publicapi"})
 public class PublicApiContractTest {

--- a/src/test/java/uk/gov/pay/directdebit/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/directdebit/pact/SelfServiceContractTest.java
@@ -17,7 +17,7 @@ import uk.gov.pay.directdebit.payments.fixtures.GatewayAccountFixture;
 
 @RunWith(PactRunner.class)
 @Provider("direct-debit-connector")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
 public class SelfServiceContractTest {


### PR DESCRIPTION
Allow passing in `PACT_BROKER_HOST`, default to existing value. This is
necessary because we're using a different pact broker for concourse ci.

## WHAT YOU DID
Similar to https://github.com/alphagov/pay-connector/pull/2376/commits/c8550f09611f20a10eda58c21c4843fc106edb90