### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2020-11-24T15:54:10Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,129 +53,182 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {
-    "dev.yml": [
+    ".pre-commit-config.yaml": [
       {
-        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
         "is_verified": false,
-        "line_number": 2,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "99a543539a29d0a6f411e38a75dd6dc1eceefa91",
-        "is_verified": false,
-        "line_number": 10,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "b15ae39f3cc1365211d41050038ee74befae65f4",
-        "is_verified": false,
-        "line_number": 12,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "a761ce3a45d97e41840a788495e85a70d1bb3815",
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Secret Keyword"
+        "line_number": 3
       }
     ],
-    "src/main/resources/config/config.yaml": [
+    "dev.yml": [
       {
-        "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
+        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 43,
-        "type": "Secret Keyword"
+        "line_number": 2
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
+        "hashed_secret": "99a543539a29d0a6f411e38a75dd6dc1eceefa91",
+        "is_verified": false,
+        "line_number": 10
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
+        "hashed_secret": "b15ae39f3cc1365211d41050038ee74befae65f4",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
+        "hashed_secret": "a761ce3a45d97e41840a788495e85a70d1bb3815",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/PatchGatewayAccountValidatorTest.java": [
       {
-        "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
-        "is_verified": false,
-        "line_number": 119,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/PatchGatewayAccountValidatorTest.java",
         "hashed_secret": "30c5ca59d79d5e678fb888161c7139624696f717",
         "is_verified": false,
-        "line_number": 125,
-        "type": "Hex High Entropy String"
+        "line_number": 114
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/api/PatchGatewayAccountValidatorTest.java",
+        "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
+        "is_verified": false,
+        "line_number": 119
       }
     ],
     "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java",
         "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
         "is_verified": false,
-        "line_number": 411,
-        "type": "Hex High Entropy String"
+        "line_number": 395
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/resources/GatewayAccountResourceIT.java",
         "hashed_secret": "30c5ca59d79d5e678fb888161c7139624696f717",
         "is_verified": false,
-        "line_number": 412,
-        "type": "Hex High Entropy String"
+        "line_number": 398
       }
     ],
     "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java": [
       {
-        "hashed_secret": "30c5ca59d79d5e678fb888161c7139624696f717",
-        "is_verified": false,
-        "line_number": 199,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java",
         "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
         "is_verified": false,
-        "line_number": 204,
-        "type": "Hex High Entropy String"
+        "line_number": 193
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/gatewayaccounts/services/GatewayAccountServiceTest.java",
+        "hashed_secret": "30c5ca59d79d5e678fb888161c7139624696f717",
+        "is_verified": false,
+        "line_number": 199
       }
     ],
     "src/test/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessGoCardlessWebhookVerifierTest.java": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessGoCardlessWebhookVerifierTest.java",
         "hashed_secret": "0663e80dc30353afdc17af60292fbdb81845aac7",
         "is_verified": false,
-        "line_number": 17,
-        "type": "Base64 High Entropy String"
+        "line_number": 17
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessGoCardlessWebhookVerifierTest.java",
         "hashed_secret": "3735027f27f99a53ca87a02c9ea12be6c353d9a2",
         "is_verified": false,
-        "line_number": 21,
-        "type": "Hex High Entropy String"
+        "line_number": 21
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessGoCardlessWebhookVerifierTest.java",
         "hashed_secret": "8689a19819968ad12f874f1a5f333edbd83267f7",
         "is_verified": false,
-        "line_number": 29,
-        "type": "Hex High Entropy String"
+        "line_number": 29
       }
     ],
     "src/test/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessWebhookSignatureCalculatorTest.java": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/directdebit/webhook/gocardless/support/GoCardlessWebhookSignatureCalculatorTest.java",
         "hashed_secret": "c7f8d71f7d86dcc16affd1dcce7a9c843c91717b",
         "is_verified": false,
-        "line_number": 28,
-        "type": "Hex High Entropy String"
+        "line_number": 28
       }
     ],
     "src/test/resources/config/test-it-config.yaml": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "0663e80dc30353afdc17af60292fbdb81845aac7",
         "is_verified": false,
-        "line_number": 26,
-        "type": "Base64 High Entropy String"
+        "line_number": 26
       },
       {
-        "hashed_secret": "f77cedc35d357371a621d0c43effe158c30e2c72",
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/test-it-config.yaml",
+        "hashed_secret": "0663e80dc30353afdc17af60292fbdb81845aac7",
         "is_verified": false,
-        "line_number": 26,
-        "type": "Secret Keyword"
+        "line_number": 26
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-13T15:45:49Z"
 }


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`