### PR TITLE
PP-7283 - Update docker image to 11.0.9

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,185 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-11-24T15:54:10Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "dev.yml": [
+      {
+        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
+        "is_verified": false,
+        "line_number": 2,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "99a543539a29d0a6f411e38a75dd6dc1eceefa91",
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "b15ae39f3cc1365211d41050038ee74befae65f4",
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "a761ce3a45d97e41840a788495e85a70d1bb3815",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/main/resources/config/config.yaml": [
+      {
+        "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/PatchGatewayAccountValidatorTest.java": [
+      {
+        "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
+        "is_verified": false,
+        "line_number": 119,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "30c5ca59d79d5e678fb888161c7139624696f717",
+        "is_verified": false,
+        "line_number": 125,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java": [
+      {
+        "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
+        "is_verified": false,
+        "line_number": 411,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "30c5ca59d79d5e678fb888161c7139624696f717",
+        "is_verified": false,
+        "line_number": 412,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java": [
+      {
+        "hashed_secret": "30c5ca59d79d5e678fb888161c7139624696f717",
+        "is_verified": false,
+        "line_number": 199,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
+        "is_verified": false,
+        "line_number": 204,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "src/test/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessGoCardlessWebhookVerifierTest.java": [
+      {
+        "hashed_secret": "0663e80dc30353afdc17af60292fbdb81845aac7",
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3735027f27f99a53ca87a02c9ea12be6c353d9a2",
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8689a19819968ad12f874f1a5f333edbd83267f7",
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "src/test/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessWebhookSignatureCalculatorTest.java": [
+      {
+        "hashed_secret": "c7f8d71f7d86dcc16affd1dcce7a9c843c91717b",
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "src/test/resources/config/test-it-config.yaml": [
+      {
+        "hashed_secret": "0663e80dc30353afdc17af60292fbdb81845aac7",
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f77cedc35d357371a621d0c43effe158c30e2c72",
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jre-11.0.8_10-alpine@sha256:85e5804bf252dd222610b73b7f2554a985a8360af4425715f64f3f818af5e6a2
+FROM adoptopenjdk/openjdk11:jre-11.0.9_11.1-alpine@sha256:58254737530df7f7e7acfe3e7538a027f898ac05accd2e15adcef34d5a33ae72
 
 RUN ["apk", "--no-cache", "upgrade"]
 


### PR DESCRIPTION
Description:
- This PR updates the AdoptOpenJDK image to 11.0.9
- From https://hub.docker.com/layers/adoptopenjdk/openjdk11/jre-11.0.9_11.1-alpine/images/sha256-58254737530df7f7e7acfe3e7538a027f898ac05accd2e15adcef34d5a33ae72?context=explore