### PR TITLE
PP-8394 fix webhook vulnerability

### DIFF
--- a/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessWebhookVerifier.java
+++ b/src/main/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessWebhookVerifier.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.directdebit.webhook.gocardless.support;
 
-import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.directdebit.webhook.gocardless.exception.InvalidWebhookException;
 
 import javax.inject.Inject;
+import java.security.MessageDigest;
 
 import static java.lang.String.format;
 
@@ -23,7 +23,7 @@ public class GoCardlessWebhookVerifier {
     private void verifySignature(String body, String expectedSignature) {
         String computedSignature = goCardlessWebhookSignatureCalculator.calculate(body);
 
-        if (!StringUtils.equals(expectedSignature, computedSignature)) {
+        if (!MessageDigest.isEqual(expectedSignature.getBytes(), computedSignature.getBytes())) {
             throw new InvalidWebhookException(format("Invalid GoCardless webhook signature, received %s but computed %s",
                     expectedSignature, computedSignature));
         }


### PR DESCRIPTION
## WHAT YOU DID
- StringUtils.equals() doesn't implement a constant-time algorithm for comparing inputs. As a result, an attacker may be able to run a timing attack that can forge a valid Webhook signature for an arbitrary body.
