### PR TITLE
PP-6763 - Remove direct debit smoke and end test from publicapi Jenki…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,17 +67,6 @@ pipeline {
         }
       }
     }
-    stage('End-to-End tests') {
-      when {
-        anyOf {
-          branch 'master'
-          environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-        }
-      }
-      steps {
-        runAppE2E("directdebit-connector", "directdebit")
-      }
-    }
     stage('Docker Tag') {
       steps {
         script {
@@ -98,14 +87,6 @@ pipeline {
       }
       steps {
         deployEcs("directdebit-connector")
-      }
-    }
-    stage('Smoke Tests') {
-      when {
-        branch 'master'
-      }
-      steps {
-        runDirectDebitSmokeTest()
       }
     }
     stage('Pact Tag') {


### PR DESCRIPTION
Description:

- Before we can turn off the direct debit smoke test we need to ensure that no pipeline calls it. This ensures that the publicapi Jenkins pipeline doesn't call the direct debit smoke Jenkins function.
- This also ensures that the direct debit portion of the end to end test suit won't be run