### PR TITLE
BAU refactor wiremock server ports to use random ports

### DIFF
--- a/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.commons.testing.port.PortFactory;
 import uk.gov.pay.directdebit.junit.DropwizardAppWithPostgresRule;
 import uk.gov.pay.directdebit.junit.TestContext;
 import uk.gov.pay.directdebit.mandate.fixtures.MandateFixture;
@@ -81,9 +82,11 @@ public class MandateResourceIT {
     private static final String JSON_STATE_KEY = "state.status";
     private static final String JSON_MANDATE_ID_KEY = "mandate_id";
 
+    private int wireMockRulePort = PortFactory.findFreePort();
+
     //todo we should be able to override this in the test-it-config or else tests won't easily run in parallel. See https://payments-platform.atlassian.net/browse/PP-3374
     @Rule
-    public WireMockRule wireMockRuleGoCardless = new WireMockRule(10107);
+    public WireMockRule wireMockRuleGoCardless = new WireMockRule(wireMockRulePort);
 
     @Rule
     public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();

--- a/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/directdebit/payments/resources/PaymentResourceIT.java
@@ -10,6 +10,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import uk.gov.pay.commons.testing.port.PortFactory;
 import uk.gov.pay.directdebit.gatewayaccounts.model.PaymentProvider;
 import uk.gov.pay.directdebit.junit.DropwizardAppWithPostgresRule;
 import uk.gov.pay.directdebit.junit.TestContext;
@@ -67,8 +68,10 @@ public class PaymentResourceIT {
     private GatewayAccountFixture testGatewayAccount;
     private TestContext testContext;
 
+    private int wireMockRulePort = PortFactory.findFreePort();
+
     @Rule
-    public WireMockRule wireMockRuleGoCardless = new WireMockRule(10107);
+    public WireMockRule wireMockRuleGoCardless = new WireMockRule(wireMockRulePort);
 
     @Rule
     public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();


### PR DESCRIPTION
## WHAT YOU DID
- refactor tests classes to use random ports for running WireMock server. This enables us to run several tests parallel

