### PR TITLE
PP-8512: Archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pay-direct-debit-connector
 
+> As of September 2021 this repository is no longer actively maintained by
+> the GOV.UK Pay team. 
+
 The [GOV.UK Pay](https://www.payments.service.gov.uk/) Direct Debit Connector
 
 ## Environment Variables


### PR DESCRIPTION
Adds archive notice to the repo. Pay's Direct Debit apps were taken out of use in September 2020. Any new Direct Debit functionality will appear in a different repo. 