### PR TITLE
BAU remove govuk pay label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,4 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  - govuk-pay
   - java


### PR DESCRIPTION
## WHAT YOU DID
- remove label from dependabot labels. since we no longer merge dependabot PRs for dd apps, we don't want them to appear on the list either.
